### PR TITLE
feat(subscriber): DB-backed fan distribution list (opt-in, confirm, unsubscribe, admin CRUD)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.13",
+  "version": "2.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.13",
+      "version": "2.0.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,51 @@
+import nodemailer, { Transporter } from 'nodemailer';
+import Debug from 'debug';
+
+// Shared Gmail mailer, reused across promotion channels (subscriber confirm /
+// unsubscribe now; gig blasts next). Mirrors the InquiryController transport so
+// both rely on the same GMAIL_USER / GMAIL_APP_PASSWORD credentials.
+const debug = Debug('web-jam-back:mailer');
+
+let transporter: Transporter | null = null;
+
+function getTransporter(): Transporter {
+  /* istanbul ignore else */
+  if (transporter) return transporter;
+  transporter = nodemailer.createTransport({
+    service: 'gmail',
+    secure: true,
+    auth: {
+      user: process.env.GMAIL_USER || /* istanbul ignore next */ '',
+      pass: process.env.GMAIL_APP_PASSWORD || /* istanbul ignore next */ '',
+    },
+  });
+  return transporter;
+}
+
+export interface MailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+// Sends one email. No-ops under NODE_ENV=test so unit tests never hit Gmail.
+export async function sendMail(input: MailInput): Promise<void> {
+  /* istanbul ignore if */
+  if (process.env.NODE_ENV !== 'test') {
+    try {
+      await getTransporter().sendMail({
+        from: process.env.GMAIL_USER || '',
+        to: input.to,
+        subject: input.subject,
+        text: input.text || input.html,
+        html: input.html,
+      });
+    } catch (err) {
+      debug('email send failed: %o', err);
+      throw err;
+    }
+  }
+}
+
+export default { sendMail };

--- a/src/model/subscriber/admin-subscriber-router.ts
+++ b/src/model/subscriber/admin-subscriber-router.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import controller from './subscriber-controller.js';
+import authUtils from '../../auth/authUtils.js';
+import routeUtils from '../../lib/routeUtils.js';
+
+// ADMIN subscriber management. Mounted at /admin/subscriber, so authUtils gates
+// every route on AUTH_ROLES.admin (same key as /admin/user) — no new env needed.
+const router = express.Router();
+
+router.route('/')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'find', controller, authUtils);
+    void action();
+  })
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'create', controller, authUtils);
+    void action();
+  });
+
+// GET/PUT/DELETE /admin/subscriber/:id (list-by-id, edit, remove), all authed.
+routeUtils.byId(router, controller, authUtils);
+
+export default router;

--- a/src/model/subscriber/subscriber-controller.ts
+++ b/src/model/subscriber/subscriber-controller.ts
@@ -1,0 +1,166 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import crypto from 'node:crypto';
+import Controller from '#src/lib/controller.js';
+import { Icontroller } from '#src/lib/routeUtils.js';
+import { sendMail } from '#src/lib/mailer.js';
+import subscriberModel from './subscriber-facade.js';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s.@]+$/;
+const STATUS_OPTIONS = ['pending', 'active', 'unsubscribed'];
+
+interface SubscriberDoc {
+  _id: string;
+  name: string;
+  email: string;
+  status: string;
+  unsubscribeToken?: string;
+}
+
+interface OptInBody {
+  name?: string;
+  email?: string;
+  phone?: number;
+  status?: string;
+  channels?: { email?: boolean; sms?: boolean };
+}
+
+// Backend's own public base URL, for the confirm/unsubscribe links emailed to
+// fans. Derived from the request so no extra Heroku env is needed; forces https
+// in production (behind the Heroku proxy req.protocol can read as http).
+function selfBaseUrl(req: Request): string {
+  const proto = process.env.NODE_ENV === 'production' ? /* istanbul ignore next */ 'https' : req.protocol;
+  return `${proto}://${req.get('host') ?? ''}`;
+}
+
+// Minimal branded HTML page returned when a fan clicks an email link, so it
+// works without the SPA.
+function page(title: string, body = ''): string {
+  const bodyStyle = 'font-family:system-ui,sans-serif;max-width:34rem;margin:4rem auto;padding:0 1rem;text-align:center;color:#222';
+  const para = body ? `<p style="color:#555">${body}</p>` : '';
+  const link = '<a href="https://www.joshandmariamusic.com" style="color:#1565c0">joshandmariamusic.com</a>';
+  return '<!doctype html><html><head><meta charset="utf-8">'
+    + '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    + `<title>${title}</title></head><body style="${bodyStyle}">`
+    + `<h1 style="font-size:1.5rem">${title}</h1>${para}`
+    + `<p style="margin-top:2rem">${link}</p>`
+    + '</body></html>';
+}
+
+function readToken(req: Request): string {
+  return typeof req.query.token === 'string' ? req.query.token : '';
+}
+
+class SubscriberController extends Controller {
+  resErr(res: Response, e: Error) { // eslint-disable-line class-methods-use-this
+    return res.status(500).json({ message: e.message });
+  }
+
+  // PUBLIC — fan opt-in from the website form. Creates/refreshes a `pending`
+  // record and emails a confirmation link (double opt-in). Already-active
+  // emails are a friendly no-op; previously-unsubscribed emails re-enter as
+  // pending.
+  async optIn(req: Request, res: Response): Promise<unknown> {
+    const body = (req.body || {}) as OptInBody;
+    const name = (body.name || '').trim();
+    const email = (body.email || '').trim().toLowerCase();
+    if (!name) return res.status(400).json({ message: 'Name is required' });
+    if (!EMAIL_RE.test(email)) return res.status(400).json({ message: 'A valid email is required' });
+
+    let existing: SubscriberDoc | null;
+    try { existing = await this.model.findOne({ email }) as unknown as SubscriberDoc | null; } catch (e) { return this.resErr(res, e as Error); }
+    if (existing && existing.status === 'active') {
+      return res.status(200).json({ message: 'You are already subscribed' });
+    }
+
+    const confirmToken = crypto.randomUUID();
+    const channels = { email: body.channels?.email !== false, sms: false };
+    try {
+      if (existing) {
+        await this.model.findByIdAndUpdate(existing._id, {
+          name, status: 'pending', confirmToken, channels,
+        });
+      } else {
+        await this.model.create({
+          name, email, channels, status: 'pending', confirmToken, unsubscribeToken: crypto.randomUUID(),
+        });
+      }
+    } catch (e) { return this.resErr(res, e as Error); }
+
+    const link = `${selfBaseUrl(req)}/subscriber/confirm?token=${confirmToken}`;
+    const html = `<p>Hi ${name},</p>`
+      + '<p>Please confirm you would like gig updates from Josh &amp; Maria Music:</p>'
+      + `<p><a href="${link}">Confirm my subscription</a></p>`
+      + '<p>If you did not request this, just ignore this email.</p>';
+    await sendMail({ to: email, subject: 'Confirm your Josh & Maria Music subscription', html });
+    return res.status(200).json({ message: 'Almost there — check your email to confirm your subscription' });
+  }
+
+  // PUBLIC — double opt-in confirmation link target. pending -> active.
+  async confirm(req: Request, res: Response): Promise<unknown> {
+    const token = readToken(req);
+    if (!token) return res.status(400).send(page('Invalid confirmation link'));
+    let doc: SubscriberDoc | null;
+    try {
+      doc = await this.model.findOne({ confirmToken: token }) as unknown as SubscriberDoc | null;
+    } catch (e) { return this.resErr(res, e as Error); }
+    if (!doc) return res.status(404).send(page('This confirmation link is no longer valid'));
+    try { await this.model.findByIdAndUpdate(doc._id, { status: 'active', confirmToken: '' }); } catch (e) { return this.resErr(res, e as Error); }
+    return res.status(200).send(page("You're subscribed!", 'Thanks for joining — we will let you know about upcoming gigs.'));
+  }
+
+  // PUBLIC — unsubscribe link target embedded in every send. -> unsubscribed.
+  async unsubscribe(req: Request, res: Response): Promise<unknown> {
+    const token = readToken(req);
+    if (!token) return res.status(400).send(page('Invalid unsubscribe link'));
+    let doc: SubscriberDoc | null;
+    try {
+      doc = await this.model.findOne({ unsubscribeToken: token }) as unknown as SubscriberDoc | null;
+    } catch (e) { return this.resErr(res, e as Error); }
+    if (!doc) return res.status(404).send(page('This unsubscribe link is no longer valid'));
+    try { await this.model.findByIdAndUpdate(doc._id, { status: 'unsubscribed' }); } catch (e) { return this.resErr(res, e as Error); }
+    return res.status(200).send(page("You've been unsubscribed", 'You will not receive any more gig emails from us. Sorry to see you go!'));
+  }
+
+  // ADMIN — manually add a subscriber (defaults to active/trusted; mints an
+  // unsubscribe token so admin-added people can still opt out).
+  async create(req: Request, res: Response): Promise<unknown> {
+    const body = (req.body || {}) as OptInBody & { _id?: string };
+    delete body._id;
+    const name = (body.name || '').trim();
+    const email = (body.email || '').trim().toLowerCase();
+    if (!name) return res.status(400).json({ message: 'Name is required' });
+    if (!EMAIL_RE.test(email)) return res.status(400).json({ message: 'A valid email is required' });
+    if (body.status && STATUS_OPTIONS.indexOf(body.status) === -1) return res.status(400).json({ message: 'status not valid' });
+    let doc;
+    try {
+      doc = await this.model.create({
+        name,
+        email,
+        phone: body.phone,
+        channels: { email: body.channels?.email !== false, sms: !!body.channels?.sms },
+        status: body.status || 'active',
+        unsubscribeToken: crypto.randomUUID(),
+      });
+    } catch (e) { return this.resErr(res, e as Error); }
+    return res.status(201).json(doc);
+  }
+
+  // ADMIN — edit a subscriber (status / channels / name / email).
+  findByIdAndUpdate(req: Request<{ id: string }>, res: Response): Response<unknown> | Promise<unknown> {
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Update id is invalid' });
+    }
+    const body = (req.body || {}) as OptInBody;
+    if (body.status && STATUS_OPTIONS.indexOf(body.status) === -1) return res.status(400).json({ message: 'status not valid' });
+    if (body.name === '') return res.status(400).json({ message: 'Name is required' });
+    if (body.email !== undefined) {
+      const email = String(body.email).trim().toLowerCase();
+      if (!EMAIL_RE.test(email)) return res.status(400).json({ message: 'A valid email is required' });
+      req.body.email = email;
+    }
+    return this.contFBIandU(req, res);
+  }
+}
+
+export default new SubscriberController(subscriberModel) as unknown as Icontroller;

--- a/src/model/subscriber/subscriber-facade.ts
+++ b/src/model/subscriber/subscriber-facade.ts
@@ -1,0 +1,6 @@
+import Model from '../../lib/facade.js';
+import subscriberSchema from './subscriber-schema.js';
+
+class SubscriberModel extends Model {}
+
+export default new SubscriberModel(subscriberSchema);

--- a/src/model/subscriber/subscriber-router.ts
+++ b/src/model/subscriber/subscriber-router.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import controller from './subscriber-controller.js';
+
+// PUBLIC subscriber routes — no auth. Opt-in form post + the confirm/unsubscribe
+// link targets fans click from their email.
+const router = express.Router();
+
+router.route('/')
+  .post((req, res, next) => { controller.optIn(req, res).catch(next); });
+
+router.route('/confirm')
+  .get((req, res, next) => { controller.confirm(req, res).catch(next); });
+
+router.route('/unsubscribe')
+  .get((req, res, next) => { controller.unsubscribe(req, res).catch(next); });
+
+export default router;

--- a/src/model/subscriber/subscriber-schema.ts
+++ b/src/model/subscriber/subscriber-schema.ts
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+// Fan distribution list for gig promotion (email now; SMS fields are present but
+// inert until the SMS sprint). `status` drives who a send reaches: only `active`
+// subscribers are emailed. Self-unsubscribe (token link) and admin removal both
+// land on `unsubscribed`.
+const subscriberSchema = new Schema({
+  name: { type: String, required: true },
+  email: {
+    type: String, required: true, unique: true, lowercase: true, trim: true,
+  },
+  phone: { type: Number, required: false },
+  channels: {
+    email: { type: Boolean, required: false, default: true },
+    sms: { type: Boolean, required: false, default: false },
+  },
+  status: {
+    type: String, required: false, enum: ['pending', 'active', 'unsubscribed'], default: 'pending',
+  },
+  // Single-use token emailed for double opt-in confirmation; cleared on confirm.
+  confirmToken: { type: String, required: false, default: '' },
+  // Stable per-subscriber token embedded in every send's unsubscribe link.
+  unsubscribeToken: { type: String, required: false, default: '' },
+  // Inert until SMS sprint; records TCPA opt-in consent.
+  consent: {
+    sms: {
+      agreed: { type: Boolean, required: false },
+      at: { type: Date, required: false },
+      ip: { type: String, required: false },
+    },
+  },
+  createdAt: { type: Date, required: false, default: Date.now },
+});
+
+export default mongoose.models.Subscriber || mongoose.model('Subscriber', subscriberSchema);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,8 @@ import book from './model/book/book-router.js';
 import inquiry from './model/inquiry/index.js';
 import livestream from './model/livestream/index.js';
 import song from './model/song/song-router.js';
+import subscriber from './model/subscriber/subscriber-router.js';
+import adminSubscriber from './model/subscriber/admin-subscriber-router.js';
 
 const router = express.Router();
 
@@ -16,4 +18,6 @@ export default function route(app: Express): void {
   router.use('/song', song);
   router.use('/inquiry', inquiry);
   router.use('/livestream', livestream);
+  router.use('/subscriber', subscriber);
+  router.use('/admin/subscriber', adminSubscriber);
 }

--- a/test/unit/subscriber/subscriber-controller.spec.ts
+++ b/test/unit/subscriber/subscriber-controller.spec.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import mongoose from 'mongoose';
+import controller from '../../../src/model/subscriber/subscriber-controller.js';
+import LibController from '../../../src/lib/controller.js';
+
+vi.mock('#src/lib/mailer.js', () => ({
+  sendMail: vi.fn(() => Promise.resolve()),
+  default: { sendMail: vi.fn(() => Promise.resolve()) },
+}));
+
+describe('Subscriber Controller', () => {
+  let status = 0;
+  let payload: any;
+  const resStub: any = {
+    status: (s: number) => {
+      status = s;
+      return {
+        json: (obj: any) => { payload = obj; return obj; },
+        send: (html: any) => { payload = html; return html; },
+      };
+    },
+  };
+  const lib = controller as unknown as LibController;
+  const reqBase = { get: () => 'localhost', protocol: 'http', query: {} };
+
+  beforeEach(() => {
+    status = 0;
+    payload = undefined;
+  });
+
+  describe('optIn (public)', () => {
+    it('rejects a missing name', async () => {
+      await (controller as any).optIn({ ...reqBase, body: { email: 'a@b.com' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('Name');
+    });
+
+    it('rejects an invalid email', async () => {
+      await (controller as any).optIn({ ...reqBase, body: { name: 'Fan', email: 'nope' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('valid email');
+    });
+
+    it('no-ops for an already-active subscriber', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve({ _id: 'x', status: 'active' })) as any;
+      await (controller as any).optIn({ ...reqBase, body: { name: 'Fan', email: 'a@b.com' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.message).toContain('already subscribed');
+    });
+
+    it('creates a pending subscriber for a new email', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve(null)) as any;
+      const create = vi.fn(() => Promise.resolve({ _id: 'new' }));
+      lib.model.create = create as any;
+      await (controller as any).optIn({ ...reqBase, body: { name: 'Fan', email: 'New@B.com' } }, resStub);
+      expect(create).toHaveBeenCalled();
+      const arg = (create.mock.calls[0] as unknown[])[0] as any;
+      expect(arg.email).toBe('new@b.com');
+      expect(arg.status).toBe('pending');
+      expect(arg.confirmToken).toBeTruthy();
+      expect(status).toBe(200);
+    });
+
+    it('reactivates a previously unsubscribed email as pending', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve({ _id: 'old', status: 'unsubscribed' })) as any;
+      const upd = vi.fn(() => Promise.resolve({ _id: 'old' }));
+      lib.model.findByIdAndUpdate = upd as any;
+      await (controller as any).optIn({ ...reqBase, body: { name: 'Fan', email: 'a@b.com' } }, resStub);
+      expect(upd).toHaveBeenCalledWith('old', expect.objectContaining({ status: 'pending' }));
+      expect(status).toBe(200);
+    });
+  });
+
+  describe('confirm (public)', () => {
+    it('rejects a missing token', async () => {
+      await (controller as any).confirm({ ...reqBase }, resStub);
+      expect(status).toBe(400);
+      expect(payload).toContain('Invalid confirmation');
+    });
+
+    it('404s an unknown token', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve(null)) as any;
+      await (controller as any).confirm({ ...reqBase, query: { token: 'zzz' } }, resStub);
+      expect(status).toBe(404);
+    });
+
+    it('activates on a valid token', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve({ _id: 'c1', status: 'pending' })) as any;
+      const upd = vi.fn(() => Promise.resolve({ _id: 'c1' }));
+      lib.model.findByIdAndUpdate = upd as any;
+      await (controller as any).confirm({ ...reqBase, query: { token: 'good' } }, resStub);
+      expect(upd).toHaveBeenCalledWith('c1', expect.objectContaining({ status: 'active' }));
+      expect(status).toBe(200);
+      expect(payload).toContain('subscribed');
+    });
+  });
+
+  describe('unsubscribe (public)', () => {
+    it('rejects a missing token', async () => {
+      await (controller as any).unsubscribe({ ...reqBase }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('marks a valid token unsubscribed', async () => {
+      lib.model.findOne = vi.fn(() => Promise.resolve({ _id: 'u1', status: 'active' })) as any;
+      const upd = vi.fn(() => Promise.resolve({ _id: 'u1' }));
+      lib.model.findByIdAndUpdate = upd as any;
+      await (controller as any).unsubscribe({ ...reqBase, query: { token: 'good' } }, resStub);
+      expect(upd).toHaveBeenCalledWith('u1', expect.objectContaining({ status: 'unsubscribed' }));
+      expect(status).toBe(200);
+      expect(payload).toContain('unsubscribed');
+    });
+  });
+
+  describe('create (admin)', () => {
+    it('rejects a missing name', async () => {
+      await controller.create({ body: { email: 'a@b.com' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('Name');
+    });
+
+    it('rejects an invalid email', async () => {
+      await controller.create({ body: { name: 'Fan', email: 'bad' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('valid email');
+    });
+
+    it('rejects an invalid status', async () => {
+      await controller.create({ body: { name: 'Fan', email: 'a@b.com', status: 'bogus' } } as any, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('status');
+    });
+
+    it('creates an active subscriber by default', async () => {
+      const create = vi.fn(() => Promise.resolve({ _id: 'a1', status: 'active' }));
+      lib.model.create = create as any;
+      await controller.create({ body: { name: 'Fan', email: 'a@b.com' } } as any, resStub);
+      const arg = (create.mock.calls[0] as unknown[])[0] as any;
+      expect(arg.status).toBe('active');
+      expect(arg.unsubscribeToken).toBeTruthy();
+      expect(status).toBe(201);
+    });
+  });
+
+  describe('findByIdAndUpdate (admin)', () => {
+    it('rejects an invalid id', async () => {
+      await (controller as any).findByIdAndUpdate({ params: { id: 'nope' }, body: {} }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('Update id');
+    });
+
+    it('rejects an invalid status', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await (controller as any).findByIdAndUpdate({ params: { id }, body: { status: 'bogus' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('status');
+    });
+
+    it('updates a valid record', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      lib.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({ _id: id, status: 'unsubscribed' })) as any;
+      await (controller as any).findByIdAndUpdate({ params: { id }, body: { status: 'unsubscribed' } }, resStub);
+      expect(status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## What & why
First step of the gig-promotion feature (Task 5). Establishes the **shared backend foundation** for the email channel: a DB-backed fan distribution list that all three promo clients — the JaMmusic admin UI, Claude, and gemma — will call. Replaces the static `ourFansEmailList.txt`.

This is **backend only**; the gig-blast send endpoint (Step 2) and the JaMmusic UI / opt-in form / Admin Subscribers page (Step 3) follow in their own PRs.

## Changes
- **`Subscriber` schema** — `name`, `email` (unique, lowercased), `phone`, `channels {email, sms}`, `status` (`pending` | `active` | `unsubscribed`), `confirmToken`, `unsubscribeToken`, inert SMS `consent` fields, `createdAt`. SMS fields exist but are unused until the SMS sprint.
- **Public routes (no auth):**
  - `POST /subscriber` — opt-in from the website form → creates a `pending` record and emails a **double opt-in** confirmation link.
  - `GET /subscriber/confirm?token=` — `pending` → `active`.
  - `GET /subscriber/unsubscribe?token=` — → `unsubscribed`. Embedded in every future send.
  - Confirm/unsubscribe return a minimal branded HTML page so the email links work without the SPA.
- **Admin routes** under `/admin/subscriber` — list / add / edit / delete. Gated by the existing `AUTH_ROLES.admin` (same key as `/admin/user`), so **no new Heroku env is needed**. Admin-added subscribers default to `active`.
- **`src/lib/mailer.ts`** — shared Gmail sender reusing `GMAIL_USER` / `GMAIL_APP_PASSWORD`; no-ops under `NODE_ENV=test`. The Step-2 gig blast will reuse it.
- Self-unsubscribe and admin removal both land on `unsubscribed`, so they're skipped on send uniformly.

## Tests
- 17 new controller unit tests (`test/unit/subscriber/subscriber-controller.spec.ts`).
- Full unit suite green (139 tests), `eslint ./src` clean, `tsc --noEmit` clean.

## How to Test Locally
```bash
git checkout feat-subscriber-list
npm install
npm test            # eslint + full vitest suite
npx tsc --noEmit    # type-check
```
Endpoints (need a running mongo + the app via `npm start`):
```bash
# opt-in (sends a real confirm email only when NODE_ENV!=test and Gmail creds are set)
curl -X POST localhost:8080/subscriber -H 'Content-Type: application/json' \
  -d '{"name":"Test Fan","email":"fan@example.com"}'
# admin list (needs an admin bearer token)
curl localhost:8080/admin/subscriber -H "Authorization: Bearer <admin-jwt>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)