### PR TITLE
fix(inquiry): CC chemmariasherman@gmail.com on every inquiry

### DIFF
--- a/src/model/inquiry/InquiryController.ts
+++ b/src/model/inquiry/InquiryController.ts
@@ -5,6 +5,9 @@ import Debug from 'debug';
 const debug = Debug('web-jam-back:InquiryController');
 
 const RECIPIENT_EMAIL = 'joshua.v.sherman@gmail.com';
+// CC Maria on every inquiry so she sees booking requests in real time
+// (Josh's preference 2026-05-18). Comma-separated string per nodemailer spec.
+const INQUIRY_CC = 'chemmariasherman@gmail.com';
 
 class InquiryController {
   private transporter: Transporter | null = null;
@@ -22,14 +25,15 @@ class InquiryController {
     return this.transporter;
   }
 
-  async sendEmail(bodyhtml: string, toemail: string, subjectline: string, res: Response) {
-    const msg = {
+  async sendEmail(bodyhtml: string, toemail: string, subjectline: string, res: Response, ccemail?: string) {
+    const msg: Record<string, string> = {
       to: toemail,
       from: process.env.GMAIL_USER || /* istanbul ignore next */ '',
       subject: subjectline,
       text: bodyhtml,
       html: bodyhtml,
     };
+    if (ccemail) msg.cc = ccemail;
     /* istanbul ignore if */
     if (process.env.NODE_ENV !== 'test') {
       try {
@@ -45,7 +49,7 @@ class InquiryController {
 
   handleInquiry(req: Request, res: Response) {
     debug(req.body);
-    return this.sendEmail(JSON.stringify(req.body), RECIPIENT_EMAIL, 'inquiry', res);
+    return this.sendEmail(JSON.stringify(req.body), RECIPIENT_EMAIL, 'inquiry', res, INQUIRY_CC);
   }
 }
 export default InquiryController;


### PR DESCRIPTION
## Summary

- Adds Maria (chemmariasherman@gmail.com) as a CC on every inquiry email sent through `/inquiry`.
- TO address stays `joshua.v.sherman@gmail.com` (unchanged).
- Implementation: new module-level constant `INQUIRY_CC`; `sendEmail()` gained an optional `ccemail` parameter; `handleInquiry()` passes it.

## Why

Josh's preference 2026-05-18 — Maria should see booking inquiries in real time alongside Josh's primary inbox so she's looped in on incoming gig requests without a forwarding step.

## Test plan

- [x] 70/70 unit tests pass
- [ ] Manual smoke test after deploy: submit a test inquiry from joshandmariamusic.com → confirm BOTH joshua.v.sherman@gmail.com (TO) AND chemmariasherman@gmail.com (CC) receive it.
- [ ] Same test from the Book Us page.

Bundles cleanly with PR #753 (the nodemailer swap) since both touch the same controller. Should be in the same dev → master release window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)