### PR TITLE
fix(ci): bump CircleCI node to 24.16 + add workflows block

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/node:24.15-browsers
+      - image: cimg/node:24.16-browsers
     working_directory: ~/repo
     steps:
       - checkout
@@ -40,3 +40,8 @@ jobs:
             done
             kill $SERVER_PID || true
             exit $STATUS
+
+workflows:
+  build-and-test:
+    jobs:
+      - build


### PR DESCRIPTION
## Summary
- Bump CircleCI Docker image `cimg/node:24.15-browsers` -> `24.16-browsers` to match `engines.node: 24.16.0`.
- Add explicit `workflows` block referencing the `build` job (resolves CircleCI "build: Job is unused" warning).

## Test plan
- [ ] CircleCI runs the `build-and-test` workflow on this branch and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)