### PR TITLE
feat(auth): add gig:* capabilities alongside tour:* (Phase 2, #779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -1,4 +1,9 @@
 export const CAPABILITIES = [
+  // `gig:*` is the new naming; `tour:*` stays valid during the tour->gig rename
+  // migration and is removed in the Phase-4 cleanup.
+  'gig:create',
+  'gig:edit',
+  'gig:delete',
   'tour:create',
   'tour:edit',
   'tour:delete',

--- a/test/unit/auth/capabilities.spec.ts
+++ b/test/unit/auth/capabilities.spec.ts
@@ -3,9 +3,15 @@ import capabilities, { CAPABILITIES, isValidCapability, validatePrivileges } fro
 describe('capabilities registry', () => {
   it('exposes the canonical list', () => {
     expect(CAPABILITIES.length).toBeGreaterThan(0);
-    expect(CAPABILITIES).toContain('tour:create');
+    expect(CAPABILITIES).toContain('gig:create');
     expect(CAPABILITIES).toContain('song:create');
     expect(CAPABILITIES).toContain('book:delete');
+  });
+
+  it('includes the new gig:* caps and keeps legacy tour:* valid during migration', () => {
+    for (const cap of ['gig:create', 'gig:edit', 'gig:delete', 'tour:create', 'tour:edit', 'tour:delete']) {
+      expect(isValidCapability(cap)).toBe(true);
+    }
   });
 
   it('does NOT include user:* capabilities (admin role only, not granted per user)', () => {


### PR DESCRIPTION
Phase 2 of the cross-repo `tour → gig` rename (#779).

## What
Adds `gig:create` / `gig:edit` / `gig:delete` to the capability registry (`src/auth/capabilities.ts`). `tour:*` is kept valid **during the migration** so the `web-jam-llm` bot's existing `tour:create` privilege keeps working until it's migrated to `gig:create` in the Phase-4 cleanup (which then drops `tour:*`).

This pairs with the SocketCluster `assertCanCreateGig`, which already accepts `gig:create` **or** legacy `tour:create` (WebJamSocketCluster #226).

## How to Test Locally
```bash
npm ci
npm run typecheck
npx vitest run test/unit/auth
npm test        # eslint + full suite (115 tests)
```
All green. New test asserts both `gig:*` and legacy `tour:*` are valid capabilities.

Closes #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)