### PR TITLE
fix(csp): allow noembed.com so Plyr YouTube titles load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ app.use(helmet.contentSecurityPolicy({
     'script-src-attr': ["'none'"],
     'style-src': ["'self'", 'https:', "'unsafe-inline'"],
     'upgrade-insecure-requests': [],
-    'connect-src': ["'self'", 'ws:', 'wss:', 'https://cdn.plyr.io'],
+    'connect-src': ["'self'", 'ws:', 'wss:', 'https://cdn.plyr.io', 'https://noembed.com'],
   },
 }));
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Follow-up to #783/#785. Prod YouTube songs throw:

```
Connecting to 'https://noembed.com/embed?url=https://www.youtube.com/watch?v=...'
violates ... "connect-src 'self' ws: wss: https://cdn.plyr.io"
→ Uncaught Error: 0
```

Plyr fetches the YouTube video **title** from `noembed.com` when the player becomes ready; `connect-src` didn't allow it, so the XHR threw.

## Fix
Add `https://noembed.com` to `connect-src`.

(The `Unrecognized feature: 'web-share'` warning and the `i.ytimg.com/.../maxresdefault.jpg 404` are benign — YouTube falls back automatically and neither is CSP-blocked.)

## How to Test Locally
```bash
git fetch origin && git checkout fix-csp-noembed-youtube-title
npm install && npm test     # 115 passing
npm start
curl -sI http://localhost:7000/ | grep -io "connect-src[^;]*"
# expect: ... https://cdn.plyr.io https://noembed.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)