### PR TITLE
Replace superagent with native fetch in google auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/express-sslify": "^1.2.2",
         "@types/morgan": "^1.9.4",
         "@types/node": "^24.0.0",
-        "@types/superagent": "^4.1.16",
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "csvtojson": "^2.0.10",
@@ -35,7 +34,6 @@
         "morgan": "^1.10.0",
         "rimraf": "^6.1.3",
         "snyk": "^1.1118.0",
-        "superagent": "^8.1.2",
         "typescript": "^5.3.3"
       },
       "devDependencies": {
@@ -1118,6 +1116,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1137,6 +1136,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
       "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
@@ -1759,6 +1759,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/cors": {
@@ -1845,6 +1846,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1928,13 +1936,16 @@
       }
     },
     "node_modules/@types/superagent": {
-      "version": "4.1.24",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.24.tgz",
-      "integrity": "sha512-mEafCgyKiMFin24SDzWN7yAADt4gt6YawFiNMp0QS5ZPboORfyxFt0s3VzJKhTaKg9py/4FUmrHLTNfJKt9Rbw==",
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/supertest": {
@@ -2771,6 +2782,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/assertion-error": {
@@ -3131,6 +3143,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3215,6 +3228,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3382,6 +3396,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "asap": "^2.0.0",
@@ -4062,6 +4077,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -4221,6 +4237,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
       "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
@@ -5513,6 +5530,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6433,6 +6451,7 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
       "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
       "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -6454,6 +6473,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -7221,6 +7241,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/express-sslify": "^1.2.2",
     "@types/morgan": "^1.9.4",
     "@types/node": "^24.0.0",
-    "@types/superagent": "^4.1.16",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "csvtojson": "^2.0.10",
@@ -67,7 +66,6 @@
     "morgan": "^1.10.0",
     "rimraf": "^6.1.3",
     "snyk": "^1.1118.0",
-    "superagent": "^8.1.2",
     "typescript": "^5.3.3"
   },
   "devDependencies": {

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -1,4 +1,3 @@
-import superagent from 'superagent';
 import Debug from 'debug';
 
 const debug = Debug('web-jam-back:auth/google');
@@ -12,32 +11,44 @@ export interface GoogleAuthenticateResponse {
 }
 
 async function authenticate(req: { body: { redirectUri: string; code: string; clientId: string; }; }): Promise<GoogleAuthenticateResponse> {
-  let reUri = req.body.redirectUri, token, profile;
+  let reUri = req.body.redirectUri;
+  let tokenBody;
+  let profileBody;
   if (reUri && reUri.includes('localhost')) {
     reUri = reUri.replace('https', 'http');
   }
-  const params = {
+  const params = new URLSearchParams({
     code: req.body.code,
     client_id: req.body.clientId,
-    client_secret: process.env.GoogleClientSecret,
+    client_secret: process.env.GoogleClientSecret || '',
     redirect_uri: reUri,
     grant_type: 'authorization_code',
-  };
+  });
   try { // Step 1. Exchange authorization code for access token.
-    token = await superagent.post(accessTokenUrl).type('form').send(params).set('Accept', 'application/json');
-    debug(token.body);
+    const tokenRes = await fetch(accessTokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+      body: params,
+    });
+    if (!tokenRes.ok) throw new Error(`${tokenRes.status} ${tokenRes.statusText}`);
+    tokenBody = await tokenRes.json();
+    debug(tokenBody);
   } catch (e) { debug(e); return Promise.reject(e); }
   try { // Step 2. Retrieve profile information about the current user.
-    profile = await superagent.get(peopleApiUrl).set({ Authorization: `Bearer ${token.body.access_token}`, Accept: 'application/json' });
+    const profileRes = await fetch(peopleApiUrl, {
+      headers: { Authorization: `Bearer ${tokenBody.access_token}`, Accept: 'application/json' },
+    });
+    if (!profileRes.ok) throw new Error(`${profileRes.status} ${profileRes.statusText}`);
+    profileBody = await profileRes.json();
   } catch (e) {
     const eMessage = (e as Error).message;
     debug(eMessage);
     throw new Error(`Failed to receive google profile information, ${eMessage}`);
   }
-  if (profile === null || profile === undefined || profile.body.emailAddresses === null || profile.body.emailAddresses === undefined) {
+  if (!profileBody || !profileBody.emailAddresses) {
     throw new Error('Failed to retrieve a proper user profile from Google');
   }
-  return profile.body;
+  return profileBody;
 }
 
 export default { authenticate };

--- a/test/jest/google.spec.ts
+++ b/test/jest/google.spec.ts
@@ -1,33 +1,32 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import superagent from 'superagent';
 import google from '../../src/auth/google.js';
 
 describe('google.ts', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
   it('authenticates returns a 401 error', async () => {
     const req = { body: { code: 'whatever', clientId: '123', redirectUri: 'http://whatever.com' } };
-    await expect(google.authenticate(req))
-      .rejects.toThrow('Unauthorized');
+    await expect(google.authenticate(req)).rejects.toThrow(/Unauthorized|401/);
   });
   it('catches error on fetching a profile', async () => {
-    const sa: any = superagent;
-    sa.post = vi.fn(() => ({ type: () => ({ send: () => ({ set: () => Promise.resolve({}) }) }) }));
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockRejectedValueOnce(new Error('boom')));
     const req = { body: { code: 'whatever', clientId: '123', redirectUri: 'http://whatever.com' } };
     const partialEmessage = new RegExp('Failed to receive google profile information');
-    await expect(google.authenticate(req))
-      .rejects.toThrow(partialEmessage);
+    await expect(google.authenticate(req)).rejects.toThrow(partialEmessage);
   });
   it('returns error when profile is null', async () => {
-    const sa: any = superagent;
-    sa.post = vi.fn(() => ({ type: () => ({ send: () => ({ set: () => Promise.resolve({ body: { access_token: 'booya' } }) }) }) }));
-    sa.get = vi.fn(() => ({ set: () => Promise.resolve(null) }));
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'booya' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => null }));
     const req = { body: { code: 'whatever', clientId: '123', redirectUri: 'http://whatever.com' } };
-    await expect(google.authenticate(req))
-      .rejects.toThrow('Failed to retrieve a proper user profile from Google');
+    await expect(google.authenticate(req)).rejects.toThrow('Failed to retrieve a proper user profile from Google');
   });
   it('uses http to when localhost auth', async () => {
-    const sa: any = superagent;
-    sa.post = vi.fn(() => ({ type: () => ({ send: () => ({ set: () => Promise.resolve({ body: { access_token: 'booya' } }) }) }) }));
-    sa.get = vi.fn(() => ({ set: () => Promise.resolve({ body: { emailAddresses: ['me@me.com'] } }) }));
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'booya' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ emailAddresses: ['me@me.com'] }) }));
     const req = { body: { code: 'whatever', clientId: '123', redirectUri: 'https://localhost.com' } };
     const res = await google.authenticate(req);
     expect(res.emailAddresses[0]).toBe('me@me.com');


### PR DESCRIPTION
## Summary
Phase 2 of the upgrade arc. Drops the only direct superagent caller in favor of Node 24's built-in fetch.

- [src/auth/google.ts](src/auth/google.ts) — token exchange (POST x-www-form-urlencoded) and profile lookup (GET with Bearer) now use `fetch`. Manual `response.ok` + `response.json()` since fetch doesn't throw on 4xx/5xx.
- [test/jest/google.spec.ts](test/jest/google.spec.ts) — mocks now use `vi.stubGlobal('fetch', ...)` with `mockResolvedValueOnce` for sequential calls. The "real 401" test still hits Google directly, matching the old behavior.
- [package.json](package.json) — removes `superagent` and `@types/superagent` from dependencies. `supertest` (devDep) still pulls superagent transitively for its own use, which is fine.

No `axios` was actually used in this repo despite being mentioned in the original ask, so nothing to change there.

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint ./src` (0 errors, 53 warnings — pre-existing)
- [x] `npx vitest run` — 70/70
- [ ] CircleCI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)