### PR TITLE
fix: don't crash on SendGrid failures from /inquiry (#747)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,12 @@
+# Gemini Context: web-jam-back
+
+## Tech Stack
+- **Runtime:** Node.js
+- **Framework:** Express (likely, based on structure)
+- **Testing:** Vitest (vitest.config.ts found)
+- **Linting:** ESLint (eslint.config.mjs found)
+
+## Development Workflow
+- **Build:** Check package.json for build scripts.
+- **Standards:** Follow existing ESM patterns.
+- **Merging:** Gemini is **NOT** allowed to merge PR changes to the `dev` or `main` branches. The user is the reviewer.

--- a/docs/inquiry-sendgrid-crash.md
+++ b/docs/inquiry-sendgrid-crash.md
@@ -1,0 +1,137 @@
+# `/inquiry` SendGrid crash — local vs production behavior
+
+Reference: issue [#747](https://github.com/WebJamApps/web-jam-back/issues/747), PR [#748](https://github.com/WebJamApps/web-jam-back/pull/748).
+
+## TL;DR
+
+A latent unhandled-rejection bug in the `/inquiry` route was crashing the
+Node process whenever `@sendgrid/mail` rejected (e.g. SendGrid 401
+`Maximum credits exceeded`). The bug existed in both environments, but
+**Heroku auto-restarts hid it in production**, while local dev had no
+supervisor and stayed dead until a file save woke `ts-watch` back up.
+
+## Why local crashes loud
+
+- `npm run dev` launches `ts-watch` + `ts-start` via `concurrently`.
+  `ts-start` runs the compiled `build/src/index.js` once. There is no
+  process supervisor.
+- When the process exits, `concurrently` prints the message below and
+  the server stays down:
+
+  ```text
+  Failed running 'build/src/index.js'. Waiting for file changes before restarting...
+  ```
+
+- All in-flight requests (e.g. `/song` from JaMmusic's Songs page) hang
+  because the backend isn't listening, which is exactly the symptom
+  reported on 2026-05-08: "navigating to Songs page does not load".
+
+## Why production hides it
+
+`Procfile`:
+
+```text
+web: node build/src/index.js
+```
+
+`package.json`:
+
+```json
+"engines": { "node": "24.15.0" }
+```
+
+That's a Heroku-style deploy. Heroku's dyno manager:
+
+1. Detects the `web` process exited.
+2. Returns **H10 / 503** to any request landing during the gap.
+3. Spawns a new dyno within ~10s.
+4. Service reads as "up" again.
+
+A casual user sees "the page didn't load that one time"; a refresh
+works. The crash *did* happen, but it's only visible in
+`heroku logs --tail`:
+
+```text
+app crashed - State changed from up to crashed
+State changed from crashed to starting
+```
+
+This is "production has a supervisor that hides it", not "doesn't
+reproduce in production".
+
+## Why local triggers it but production might not
+
+The crash also requires SendGrid to actually reject. Two things make
+that more likely on local than production:
+
+1. **API keys differ.** `.env` typically holds a long-lived dev key on
+   the SendGrid free tier. Production reads `SENDGRID_API_KEY` from
+   Heroku config vars, often a different key (paid plan, separate
+   sub-user, or just one not yet over its monthly cap).
+2. **Traffic differs.** Repeated local form testing burns credits
+   quickly on a free-tier key. Production gets far fewer real Contact Us
+   submissions per day, so the credit ceiling is hit later or not at
+   all.
+
+So even with the same buggy code on the same Node version, production
+may go weeks without ever triggering the crash, while local devs hit it
+on the first round of inquiry testing after credits run out.
+
+## Where the bug actually was
+
+- `src/model/inquiry/index.ts` — fire-and-forget IIFE wrapping the async
+  controller. The IIFE's promise was never returned to Express, so
+  neither Express 4 nor Express 5's async-error pipeline saw the
+  rejection.
+- `src/model/inquiry/InquiryController.ts` — no try/catch around
+  `sgMail.send`, so any provider error propagated up.
+- Combined: the rejection escaped to the Node process. On Node ≥15
+  (default `--unhandled-rejections=throw`), the process terminates.
+
+The buggy code was introduced **2023-03-16** in commit `7fd8b8b`
+("handleing promises"), well before the Express 5 upgrade. It stayed
+dormant on Node 14 (which only logged a warning). The Express 5 PR
+(#744) bumped the runtime to Node 24, which made the latent bug fatal.
+
+## How to verify in production
+
+```bash
+# Crash history + 503s + inquiry requests
+heroku logs --app <web-jam-back-app> --num 500 \
+  | grep -E "crashed|H10|inquiry"
+
+# Compare keys (do NOT paste these anywhere):
+heroku config:get SENDGRID_API_KEY --app <web-jam-back-app>
+grep SENDGRID_API_KEY .env
+```
+
+If the keys are the same and Heroku logs show `app crashed` events
+clustered around inquiry requests, that confirms the same bug was
+firing in prod too — Heroku just kept respawning the dyno fast enough
+that no one filed a ticket.
+
+## Fix shipped in PR #748
+
+1. **Controller** wraps `sgMail.send` in try/catch and returns a clean
+   502 with the provider error code/message.
+2. **Router** uses a proper `async (req, res, next)` handler that
+   forwards rejections to `next(err)` — Express 5 then handles it via
+   the error middleware pipeline.
+3. **Process** adds a `process.on('unhandledRejection', ...)` safety net
+   in `src/index.ts` that logs and does NOT exit, so any future similar
+   bug in any other route can't take the dev server down.
+
+After the fix, the inquiry route stays up under SendGrid failures in
+**both** environments. Production stops relying on Heroku's restart
+loop to mask the bug.
+
+## Open follow-ups
+
+- The trigger today was `Maximum credits exceeded`. The fix prevents
+  the crash but does not deliver email — the contact form will return
+  502 until SendGrid is upgraded, or the integration is replaced
+  (Mailgun / AWS SES / Resend).
+- Add automated + manual coverage for SendGrid use cases from local
+  before merging future inquiry changes; if the local flow remains
+  flaky on the free tier, swap providers. Tracked in
+  [#749](https://github.com/WebJamApps/web-jam-back/issues/749).

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,15 @@ import apolloSetup from './apollo/setup.js';
 dotenv.config({ quiet: true });
 
 const debug = Debug('web-jam-back:index');
+
+/* Safety net: surface unhandled promise rejections as a log line instead
+   of letting Node terminate the dev server. Caught the day SendGrid
+   returned 401 ("Maximum credits exceeded") and the inquiry route's
+   fire-and-forget IIFE swallowed the rejection past Express. */
+/* istanbul ignore next */
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandledRejection]', reason); // eslint-disable-line no-console
+});
 const readCsv = new ReadCSV();
 const corsOptions = {
   origin: JSON.parse(process.env.AllowUrl || /* istanbul ignore next */'{}').urls,

--- a/src/model/inquiry/InquiryController.ts
+++ b/src/model/inquiry/InquiryController.ts
@@ -21,7 +21,15 @@ class InquiryController {
       html: bodyhtml,
     };
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'test') await sgMail.send(msg);
+    if (process.env.NODE_ENV !== 'test') {
+      try {
+        await sgMail.send(msg);
+      } catch (err) {
+        const e = err as { code?: number; message?: string };
+        debug('SendGrid send failed: %o', e);
+        return res.status(502).json({ message: 'email provider error', code: e.code, error: e.message });
+      }
+    }
     return res.status(200).json({ message: 'email sent' });
   }
 

--- a/src/model/inquiry/index.ts
+++ b/src/model/inquiry/index.ts
@@ -6,6 +6,12 @@ const router = express.Router();
 const controller = new InquiryController();
 
 router.route('/')
-  .post((req, res) => { (async () => { await controller.handleInquiry(req, res); })(); });
+  .post(async (req, res, next) => {
+    try {
+      await controller.handleInquiry(req, res);
+    } catch (err) {
+      next(err);
+    }
+  });
 
 export default router;


### PR DESCRIPTION
Closes #747

## Summary

\`POST /inquiry\` was crashing the entire Node process whenever \`@sendgrid/mail\` rejected (observed today via SendGrid 401 \`"Maximum credits exceeded"\`). The crash took the dev server down and broke every other JaMmusic page (Songs, Map, Sort, etc.) until the server was restarted. See #747 for full root-cause writeup.

## Changes

### 1. \`src/model/inquiry/InquiryController.ts\`
Wrapped \`sgMail.send\` in try/catch. SendGrid failures now return a clean **502** with \`{ message, code, error }\` and a \`debug()\` log, instead of throwing.

### 2. \`src/model/inquiry/index.ts\`
Replaced the fire-and-forget async IIFE with a proper async handler that forwards rejections to \`next(err)\`:

\`\`\`diff
- .post((req, res) => { (async () => { await controller.handleInquiry(req, res); })(); });
+ .post(async (req, res, next) => {
+   try { await controller.handleInquiry(req, res); }
+   catch (err) { next(err); }
+ });
\`\`\`

The old IIFE never returned its promise to Express, so neither Express 4 nor Express 5's async error forwarding ever saw a rejection.

### 3. \`src/index.ts\`
Added a global \`process.on('unhandledRejection', ...)\` that logs and does NOT exit, as defense in depth for future similar bugs in any other route.

## Test plan

### Automated
- [x] \`npm test\` — 70/70 tests pass, including the existing inquiry router test (\`test/unit/inquiry/index.spec.ts\`) which now exercises the wrapped controller.
- [x] No new lint errors.

### Manual smoke (in \`web-jam-back\` dev terminal + JaMmusic dev terminal running side by side)

**Healthy path — server stays up**
- [ ] \`npm run dev\` in web-jam-back. Submit the Contact Us form on JaMmusic homepage with valid input.
- [ ] If SendGrid is healthy: server logs \`POST /inquiry 200\`, JaMmusic shows the success state. No process exit.
- [ ] Navigate to /music/songs — Songs page loads.

**SendGrid failure path — server stays up, client gets 502**
- [ ] Temporarily break SendGrid (easiest: \`unset SENDGRID_API_KEY\` or set it to an obviously invalid value, restart the dev server). Submit Contact Us again.
- [ ] Expected: backend logs \`SendGrid send failed\` debug line + \`POST /inquiry 502\`. **Process does NOT crash.**
- [ ] Navigate to /music/songs — still loads (regression check — this was the original symptom).
- [ ] Restore the SENDGRID_API_KEY and confirm normal flow returns.

**Unhandled-rejection safety net**
- [ ] Verify the new process listener: in a temporary sandbox, throw \`new Error('test')\` from a stray \`Promise.reject\` not awaited — observe the server logs \`[unhandledRejection]\` instead of exiting. (Optional / spot-check, not required to merge.)

## Out of scope (separate concern)

The trigger today was that the SendGrid account is over its free-tier credit limit (\`Maximum credits exceeded\`). After this fix the server no longer crashes, but the contact form still won't actually deliver email until SendGrid is upgraded or replaced (Mailgun / AWS SES / Resend). Worth tracking as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)