### PR TITLE
feat(livestream): return publishedAt from /livestream/current

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/livestream/LivestreamController.ts
+++ b/src/model/livestream/LivestreamController.ts
@@ -11,6 +11,7 @@ const SEARCH_URL = 'https://www.googleapis.com/youtube/v3/search';
 export interface LivestreamResult {
   videoId: string | null;
   status: 'live' | 'completed' | 'none';
+  publishedAt?: string;
 }
 
 let cache: { value: LivestreamResult; at: number } | null = null;
@@ -19,7 +20,7 @@ let cache: { value: LivestreamResult; at: number } | null = null;
 export const __clearCache = (): void => { cache = null; };
 
 class LivestreamController {
-  private async search(eventType: 'live' | 'completed'): Promise<string | null> {
+  private async search(eventType: 'live' | 'completed'): Promise<{ videoId: string; publishedAt?: string } | null> {
     const params = new URLSearchParams({
       part: 'snippet',
       type: 'video',
@@ -31,8 +32,12 @@ class LivestreamController {
     });
     const res = await fetch(`${SEARCH_URL}?${params.toString()}`);
     if (!res.ok) throw new Error(`YouTube API responded ${res.status}`);
-    const body = await res.json() as { items?: Array<{ id?: { videoId?: string } }> };
-    return body.items?.[0]?.id?.videoId || null;
+    const body = await res.json() as {
+      items?: Array<{ id?: { videoId?: string }, snippet?: { publishedAt?: string } }>
+    };
+    const item = body.items?.[0];
+    if (!item?.id?.videoId) return null;
+    return { videoId: item.id.videoId, publishedAt: item.snippet?.publishedAt };
   }
 
   async getCurrent(_req: Request, res: Response): Promise<void> {
@@ -48,10 +53,10 @@ class LivestreamController {
     let result: LivestreamResult = { videoId: null, status: 'none' };
     try {
       const live = await this.search('live');
-      if (live) result = { videoId: live, status: 'live' };
+      if (live) result = { videoId: live.videoId, status: 'live', publishedAt: live.publishedAt };
       else {
         const completed = await this.search('completed');
-        if (completed) result = { videoId: completed, status: 'completed' };
+        if (completed) result = { videoId: completed.videoId, status: 'completed', publishedAt: completed.publishedAt };
       }
       cache = { value: result, at: Date.now() }; // cache only successful lookups
     } catch (err) {

--- a/test/unit/livestream/index.spec.ts
+++ b/test/unit/livestream/index.spec.ts
@@ -5,9 +5,9 @@ import { __clearCache } from '#src/model/livestream/LivestreamController.js';
 // The test client (request(app)) uses global fetch to hit the app over HTTP, so
 // we only intercept calls to the YouTube API and pass everything else through.
 const realFetch = globalThis.fetch.bind(globalThis);
-const ytBody = (videoId?: string) => ({
+const ytBody = (videoId?: string, publishedAt?: string) => ({
   ok: true,
-  json: async () => ({ items: videoId ? [{ id: { videoId } }] : [] }),
+  json: async () => ({ items: videoId ? [{ id: { videoId }, snippet: { publishedAt } }] : [] }),
 });
 
 function stubYouTube(...responses: any[]) {
@@ -45,17 +45,17 @@ describe('Livestream Router GET /livestream/current', () => {
   it('returns the active live stream when the channel is live', async () => {
     process.env.YOUTUBE_API_KEY = 'k';
     process.env.YOUTUBE_CHANNEL_ID = 'c';
-    stubYouTube(ytBody('LIVE123'));
+    stubYouTube(ytBody('LIVE123', '2026-05-25T15:00:00Z'));
     const r = await request(app).get('/livestream/current');
-    expect(r.body).toEqual({ videoId: 'LIVE123', status: 'live' });
+    expect(r.body).toEqual({ videoId: 'LIVE123', status: 'live', publishedAt: '2026-05-25T15:00:00Z' });
   });
 
   it('falls back to the latest completed stream when not live', async () => {
     process.env.YOUTUBE_API_KEY = 'k';
     process.env.YOUTUBE_CHANNEL_ID = 'c';
-    const yt = stubYouTube(ytBody(undefined), ytBody('DONE456'));
+    const yt = stubYouTube(ytBody(undefined), ytBody('DONE456', '2026-05-20T15:00:00Z'));
     const r = await request(app).get('/livestream/current');
-    expect(r.body).toEqual({ videoId: 'DONE456', status: 'completed' });
+    expect(r.body).toEqual({ videoId: 'DONE456', status: 'completed', publishedAt: '2026-05-20T15:00:00Z' });
     expect(yt).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
Supplies the **date** for CollegeLutheran's livestream label (paired with CL frontend **#716**).

## Change
`GET /livestream/current` now includes the video's **`publishedAt`** (from the YouTube `search.list` snippet) for `live`/`completed` results — so the CL page can show *"Most recent service — <date>"*. Omitted for `none`.

- `search()` returns `{ videoId, publishedAt }`; `LivestreamResult` gains optional `publishedAt`.
- Tests assert `publishedAt` round-trips for live + completed. **101 tests pass**, tsc + eslint clean.
- semver 2.0.4 → 2.0.5 (+ lockfile).

## How to Test Locally
```bash
git checkout feat-livestream-publishedat
npm install && npm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)