### PR TITLE
feat(admin): add admin Users management with per-user privileges

### DIFF
--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -43,6 +43,14 @@ const createJWT = (user: { _id: string }): string => {
   return jwt.encode(payload, process.env.HashString || /* istanbul ignore next */'');
 };
 
+const createServiceJWT = (user: { _id: string }): string => {
+  const payload = {
+    sub: user._id,
+    iat: Math.floor(Date.now() / 1000),
+  };
+  return jwt.encode(payload, process.env.HashString || /* istanbul ignore next */'');
+};
+
 const ensureAuthenticated = (req: AuthRequest): Promise<void> => {
   if (!req.headers.authorization && !req.headers.Authorization) {
     throw new Error('The request does not have an Authorization header');
@@ -64,5 +72,5 @@ const checkEmailSyntax = (req: { body: { changeemail: string } }): Promise<boole
 };
 
 export default {
-  checkEmailSyntax, ensureAuthenticated, createJWT, findUserById,
+  checkEmailSyntax, ensureAuthenticated, createJWT, createServiceJWT, findUserById,
 };

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -1,0 +1,35 @@
+export const CAPABILITIES = [
+  'tour:create',
+  'tour:edit',
+  'tour:delete',
+  'song:read',
+  'song:create',
+  'song:edit',
+  'song:delete',
+  'book:read',
+  'book:create',
+  'book:edit',
+  'book:delete',
+] as const;
+
+export type Capability = (typeof CAPABILITIES)[number];
+
+const capabilitySet: Set<string> = new Set(CAPABILITIES);
+
+export function isValidCapability(value: string): value is Capability {
+  return capabilitySet.has(value);
+}
+
+export function validatePrivileges(input: unknown): { ok: true; privileges: Capability[] } | { ok: false; message: string } {
+  if (!Array.isArray(input)) {
+    return { ok: false, message: 'privileges must be an array' };
+  }
+  for (const entry of input) {
+    if (typeof entry !== 'string' || !isValidCapability(entry)) {
+      return { ok: false, message: `invalid capability: ${String(entry)}` };
+    }
+  }
+  return { ok: true, privileges: input as Capability[] };
+}
+
+export default { CAPABILITIES, isValidCapability, validatePrivileges };

--- a/src/model/admin-user/admin-user-controller.ts
+++ b/src/model/admin-user/admin-user-controller.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import Controller from '#src/lib/controller.js';
+import { Icontroller } from '#src/lib/routeUtils.js';
+import userModel from '../user/user-facade.js';
+import { validatePrivileges } from '../../auth/capabilities.js';
+
+class AdminUserController extends Controller {
+  constructor(uModel: typeof userModel) {
+    super(uModel);
+  }
+
+  resErr(res: Response, e: Error) { // eslint-disable-line class-methods-use-this
+    return res.status(500).json({ message: e.message });
+  }
+
+  async create(req: Request, res: Response): Promise<unknown> {
+    const { body } = req;
+    delete body._id;
+    if (body.privileges !== undefined) {
+      const result = validatePrivileges(body.privileges);
+      if (!result.ok) return res.status(400).json({ message: result.message });
+      body.privileges = result.privileges;
+    }
+    if (body.userType && this.userRoles.indexOf(body.userType) === -1) {
+      return res.status(400).json({ message: 'userType not valid' });
+    }
+    if (!body.name) return res.status(400).json({ message: 'Name is required' });
+    if (!body.email) return res.status(400).json({ message: 'Email is required' });
+    let doc;
+    try { doc = await this.model.create(body); } catch (e) { return this.resErr(res, e as Error); }
+    return res.status(201).json(doc);
+  }
+
+  async findByIdAndUpdate(req: Request<{ id: string }>, res: Response): Promise<unknown> {
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Update id is invalid' });
+    }
+    if (req.body.privileges !== undefined) {
+      const result = validatePrivileges(req.body.privileges);
+      if (!result.ok) return res.status(400).json({ message: result.message });
+      req.body.privileges = result.privileges;
+    }
+    if (req.body.userType && this.userRoles.indexOf(req.body.userType) === -1) {
+      return res.status(400).json({ message: 'userType not valid' });
+    }
+    return this.contFBIandU(req, res);
+  }
+
+  async mintToken(req: Request<{ id: string }>, res: Response): Promise<unknown> {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'id is invalid' });
+    }
+    let user;
+    try { user = await this.model.findById(req.params.id); } catch (e) { return this.resErr(res, e as Error); }
+    if (!user) return res.status(400).json({ message: 'user not found' });
+    const token = this.authUtils.createServiceJWT(user as unknown as { _id: string });
+    return res.status(200).json({ token });
+  }
+}
+
+export default new AdminUserController(userModel) as unknown as Icontroller;

--- a/src/model/admin-user/admin-user-router.ts
+++ b/src/model/admin-user/admin-user-router.ts
@@ -1,0 +1,26 @@
+import express, { Request, Response } from 'express';
+import controller from './admin-user-controller.js';
+import authUtils from '../../auth/authUtils.js';
+import routeUtils from '../../lib/routeUtils.js';
+
+const router = express.Router();
+
+router.route('/')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'find', controller, authUtils);
+    void action();
+  })
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'create', controller, authUtils);
+    void action();
+  });
+
+routeUtils.byId(router, controller, authUtils);
+
+router.route('/:id/token')
+  .post((req: Request, res: Response) => {
+    const action = routeUtils.makeAction(req, res, 'mintToken', controller, authUtils);
+    void action();
+  });
+
+export default router;

--- a/src/model/user/user-schema.ts
+++ b/src/model/user/user-schema.ts
@@ -15,6 +15,7 @@ const userSchema = new Schema({
   userState: { type: String, required: false },
   userZip: { type: String, required: false },
   userDetails: { type: String, required: false },
+  privileges: { type: [String], required: false, default: [] },
 });
 
 export default mongoose.models.User || mongoose.model('User', userSchema);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,6 @@
 import express, { Express } from 'express';
 import user from './model/user/user-router.js';
+import adminUser from './model/admin-user/admin-user-router.js';
 import book from './model/book/book-router.js';
 import inquiry from './model/inquiry/index.js';
 import song from './model/song/song-router.js';
@@ -9,6 +10,7 @@ const router = express.Router();
 export default function route(app: Express): void {
   app.use(router);
   router.use('/user', user);
+  router.use('/admin/user', adminUser);
   router.use('/book', book);
   router.use('/song', song);
   router.use('/inquiry', inquiry);

--- a/test/unit/admin-user/admin-user-controller.spec.ts
+++ b/test/unit/admin-user/admin-user-controller.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import mongoose from 'mongoose';
+import controller from '../../../src/model/admin-user/admin-user-controller.js';
+import LibController from '../../../src/lib/controller.js';
+
+describe('Admin User Controller', () => {
+  let status = 0;
+  let testObj: any = {};
+  const resStub: any = {
+    status: (s: number) => { status = s; return ({ json: (obj: any) => { testObj = obj; return testObj; } }); },
+  };
+  const lib = controller as unknown as LibController;
+
+  beforeEach(() => {
+    status = 0;
+    testObj = {};
+  });
+
+  describe('create', () => {
+    it('rejects missing name', async () => {
+      await controller.create({ body: { email: 'a@b.com' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('Name');
+    });
+
+    it('rejects missing email', async () => {
+      await controller.create({ body: { name: 'Bot' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('Email');
+    });
+
+    it('rejects invalid privileges', async () => {
+      await controller.create({ body: { name: 'Bot', email: 'a@b.com', privileges: ['tour:nuke'] } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('tour:nuke');
+    });
+
+    it('rejects unknown userType', async () => {
+      lib.userRoles = ['JaM-admin'];
+      await controller.create({ body: { name: 'Bot', email: 'a@b.com', userType: 'unknown-role' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('userType');
+    });
+
+    it('creates with valid privileges', async () => {
+      lib.userRoles = ['web-jam-llm'];
+      lib.model.create = vi.fn(() => Promise.resolve({ _id: 'id', name: 'Bot', privileges: ['tour:create'] })) as any;
+      await controller.create({ body: { name: 'Bot', email: 'a@b.com', userType: 'web-jam-llm', privileges: ['tour:create'] } } as any, resStub);
+      expect(status).toBe(201);
+      expect(testObj._id).toBe('id');
+    });
+
+    it('creates with no privileges field set', async () => {
+      lib.model.create = vi.fn(() => Promise.resolve({ _id: 'id', name: 'Bot' })) as any;
+      await controller.create({ body: { name: 'Bot', email: 'a@b.com' } } as any, resStub);
+      expect(status).toBe(201);
+    });
+
+    it('returns 500 on model error', async () => {
+      lib.model.create = vi.fn(() => Promise.reject(new Error('boom'))) as any;
+      await controller.create({ body: { name: 'Bot', email: 'a@b.com' } } as any, resStub);
+      expect(status).toBe(500);
+    });
+  });
+
+  describe('findByIdAndUpdate', () => {
+    it('rejects invalid id', async () => {
+      await controller.findByIdAndUpdate({ params: { id: 'not-an-id' }, body: {} } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('Update id');
+    });
+
+    it('rejects invalid privileges in update', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.findByIdAndUpdate({ params: { id }, body: { privileges: ['evil:capability'] } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('evil:capability');
+    });
+
+    it('rejects invalid userType in update', async () => {
+      lib.userRoles = ['JaM-admin'];
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.findByIdAndUpdate({ params: { id }, body: { userType: 'fake' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('userType');
+    });
+
+    it('updates with valid privileges', async () => {
+      lib.userRoles = ['web-jam-llm'];
+      lib.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({ _id: 'id', privileges: ['tour:create'] })) as any;
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.findByIdAndUpdate({ params: { id }, body: { privileges: ['tour:create'] } } as any, resStub);
+      expect(status).toBe(200);
+    });
+  });
+
+  describe('mintToken', () => {
+    it('rejects invalid id', async () => {
+      await controller.mintToken({ params: { id: 'bad' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('id is invalid');
+    });
+
+    it('rejects when user not found', async () => {
+      lib.model.findById = vi.fn(() => Promise.resolve(null)) as any;
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.mintToken({ params: { id } } as any, resStub);
+      expect(status).toBe(400);
+      expect(testObj.message).toContain('not found');
+    });
+
+    it('mints a token when user found', async () => {
+      lib.model.findById = vi.fn(() => Promise.resolve({ _id: 'someid' })) as any;
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.mintToken({ params: { id } } as any, resStub);
+      expect(status).toBe(200);
+      expect(testObj.token).toBeDefined();
+      expect(typeof testObj.token).toBe('string');
+    });
+
+    it('returns 500 when model throws', async () => {
+      lib.model.findById = vi.fn(() => Promise.reject(new Error('db down'))) as any;
+      const id = new mongoose.Types.ObjectId().toString();
+      await controller.mintToken({ params: { id } } as any, resStub);
+      expect(status).toBe(500);
+    });
+  });
+});

--- a/test/unit/auth/capabilities.spec.ts
+++ b/test/unit/auth/capabilities.spec.ts
@@ -1,0 +1,61 @@
+import capabilities, { CAPABILITIES, isValidCapability, validatePrivileges } from '../../../src/auth/capabilities.js';
+
+describe('capabilities registry', () => {
+  it('exposes the canonical list', () => {
+    expect(CAPABILITIES.length).toBeGreaterThan(0);
+    expect(CAPABILITIES).toContain('tour:create');
+    expect(CAPABILITIES).toContain('song:read');
+    expect(CAPABILITIES).toContain('book:delete');
+  });
+
+  it('does NOT include user:* capabilities (admin role only, not granted per user)', () => {
+    for (const cap of CAPABILITIES) {
+      expect(cap.startsWith('user:')).toBe(false);
+    }
+  });
+
+  it('isValidCapability returns true for known capabilities', () => {
+    expect(isValidCapability('tour:create')).toBe(true);
+    expect(isValidCapability('book:read')).toBe(true);
+  });
+
+  it('isValidCapability returns false for unknown values', () => {
+    expect(isValidCapability('tour:nuke')).toBe(false);
+    expect(isValidCapability('')).toBe(false);
+    expect(isValidCapability('admin:everything')).toBe(false);
+  });
+
+  it('validatePrivileges accepts a valid array', () => {
+    const result = validatePrivileges(['tour:create', 'song:read']);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.privileges).toEqual(['tour:create', 'song:read']);
+  });
+
+  it('validatePrivileges accepts an empty array', () => {
+    const result = validatePrivileges([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('validatePrivileges rejects non-array input', () => {
+    const result = validatePrivileges('tour:create' as unknown);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('must be an array');
+  });
+
+  it('validatePrivileges rejects array with unknown capability', () => {
+    const result = validatePrivileges(['tour:create', 'tour:nuke']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('tour:nuke');
+  });
+
+  it('validatePrivileges rejects array with non-string entry', () => {
+    const result = validatePrivileges(['tour:create', 42]);
+    expect(result.ok).toBe(false);
+  });
+
+  it('default export wires up all three exports', () => {
+    expect(capabilities.CAPABILITIES).toBe(CAPABILITIES);
+    expect(capabilities.isValidCapability).toBe(isValidCapability);
+    expect(capabilities.validatePrivileges).toBe(validatePrivileges);
+  });
+});

--- a/test/unit/authUtils.spec.ts
+++ b/test/unit/authUtils.spec.ts
@@ -20,6 +20,15 @@ describe('the authUtils', () => {
     const decoded = jwt.decode(payload, config.hashString || '');
     expect(decoded.sub).toBe(user._id);
   });
+  it('creates a service token without an exp claim', () => {
+    const user = { _id: 'svc-id' };
+    const token = AuthUtils.createServiceJWT(user);
+    expect(token).toBeDefined();
+    const decoded = jwt.decode(token, config.hashString || '');
+    expect(decoded.sub).toBe(user._id);
+    expect(decoded.iat).toBeDefined();
+    expect(decoded.exp).toBeUndefined();
+  });
   it('does not find the user by id', async () => {
     let eMessage = '';
     const uM:any = userModel;


### PR DESCRIPTION
## Summary

- Adds a new `/admin/user/*` route surface on web-jam-back for managing all users — humans and AI agents — from a forthcoming admin UI in JaMmusic.
- Introduces a capability registry (`tour:*`, `song:*`, `book:*`) and a `privileges: [String]` field on User; the registry will gate fine-grained authorization per user, with the existing role-based check as a backward-compatible fallback.
- Adds `createServiceJWT` (no `exp` claim) for long-lived service tokens issued to AI agent users.

## What this does NOT do (intentional, additive scope)

- Does not change any existing route or guard behavior. Existing users (who have no `privileges` set) continue authorizing exactly as today.
- Does not migrate any existing route to the new capability model. The companion SCS PR migrates `newTour` only.
- No new dependencies; no schema migration needed (the new field is optional with a default of `[]`).

## Test plan

- [x] Lint clean (`npm run test:lint`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] All 96 unit tests pass (`npm run test:unit`)
- [ ] Companion SCS PR merged
- [ ] JaMmusic admin UI PR merged
- [ ] End-to-end: create a `web-jam-llm` user via the new admin UI, mint a token, transmit a `newTour` from a test script, verify gig appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)