### PR TITLE
fix(csp): allow Plyr + www.dropbox.com so the migrated player works in prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,14 +52,14 @@ app.use(helmet.contentSecurityPolicy({
       'https://w.soundcloud.com', 'https://www.youtube.com', 'https://dl.dropboxusercontent.com', 'https://js.stripe.com'],
     'frame-ancestors': ["'self'"],
     'img-src': ["'self'", 'data:', 'https:', 'https://dl.dropboxusercontent.com'],
-    'media-src': ["'self'", 'https://dl.dropboxusercontent.com'],
+    'media-src': ["'self'", 'https://dl.dropboxusercontent.com', 'https://www.dropbox.com', 'https://cdn.plyr.io'],
     'object-src': ["'none'"],
     'script-src': ["'self'", 'https://accounts.google.com', 'https://maps.googleapis.com', 'https://apis.google.com', 'https://cdn.tiny.cloud',
       'https://w.soundcloud.com', 'https://www.youtube.com', 'https://s.ytimg.com', 'https://cdnjs.cloudflare.com', 'https://js.stripe.com'],
     'script-src-attr': ["'none'"],
     'style-src': ["'self'", 'https:', "'unsafe-inline'"],
     'upgrade-insecure-requests': [],
-    'connect-src': ["'self'", 'ws:', 'wss:'],
+    'connect-src': ["'self'", 'ws:', 'wss:', 'https://cdn.plyr.io'],
   },
 }));
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
The Plyr player migration (JaMmusic #1087) works in local dev but **breaks playback in production** because Helmet's CSP — which only runs on the prod Express server, not the local Vite dev server — blocks what Plyr needs.

## Symptoms (prod console)
- `Connecting to '…' violates … "connect-src 'self' ws: wss:"` → Plyr's icon-sprite XHR (`cdn.plyr.io/3.8.4/plyr.svg`) is blocked; the failed XHR throws `Uncaught Error: 0`, which crashes the React render.
- `Loading media from '…' violates … "media-src 'self' …"` → blocks `cdn.plyr.io/static/blank.mp4` (Plyr's YouTube placeholder) and the 5 songs hosted on `www.dropbox.com`.

## Fix (CSP directives)
- `connect-src`: add `https://cdn.plyr.io` (sprite fetch).
- `media-src`: add `https://cdn.plyr.io` (blank.mp4) and `https://www.dropbox.com` (new-style share links — they 302 to the already-allowed `dl.dropboxusercontent.com`, but the initial host must be allowed).

Prod song-host audit: 46 on `dl.dropboxusercontent.com` (already ok), 5 on `www.dropbox.com`, 2 YouTube (frame-src, ok), 7 SoundCloud (to be deleted — Plyr can't play them).

## How to Test Locally
CSP isn't applied by the Vite dev server, so verify the header directly:
```bash
git fetch origin
git checkout fix-csp-plyr-media
npm install
npm run typecheck
npm test            # 115 passing
npm start           # prod server on :7000
curl -sI http://localhost:7000/ | grep -i content-security-policy
# confirm connect-src includes cdn.plyr.io and media-src includes
# cdn.plyr.io + www.dropbox.com
```
Full end-to-end verification happens once this deploys to `webjamsalem` and the frontend Plyr build is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)