### PR TITLE
feat(promo): POST /promo/gig/email — fan out a gig blast to the subscriber list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -13,6 +13,9 @@ export const CAPABILITIES = [
   'book:create',
   'book:edit',
   'book:delete',
+  // Gig-promotion channels (Task 5). Assignable to the web-jam-llm bot so
+  // Claude/gemma can trigger sends; humans pass via admin role fallback.
+  'promo:email',
 ] as const;
 
 export type Capability = (typeof CAPABILITIES)[number];

--- a/src/model/promo/promo-controller.ts
+++ b/src/model/promo/promo-controller.ts
@@ -1,0 +1,85 @@
+import { Request, Response } from 'express';
+import Debug from 'debug';
+import { sendMail } from '#src/lib/mailer.js';
+import { Icontroller } from '#src/lib/routeUtils.js';
+import subscriberModel from '../subscriber/subscriber-facade.js';
+import userModel from '../user/user-facade.js';
+
+// Shared gig-promotion send core. All three clients (admin UI, Claude, gemma)
+// POST finished content here; the backend fans it out to the subscriber list.
+const debug = Debug('web-jam-back:promo');
+
+// Role fallback for callers with no privileges array (e.g. the human admin who
+// passes on role today). Bots/agents pass via the promo:email capability.
+const ALLOWED_ROLES = ['JaM-admin', 'Developer'];
+const REQUIRED_CAPABILITY = 'promo:email';
+
+interface AuthedUser { userType?: string; privileges?: string[] }
+interface SubDoc { email: string; unsubscribeToken?: string }
+type AuthRequest = Request & { user?: string };
+
+// Backend's own public base URL for the per-recipient unsubscribe links.
+function selfBaseUrl(req: Request): string {
+  const proto = process.env.NODE_ENV === 'production' ? /* istanbul ignore next */ 'https' : req.protocol;
+  return `${proto}://${req.get('host') ?? ''}`;
+}
+
+function unsubscribeFooter(link: string): string {
+  return '<hr><p style="font-size:12px;color:#888">'
+    + 'You are receiving this because you subscribed to Josh &amp; Maria Music gig updates. '
+    + `<a href="${link}">Unsubscribe</a>.</p>`;
+}
+
+class PromoController {
+  // Privilege-first, role-fallback authorization. Returns an error to send, or
+  // null when the caller may send.
+  async authorize(req: AuthRequest): Promise<{ status: number; message: string } | null> { // eslint-disable-line class-methods-use-this
+    let user: AuthedUser | null;
+    try {
+      user = await userModel.findById(req.user || '') as unknown as AuthedUser | null;
+    } catch (e) { return { status: 500, message: (e as Error).message }; }
+    if (!user) return { status: 401, message: 'user not found' };
+    const privileges = user.privileges || [];
+    if (privileges.length) {
+      if (privileges.indexOf(REQUIRED_CAPABILITY) === -1) {
+        return { status: 403, message: `missing ${REQUIRED_CAPABILITY} capability` };
+      }
+      return null;
+    }
+    if (ALLOWED_ROLES.indexOf(user.userType || '') === -1) {
+      return { status: 403, message: 'not authorized to send promo email' };
+    }
+    return null;
+  }
+
+  // POST /promo/gig/email — body: { subject, bodyHtml }. Sends to every active
+  // email subscriber, appending their unsubscribe link. Sequential to stay
+  // within Gmail rate limits; per-recipient failures are counted, not fatal.
+  async sendGigEmail(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+
+    const { subject, bodyHtml } = (req.body || {}) as { subject?: string; bodyHtml?: string };
+    if (!subject || !bodyHtml) return res.status(400).json({ message: 'subject and bodyHtml are required' });
+
+    let subs: SubDoc[];
+    try {
+      subs = await subscriberModel.find({ status: 'active', 'channels.email': true }) as unknown as SubDoc[];
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+
+    const base = selfBaseUrl(req);
+    let sent = 0;
+    let failed = 0;
+    for (const s of subs) {
+      const link = `${base}/subscriber/unsubscribe?token=${s.unsubscribeToken ?? ''}`;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await sendMail({ to: s.email, subject, html: bodyHtml + unsubscribeFooter(link) });
+        sent += 1;
+      } catch (e) { debug('send failed for %s: %o', s.email, e); failed += 1; }
+    }
+    return res.status(200).json({ sent, failed, total: subs.length });
+  }
+}
+
+export default new PromoController() as unknown as Icontroller;

--- a/src/model/promo/promo-router.ts
+++ b/src/model/promo/promo-router.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+import controller from './promo-controller.js';
+import authUtils from '../../auth/authUtils.js';
+import routeUtils from '../../lib/routeUtils.js';
+
+// Gig-promotion send routes. makeAction runs ensureAuthenticated (populates
+// req.user from the token) before the controller's own capability/role check.
+const router = express.Router();
+
+router.route('/gig/email')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'sendGigEmail', controller, authUtils);
+    void action();
+  });
+
+export default router;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,6 +7,7 @@ import livestream from './model/livestream/index.js';
 import song from './model/song/song-router.js';
 import subscriber from './model/subscriber/subscriber-router.js';
 import adminSubscriber from './model/subscriber/admin-subscriber-router.js';
+import promo from './model/promo/promo-router.js';
 
 const router = express.Router();
 
@@ -20,4 +21,5 @@ export default function route(app: Express): void {
   router.use('/livestream', livestream);
   router.use('/subscriber', subscriber);
   router.use('/admin/subscriber', adminSubscriber);
+  router.use('/promo', promo);
 }

--- a/test/unit/promo/promo-controller.spec.ts
+++ b/test/unit/promo/promo-controller.spec.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import controller from '../../../src/model/promo/promo-controller.js';
+import userModel from '../../../src/model/user/user-facade.js';
+import subscriberModel from '../../../src/model/subscriber/subscriber-facade.js';
+
+vi.mock('#src/lib/mailer.js', () => ({
+  sendMail: vi.fn(() => Promise.resolve()),
+  default: { sendMail: vi.fn(() => Promise.resolve()) },
+}));
+
+describe('Promo Controller — sendGigEmail', () => {
+  let status = 0;
+  let payload: any;
+  const resStub: any = {
+    status: (s: number) => { status = s; return { json: (obj: any) => { payload = obj; return obj; } }; },
+  };
+  const makeReq = (overrides: any = {}) => ({
+    user: 'uid', get: () => 'localhost', protocol: 'http', body: { subject: 'Gig!', bodyHtml: '<p>come</p>' }, ...overrides,
+  });
+
+  beforeEach(() => { status = 0; payload = undefined; });
+
+  it('403s a caller whose privileges lack promo:email', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ privileges: ['gig:create'] })) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(403);
+    expect(payload.message).toContain('promo:email');
+  });
+
+  it('403s a roleless caller with no privileges', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'none', privileges: [] })) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(403);
+    expect(payload.message).toContain('not authorized');
+  });
+
+  it('401s when the user is not found', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve(null)) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(401);
+  });
+
+  it('allows a bot with the promo:email capability', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'web-jam-llm', privileges: ['promo:email'] })) as any;
+    subscriberModel.find = vi.fn(() => Promise.resolve([])) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(200);
+    expect(payload).toEqual({ sent: 0, failed: 0, total: 0 });
+  });
+
+  it('allows a JaM-admin via role fallback (no privileges)', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'JaM-admin', privileges: [] })) as any;
+    subscriberModel.find = vi.fn(() => Promise.resolve([])) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(200);
+  });
+
+  it('allows a Developer via role fallback', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'Developer' })) as any;
+    subscriberModel.find = vi.fn(() => Promise.resolve([])) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(200);
+  });
+
+  it('400s when subject or bodyHtml is missing', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'Developer' })) as any;
+    await (controller as any).sendGigEmail(makeReq({ body: { subject: 'x' } }), resStub);
+    expect(status).toBe(400);
+  });
+
+  it('sends to every active email subscriber and reports the count', async () => {
+    userModel.findById = vi.fn(() => Promise.resolve({ userType: 'Developer' })) as any;
+    subscriberModel.find = vi.fn(() => Promise.resolve([
+      { email: 'a@b.com', unsubscribeToken: 't1' },
+      { email: 'c@d.com', unsubscribeToken: 't2' },
+    ])) as any;
+    await (controller as any).sendGigEmail(makeReq(), resStub);
+    expect(status).toBe(200);
+    expect(payload).toEqual({ sent: 2, failed: 0, total: 2 });
+    expect((subscriberModel.find as any).mock.calls[0][0]).toEqual({ status: 'active', 'channels.email': true });
+  });
+});


### PR DESCRIPTION
## What & why
Step 2 of the gig-promotion feature (Task 5), building on the Step 1 subscriber list (#791). This is the **shared send core** that all three promo clients — the JaMmusic admin UI, Claude, and gemma — will call. Backend only; the JaMmusic UI (opt-in form, "Email fans" button, Admin Subscribers page) is Step 3.

## Changes
- **`promo:email` capability** added to the registry (`src/auth/capabilities.ts`), so it can be assigned to the `web-jam-llm` bot via the existing admin UI and is accepted by `validatePrivileges`.
- **`POST /promo/gig/email`** — body `{ subject, bodyHtml }`. Sends to every **active** email-channel subscriber, appending each recipient's **unsubscribe link**. Returns `{ sent, failed, total }`.
  - Sequential sends to respect Gmail rate limits; a per-recipient failure is counted, not fatal.
  - Content arrives in the **payload** (gig data lives in WebJamSocketCluster), so the backend stays decoupled and the frontend's preview-and-approve controls exactly what goes out.
  - Reuses the Step 1 `src/lib/mailer.ts`.
- **Authorization — privilege-first with role fallback:** a caller with a `privileges` array must hold `promo:email` (bot / Claude / gemma); a caller with no privileges falls back to the admin **role** check (`JaM-admin` or `Developer`), so the human admin keeps working with no change to their user record.

## Tests
- 8 new controller unit tests (`test/unit/promo/promo-controller.spec.ts`) covering the authz matrix (capability, role fallback, 401/403/400) and the send/count path.
- Full unit suite green (147), `eslint ./src` clean, `tsc --noEmit` clean.

## How to Test Locally
```bash
git checkout feat-promo-email-send
npm install
npm test            # eslint + full vitest suite
npx tsc --noEmit
```
With a running app + an admin/bot JWT:
```bash
curl -X POST localhost:8080/promo/gig/email \
  -H "Authorization: Bearer <admin-or-bot-jwt>" -H 'Content-Type: application/json' \
  -d '{"subject":"Josh & Maria this Saturday!","bodyHtml":"<p>Come see us at ...</p>"}'
# -> { "sent": N, "failed": 0, "total": N }
```
(Real emails send only when `NODE_ENV!=test` and Gmail creds are set.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)