### PR TITLE
finish migrating off supertest; add native-fetch test helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/supertest": "^7.2.0",
     "@vitest/coverage-v8": "^4.1.5",
     "@vitest/eslint-plugin": "^1.6.16",
     "concurrently": "^9.2.1",
@@ -80,7 +79,6 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-security": "^4.0.0",
     "globals": "^17.5.0",
-    "supertest": "^7.2.2",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.5"
   },

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -28,6 +28,8 @@ interface JwtPayload {
   exp?: number;
 }
 
+const authRoles = JSON.parse(process.env.AUTH_ROLES || /* istanbul ignore next */'{}') as Record<string, string[]>;
+
 const findUserById = async (req: AuthRequest): Promise<void> => {
   let myUser: UserDoc | null;
   try { myUser = await userModel.findById(req.user || '').lean().exec() as UserDoc | null; } catch (err) {
@@ -37,7 +39,6 @@ const findUserById = async (req: AuthRequest): Promise<void> => {
   req.userType = myUser ? myUser.userType : 'none';
   debug(req.userType);
   debug(req.baseUrl);
-  const authRoles = JSON.parse(process.env.AUTH_ROLES || /* istanbul ignore next */'{}') as Record<string, string[]>;
   const route = req.baseUrl.split('/')[1] || '';
   // eslint-disable-next-line security/detect-object-injection
   const rolesArr: string[] = authRoles[route] || /* istanbul ignore next */[];
@@ -78,11 +79,11 @@ const ensureAuthenticated = (req: AuthRequest): Promise<void> => {
   return findUserById(req);
 };
 
-const checkEmailSyntax = (req: EmailCheckRequest): Promise<boolean> => { // eslint-disable-next-line security/detect-unsafe-regex
+const checkEmailSyntax = async (req: EmailCheckRequest): Promise<boolean> => { // eslint-disable-next-line security/detect-unsafe-regex
   if (/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(req.body.changeemail)) {
-    return Promise.resolve(true);
+    return true;
   }
-  return Promise.reject(new Error('email address is not a valid format'));
+  throw new Error('email address is not a valid format');
 };
 
 export default {

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -37,7 +37,7 @@ async function authenticate(req: { body: { redirectUri: string; code: string; cl
     if (!tokenRes.ok) throw new Error(`${tokenRes.status} ${tokenRes.statusText}`);
     tokenBody = await tokenRes.json() as GoogleTokenResponse;
     debug(tokenBody);
-  } catch (e) { debug(e); return Promise.reject(e); }
+  } catch (e) { debug(e); throw e; }
   try { // Step 2. Retrieve profile information about the current user.
     const profileRes = await fetch(peopleApiUrl, {
       headers: { Authorization: `Bearer ${tokenBody.access_token}`, Accept: 'application/json' },

--- a/test/helpers/api.ts
+++ b/test/helpers/api.ts
@@ -1,0 +1,127 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Minimal supertest-shaped wrapper using native fetch + an ephemeral HTTP server.
+// Replaces supertest in this repo's tests; covers the .get/.post/.put/.delete +
+// .set/.send/.query chain that the existing tests use.
+
+import http from 'node:http';
+import type { Express } from 'express';
+
+export interface ApiResponse {
+  status: number;
+  body: any;
+  headers: Record<string, string>;
+}
+
+interface BoundServer {
+  server: http.Server;
+  baseUrl: string;
+}
+
+const cache = new WeakMap<Express, Promise<BoundServer>>();
+
+function getServer(app: Express): Promise<BoundServer> {
+  let p = cache.get(app);
+  if (p) return p;
+  p = new Promise((resolve, reject) => {
+    const server = http.createServer(app as unknown as http.RequestListener);
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to bind ephemeral port'));
+        return;
+      }
+      resolve({ server, baseUrl: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+  cache.set(app, p);
+  return p;
+}
+
+class ApiRequest implements PromiseLike<ApiResponse> {
+  private headers: Record<string, string> = {};
+
+  private body: unknown = undefined;
+
+  private bodyIsRaw = false;
+
+  private queryParams: Record<string, string> = {};
+
+  constructor(
+    private readonly app: Express,
+    private readonly method: string,
+    private readonly path: string,
+  ) {}
+
+  set(headers: Record<string, string>): this;
+  set(name: string, value: string): this;
+  set(arg1: string | Record<string, string>, arg2?: string): this {
+    if (typeof arg1 === 'string') {
+      this.headers[arg1] = arg2 as string;
+    } else {
+      for (const [k, v] of Object.entries(arg1)) this.headers[k] = v;
+    }
+    return this;
+  }
+
+  send(body: unknown): this {
+    this.body = body;
+    this.bodyIsRaw = typeof body === 'string';
+    return this;
+  }
+
+  query(q: Record<string, unknown>): this {
+    for (const [k, v] of Object.entries(q)) this.queryParams[k] = String(v);
+    return this;
+  }
+
+  private async execute(): Promise<ApiResponse> {
+    const { baseUrl } = await getServer(this.app);
+    let url = baseUrl + this.path;
+    const qs = new URLSearchParams(this.queryParams).toString();
+    if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+
+    const init: RequestInit = { method: this.method, headers: { ...this.headers } };
+    if (this.body !== undefined) {
+      if (this.bodyIsRaw) {
+        init.body = this.body as string;
+      } else {
+        init.body = JSON.stringify(this.body);
+        const h = init.headers as Record<string, string>;
+        if (!Object.keys(h).some((k) => k.toLowerCase() === 'content-type')) {
+          h['Content-Type'] = 'application/json';
+        }
+      }
+    }
+
+    const res = await fetch(url, init);
+    const ct = res.headers.get('content-type') || '';
+    let body: any;
+    if (ct.includes('application/json')) {
+      body = await res.json().catch(() => undefined);
+    } else {
+      const text = await res.text();
+      body = text === '' ? undefined : text;
+    }
+    const headers: Record<string, string> = {};
+    res.headers.forEach((v, k) => { headers[k] = v; });
+    return { status: res.status, body, headers };
+  }
+
+  then<TResolve = ApiResponse, TReject = never>(
+    onFulfilled?: ((value: ApiResponse) => TResolve | PromiseLike<TResolve>) | null,
+    onRejected?: ((reason: any) => TReject | PromiseLike<TReject>) | null,
+  ): Promise<TResolve | TReject> {
+    return this.execute().then(onFulfilled, onRejected);
+  }
+}
+
+export default function request(app: Express) {
+  return {
+    get: (path: string) => new ApiRequest(app, 'GET', path),
+    post: (path: string) => new ApiRequest(app, 'POST', path),
+    put: (path: string) => new ApiRequest(app, 'PUT', path),
+    delete: (path: string) => new ApiRequest(app, 'DELETE', path),
+    patch: (path: string) => new ApiRequest(app, 'PATCH', path),
+  };
+}

--- a/test/unit/book-router.spec.ts
+++ b/test/unit/book-router.spec.ts
@@ -1,11 +1,11 @@
-import request, { type Response } from 'supertest';
 import app from '#src/index.js';
 import BookModel from '../../src/model/book/book-facade.js';
 import userModel from '../../src/model/user/user-facade.js';
 import authUtils from '../../src/auth/authUtils.js';
+import request, { type ApiResponse } from '../helpers/api.js';
 
 describe('The Book API', () => {
-  let r: Response, newUser: { _id: string; userType: string };
+  let r: ApiResponse, newUser: { _id: string; userType: string };
   const allowedUrl = JSON.parse(process.env.AllowUrl || '{}').urls[0];
   beforeAll(async () => {
     await BookModel.deleteMany({});

--- a/test/unit/inquiry/index.spec.ts
+++ b/test/unit/inquiry/index.spec.ts
@@ -1,8 +1,8 @@
-import request from 'supertest';
 import app from '#src/index.js';
+import request from '../../helpers/api.js';
 
 describe('Inquiry Router', () => {
-  let r:any;
+  let r: any;
   it('sends an email', async () => {
     r = await request(app)
       .post('/inquiry')

--- a/test/unit/user/user-router.spec.ts
+++ b/test/unit/user/user-router.spec.ts
@@ -1,6 +1,6 @@
-import request from 'supertest';
 import authUtils from '../../../src/auth/authUtils.js';
 import app from '../../../src/index.js';
+import request from '../../helpers/api.js';
 
 describe('user-router', () => {
   it('should find matching users', async () => {


### PR DESCRIPTION
Picks up the in-flight 'better-types' branch work which had removed supertest from package.json + the imports from 3 spec files but left the call sites referencing the now-undefined `request`.

Source-side changes (preserved as-is):
- src/auth/authUtils.ts: hoist authRoles JSON.parse to module scope (was parsed per-request inside findUserById); convert checkEmailSyntax from Promise.resolve/reject to async/throw.
- src/auth/google.ts: Promise.reject(e) -> throw e inside async function.

Test migration:
- New test/helpers/api.ts: ~120-line wrapper around `http.createServer(app)`
  + native fetch that mimics supertest's chained .get/.post/.put/.delete + .set/.send/.query API closely enough that no test body changes are needed. Returns { status, body, headers }. Caches the server per app via WeakMap so all tests share one ephemeral port.
- 3 spec files (inquiry, book-router, user-router) now import `request` from the local helper instead of supertest.
- book-router.spec.ts: `let r: Response` -> `let r: ApiResponse` (the Response type came from supertest, now from our helper).

All 96 tests pass; lint clean; typecheck clean.