### PR TITLE
Fix the issue with web-jam-front and pushState in router config

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,11 @@ app.use(bodyParser.json());
 app.use(morgan('tiny'));
 // app.use('/', routes);
 routes(app);
+
+app.get('*', function(request, response){
+    response.sendFile(path.normalize(path.join(__dirname, 'frontend/dist/index.html')));
+});
+
 app.listen(config.server.port, () => {
   console.log(`Magic happens on port ${config.server.port}`);
 });


### PR DESCRIPTION
This fixes WebJamApps/web-jam-front#78

Because you enabled `pushState` in the router (I'm guessing to get rid of the # in the URLs), you need the server side support. When you were doing the separate frontend, you were using the `pushstate-server` package to facilitate this. Now that you are serving the frontend from the backend, the backend server needs to support this. This PR does that.