### PR TITLE
feat(livestream): GET /livestream/current (YouTube live or latest completed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,7 @@ SOCKETCLUSTER_SECURE=false
 BUILD_BRANCH=main
 TINY_KEY=
 GOOGLE_MAPS_API_KEY=
+YOUTUBE_API_KEY=
+YOUTUBE_CHANNEL_ID=UCOra1rXiO-BHzMDNlLd9hFQ
 AUTH_ROLES={"song":["userType1","userType2"],"book":["userType1","userType2"],"user":["userType1", "userType2"]}
 APP_NAME=Example

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ SCS_PORT=8888
 SOCKETCLUSTER_SECURE=false
 BUILD_BRANCH=main
 TINY_KEY=
-GOOGLE_MAPS_API_KEY=
 YOUTUBE_API_KEY=
 YOUTUBE_CHANNEL_ID=UCOra1rXiO-BHzMDNlLd9hFQ
 AUTH_ROLES={"song":["userType1","userType2"],"book":["userType1","userType2"],"user":["userType1", "userType2"]}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,42 @@ Setting a config var triggers a Heroku dyno restart automatically. The change is
 6. Send a test inquiry from the live site, confirm it arrives at `joshua.v.sherman@gmail.com`.
 7. ONLY after delivery is confirmed, remove `SENDGRID_API_KEY`, `SENDGRID_USERNAME`, `SENDGRID_PASSWORD` from the same Config Vars page (click the X next to each).
 
+## Livestream (`/livestream/current` route)
+
+`GET /livestream/current` powers the CollegeLutheran livestream page's "always show a real video" behavior (CollegeLutheran#706). It queries the YouTube Data API v3 and returns:
+
+- `{ "videoId": "…", "status": "live" }` — the channel is live right now
+- `{ "videoId": "…", "status": "completed" }` — otherwise, the most recent finished stream
+- `{ "videoId": null, "status": "none" }` — on error, nothing found, or when the API key/channel are not configured (the UI then falls back to plain links)
+
+The result is cached in-memory for 15 minutes, because each YouTube `search.list` call costs 100 of the free 10,000-units/day quota.
+
+Two env vars must be set on the deployed environment (and in your local `.env` for end-to-end testing):
+
+- `YOUTUBE_API_KEY` — a YouTube Data API v3 key from the Google Cloud Console (Web Jam LLC project), restricted to the YouTube Data API v3. **Secret — server-side only**, never exposed to the browser (that's the whole reason this lives in the backend).
+- `YOUTUBE_CHANNEL_ID` — the channel to watch. College Lutheran: `UCOra1rXiO-BHzMDNlLd9hFQ` (public).
+
+Without these, the endpoint returns `none` and the page shows its fallback links, so it is safe to deploy before they are set. In `NODE_ENV=test` no real API calls are made (tests stub `fetch`).
+
+### Setting the env vars on Heroku (app: `webjamsalem`)
+
+**Option A — Heroku dashboard (recommended):**
+
+1. Log in to <https://dashboard.heroku.com> and select the `webjamsalem` app.
+2. Settings → Reveal Config Vars.
+3. Add `YOUTUBE_API_KEY` = the key from Google Cloud Console.
+4. Add `YOUTUBE_CHANNEL_ID` = `UCOra1rXiO-BHzMDNlLd9hFQ`.
+
+**Option B — Heroku CLI:**
+
+```bash
+heroku config:set YOUTUBE_API_KEY='<your-key>' -a webjamsalem
+heroku config:set YOUTUBE_CHANNEL_ID=UCOra1rXiO-BHzMDNlLd9hFQ -a webjamsalem
+heroku config:get YOUTUBE_CHANNEL_ID -a webjamsalem   # verify (do NOT echo the key)
+```
+
+Setting a config var triggers a dyno restart automatically; the change is live within ~30 seconds.
+
 ## Test
 
 **`npm test`** runs the tests and generates a coverage report.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/livestream/LivestreamController.ts
+++ b/src/model/livestream/LivestreamController.ts
@@ -1,0 +1,65 @@
+import { Request, Response } from 'express';
+import Debug from 'debug';
+
+const debug = Debug('web-jam-back:LivestreamController');
+
+// Each search.list call costs 100 of the 10,000/day free quota units, so we
+// cache the resolved result for 15 minutes to avoid exhausting the quota.
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const SEARCH_URL = 'https://www.googleapis.com/youtube/v3/search';
+
+export interface LivestreamResult {
+  videoId: string | null;
+  status: 'live' | 'completed' | 'none';
+}
+
+let cache: { value: LivestreamResult; at: number } | null = null;
+
+// test-only hook to reset the module-level cache between cases
+export const __clearCache = (): void => { cache = null; };
+
+class LivestreamController {
+  private async search(eventType: 'live' | 'completed'): Promise<string | null> {
+    const params = new URLSearchParams({
+      part: 'snippet',
+      type: 'video',
+      eventType,
+      order: 'date',
+      maxResults: '1',
+      channelId: process.env.YOUTUBE_CHANNEL_ID || /* istanbul ignore next */ '',
+      key: process.env.YOUTUBE_API_KEY || /* istanbul ignore next */ '',
+    });
+    const res = await fetch(`${SEARCH_URL}?${params.toString()}`);
+    if (!res.ok) throw new Error(`YouTube API responded ${res.status}`);
+    const body = await res.json() as { items?: Array<{ id?: { videoId?: string } }> };
+    return body.items?.[0]?.id?.videoId || null;
+  }
+
+  async getCurrent(_req: Request, res: Response): Promise<void> {
+    if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
+      res.json(cache.value);
+      return;
+    }
+    // Not configured yet → let the UI fall back to plain links (no API call).
+    if (!process.env.YOUTUBE_API_KEY || !process.env.YOUTUBE_CHANNEL_ID) {
+      res.json({ videoId: null, status: 'none' });
+      return;
+    }
+    let result: LivestreamResult = { videoId: null, status: 'none' };
+    try {
+      const live = await this.search('live');
+      if (live) result = { videoId: live, status: 'live' };
+      else {
+        const completed = await this.search('completed');
+        if (completed) result = { videoId: completed, status: 'completed' };
+      }
+      cache = { value: result, at: Date.now() }; // cache only successful lookups
+    } catch (err) {
+      // Don't cache failures; return 'none' so the UI falls back gracefully.
+      debug('livestream lookup failed: %s', (err as Error).message);
+    }
+    res.json(result);
+  }
+}
+
+export default LivestreamController;

--- a/src/model/livestream/index.ts
+++ b/src/model/livestream/index.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import LivestreamController from './LivestreamController.js';
+
+const router = express.Router();
+
+const controller = new LivestreamController();
+
+router.route('/current')
+  .get(async (req, res, next) => {
+    try {
+      await controller.getCurrent(req, res);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+export default router;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,6 +3,7 @@ import user from './model/user/user-router.js';
 import adminUser from './model/admin-user/admin-user-router.js';
 import book from './model/book/book-router.js';
 import inquiry from './model/inquiry/index.js';
+import livestream from './model/livestream/index.js';
 import song from './model/song/song-router.js';
 
 const router = express.Router();
@@ -14,4 +15,5 @@ export default function route(app: Express): void {
   router.use('/book', book);
   router.use('/song', song);
   router.use('/inquiry', inquiry);
+  router.use('/livestream', livestream);
 }

--- a/test/unit/livestream/index.spec.ts
+++ b/test/unit/livestream/index.spec.ts
@@ -1,0 +1,87 @@
+import app from '#src/index.js';
+import request from '../../helpers/api.js';
+import { __clearCache } from '#src/model/livestream/LivestreamController.js';
+
+// The test client (request(app)) uses global fetch to hit the app over HTTP, so
+// we only intercept calls to the YouTube API and pass everything else through.
+const realFetch = globalThis.fetch.bind(globalThis);
+const ytBody = (videoId?: string) => ({
+  ok: true,
+  json: async () => ({ items: videoId ? [{ id: { videoId } }] : [] }),
+});
+
+function stubYouTube(...responses: any[]) {
+  const yt = vi.fn();
+  responses.forEach((r) => yt.mockResolvedValueOnce(r));
+  vi.stubGlobal('fetch', (url: any, init: any) => (
+    String(url).startsWith('https://www.googleapis.com/youtube')
+      ? yt(url)
+      : realFetch(url, init)
+  ));
+  return yt;
+}
+
+describe('Livestream Router GET /livestream/current', () => {
+  const origKey = process.env.YOUTUBE_API_KEY;
+  const origChannel = process.env.YOUTUBE_CHANNEL_ID;
+
+  beforeEach(() => { __clearCache(); });
+  afterEach(() => {
+    if (origKey === undefined) delete process.env.YOUTUBE_API_KEY; else process.env.YOUTUBE_API_KEY = origKey;
+    if (origChannel === undefined) delete process.env.YOUTUBE_CHANNEL_ID; else process.env.YOUTUBE_CHANNEL_ID = origChannel;
+    vi.unstubAllGlobals();
+  });
+
+  it('returns none (no API call) when not configured', async () => {
+    delete process.env.YOUTUBE_API_KEY;
+    delete process.env.YOUTUBE_CHANNEL_ID;
+    const yt = stubYouTube();
+    const r = await request(app).get('/livestream/current');
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual({ videoId: null, status: 'none' });
+    expect(yt).not.toHaveBeenCalled();
+  });
+
+  it('returns the active live stream when the channel is live', async () => {
+    process.env.YOUTUBE_API_KEY = 'k';
+    process.env.YOUTUBE_CHANNEL_ID = 'c';
+    stubYouTube(ytBody('LIVE123'));
+    const r = await request(app).get('/livestream/current');
+    expect(r.body).toEqual({ videoId: 'LIVE123', status: 'live' });
+  });
+
+  it('falls back to the latest completed stream when not live', async () => {
+    process.env.YOUTUBE_API_KEY = 'k';
+    process.env.YOUTUBE_CHANNEL_ID = 'c';
+    const yt = stubYouTube(ytBody(undefined), ytBody('DONE456'));
+    const r = await request(app).get('/livestream/current');
+    expect(r.body).toEqual({ videoId: 'DONE456', status: 'completed' });
+    expect(yt).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns none when neither live nor completed is found', async () => {
+    process.env.YOUTUBE_API_KEY = 'k';
+    process.env.YOUTUBE_CHANNEL_ID = 'c';
+    stubYouTube(ytBody(undefined), ytBody(undefined));
+    const r = await request(app).get('/livestream/current');
+    expect(r.body).toEqual({ videoId: null, status: 'none' });
+  });
+
+  it('returns none on YouTube API error (and does not cache it)', async () => {
+    process.env.YOUTUBE_API_KEY = 'k';
+    process.env.YOUTUBE_CHANNEL_ID = 'c';
+    stubYouTube({ ok: false, status: 403, json: async () => ({}) });
+    const r = await request(app).get('/livestream/current');
+    expect(r.body).toEqual({ videoId: null, status: 'none' });
+  });
+
+  it('serves the cached result without calling the API again', async () => {
+    process.env.YOUTUBE_API_KEY = 'k';
+    process.env.YOUTUBE_CHANNEL_ID = 'c';
+    const yt = stubYouTube(ytBody('LIVE123'));
+    await request(app).get('/livestream/current'); // populates cache
+    const r2 = await request(app).get('/livestream/current'); // served from cache
+    expect(r2.body).toEqual({ videoId: 'LIVE123', status: 'live' });
+    expect(yt).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Backs **CollegeLutheran#706** / closes **#765**. The backend half of the always-show-a-real-video livestream feature.

## What
New `GET /livestream/current` endpoint:
- Channel live now → `{ videoId, status: 'live' }`
- Else most recent completed stream → `{ videoId, status: 'completed' }`
- Error / nothing / **not yet configured (no API key)** → `{ videoId: null, status: 'none' }` so the UI falls back to plain links

## How
- `src/model/livestream/` — router (`index.ts`) + `LivestreamController.ts`, mirroring the `inquiry` pattern; wired in `routes.ts` as `/livestream`.
- YouTube Data API v3 `search.list` via native `fetch`: `eventType=live` first, else `eventType=completed&order=date&maxResults=1`.
- **In-memory 15-min cache** — each `search.list` costs 100 of the 10k/day free quota units. Failures and the no-key case are *not* cached.
- 6 unit tests (live / completed / none / no-key / API-error / cache-hit). Full suite: **100 tests pass**, eslint + tsc clean.

## Config (prerequisite to actually return video — safe to merge without it)
Set on the `webjamsalem` Heroku app:
- `YOUTUBE_API_KEY` — YouTube Data API v3 key (Google Cloud Console)
- `YOUTUBE_CHANNEL_ID` — `UCOra1rXiO-BHzMDNlLd9hFQ` (CL channel, public)

Until those exist the endpoint returns `none` and the page shows the existing links — no breakage.

## How to Test Locally
```bash
git checkout feat-livestream-current-endpoint
npm install
npm test                      # eslint + 100 unit tests (incl. 6 new)
# manual (optional): with YOUTUBE_API_KEY + YOUTUBE_CHANNEL_ID in .env:
PORT=7000 node build/src/index.js   # then: curl localhost:7000/livestream/current
```

Paired with the CollegeLutheran frontend PR (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)