### PR TITLE
feat(book): add `enabled` field for page-content visibility toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/book/book-schema.ts
+++ b/src/model/book/book-schema.ts
@@ -21,6 +21,9 @@ const bookSchema = new Schema({
   comments: { type: String, required: false },
   checkedOutBy: { type: String, required: false },
   checkedOutByName: { type: String, required: false },
+  // page-content docs (e.g. type:'stewardshipPageContent') use this as an
+  // admin on/off visibility toggle; absent/false = hidden (CollegeLutheran#707)
+  enabled: { type: Boolean, required: false },
 }, options);
 
 export default mongoose.models.Book || mongoose.model('Book', bookSchema);

--- a/test/unit/book-router.spec.ts
+++ b/test/unit/book-router.spec.ts
@@ -63,6 +63,17 @@ describe('The Book API', () => {
     expect(r.status).toBe(200);
     expect(r.body.title).toBe('Bad Book');
   });
+  it('persists the enabled toggle on a content doc', async () => {
+    await BookModel.create({ title: 'Stewardship', type: 'stewardshipPageContent' });
+    r = await request(app)
+      .put('/book/one')
+      .set({ origin: allowedUrl })
+      .set('Authorization', `Bearer ${authUtils.createJWT({ _id: newUser._id })}`)
+      .query({ type: 'stewardshipPageContent' })
+      .send({ title: 'Stewardship', enabled: true });
+    expect(r.status).toBe(200);
+    expect(r.body.enabled).toBe(true);
+  });
   it('deletes a book by id', async () => {
     const newBook = await BookModel.create({
       title: 'Best Test Book Ever', type: 'paperback',


### PR DESCRIPTION
Backend half of **CollegeLutheran#707** (stewardship seasonal show/hide). Tiny, additive.

## Change
- `book-schema.ts`: add `enabled: { type: Boolean, required: false }`. Page-content docs (e.g. `type:'stewardshipPageContent'`) use it as an admin on/off toggle; absent/false = hidden.
- No controller change needed — `PUT /book/one` already passes the request body through `findOneAndUpdate`; the schema field is required only so Mongoose strict mode persists it.
- Test: `PUT /book/one` round-trips `enabled:true`. **101 tests pass**, tsc + eslint clean.
- semver 2.0.3 → 2.0.4 (package.json + package-lock.json synced).

## How to Test Locally
```bash
git checkout feat-book-enabled-field
npm install
npm test
```

Paired with the CollegeLutheran frontend PR (next): nav-link + route gating on `enabled`, plus the admin toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)