### PR TITLE
ci: redeploy webjamsalem when JaMmusic merges to main (Task 195b receiver)

### DIFF
--- a/.github/workflows/redeploy-on-jammusic.yml
+++ b/.github/workflows/redeploy-on-jammusic.yml
@@ -1,0 +1,23 @@
+name: Redeploy on JaMmusic main update
+
+# Fired by a repository_dispatch from JaMmusic when it merges to main, so the
+# embedded JaMmusic build (via postinstallJaM) is refreshed. Also runnable by
+# hand from the Actions tab (workflow_dispatch).
+on:
+  repository_dispatch:
+    types: [jammusic-main-deploy]
+  workflow_dispatch: {}
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Heroku build of current main
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          curl -fsS -X POST https://api.heroku.com/apps/webjamsalem/builds \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.heroku+json; version=3" \
+            -H "Authorization: Bearer $HEROKU_API_KEY" \
+            -d '{"source_blob":{"url":"https://github.com/WebJamApps/web-jam-back/tarball/main","version":"main"}}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",


### PR DESCRIPTION
## What

Adds `.github/workflows/redeploy-on-jammusic.yml` — a GitHub Actions workflow that rebuilds the **webjamsalem** Heroku app whenever JaMmusic merges to `main`, so the embedded JaMmusic frontend (pulled in at build time by `postinstallJaM`) stays current.

This is the **receiver** half of the Task 195(b) fan-out. It's triggered by a `repository_dispatch` (`jammusic-main-deploy`) that the JaMmusic dispatcher workflow (separate PR) will send. It can also be run by hand from the Actions tab via `workflow_dispatch`.

The step calls the Heroku Platform API to build the current `main` from its public GitHub source tarball — running the full buildpack (incl. `postinstallJaM`, which re-pulls JaMmusic `main`). No empty commits, idempotent.

## Required secret (add before this does anything)

- `HEROKU_API_KEY` — repo secret, a Heroku API token authorized for the `webjamsalem` app.

## How to Test Locally

This workflow runs on GitHub's runners, not locally, but you can validate and dry-run the pieces:

```bash
# 1. Validate the workflow YAML
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/redeploy-on-jammusic.yml')); print('valid')"

# 2. After merging + adding the HEROKU_API_KEY secret, trigger it manually:
gh workflow run "Redeploy on JaMmusic main update" -R WebJamApps/web-jam-back
gh run watch -R WebJamApps/web-jam-back

# 3. Confirm a new Heroku build/release was created (requires Heroku auth — your call):
#    heroku builds -a webjamsalem   |   heroku releases -a webjamsalem
```

Part of the Task 195(b) fan-out tracked in JaMmusic#1071. Companion PRs: WebJamSocketCluster receiver + JaMmusic dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)