### PR TITLE
fix(facebook): read page token from the page node, not /me/accounts

### DIFF
--- a/src/model/facebook/FacebookController.ts
+++ b/src/model/facebook/FacebookController.ts
@@ -168,12 +168,17 @@ async function exchangeForPageToken(userToken: string, pageId: string): Promise<
   const llBody = await llRes.json() as { access_token?: string; error?: GraphError };
   if (llBody.error || !llBody.access_token) throw new Error(llBody.error?.message || 'long-lived token exchange failed');
 
-  const accRes = await fetch(`${GRAPH}/me/accounts?access_token=${encodeURIComponent(llBody.access_token)}`);
-  const accBody = await accRes.json() as { data?: Array<{ id: string; access_token: string }>; error?: GraphError };
-  if (accBody.error) throw new Error(accBody.error.message || 'failed to list pages');
-  const page = (accBody.data || []).find((p) => p.id === pageId);
-  if (!page) throw new Error(`${getPages()[pageId] || pageId} page not found in /me/accounts`);
-  return page.access_token;
+  // Read the page token straight from the page node. We deliberately do NOT use
+  // /me/accounts: "New Pages Experience" pages (e.g. WebJamLLC) don't appear
+  // there even when the user is an admin, which 400'd the reconnect. The page
+  // node works for both classic and new pages and returns the same page token.
+  const name = getPages()[pageId] || pageId;
+  const pageRes = await fetch(`${GRAPH}/${pageId}?fields=access_token&access_token=${encodeURIComponent(llBody.access_token)}`);
+  const pageBody = await pageRes.json() as { access_token?: string; error?: GraphError };
+  if (pageBody.error || !pageBody.access_token) {
+    throw new Error(pageBody.error?.message || `${name} page token not available — are you an admin of this page?`);
+  }
+  return pageBody.access_token;
 }
 
 // Kick off the legacy-token migration, startup refresh, and hourly interval.

--- a/test/unit/facebook/index.spec.ts
+++ b/test/unit/facebook/index.spec.ts
@@ -80,7 +80,7 @@ describe('Facebook feed API', () => {
   it('PUT /facebook/token exchanges the token, stores it, and primes the cache', async () => {
     const fb = stubGraph(
       jsonRes({ access_token: 'long-lived-user-token' }), // fb_exchange_token
-      jsonRes({ data: [{ id: '202368653220334', access_token: 'PAGE-TOKEN' }] }), // /me/accounts
+      jsonRes({ access_token: 'PAGE-TOKEN' }), // GET /{pageId}?fields=access_token
       jsonRes({ data: [{ id: 'p1', message: 'Hello', permalink_url: 'https://fb/p1', created_time: '2026-06-01T00:00:00Z' }] }), // /posts
     );
     const r = await request(app)
@@ -100,10 +100,10 @@ describe('Facebook feed API', () => {
     expect(feed.body.posts[0].message).toBe('Hello');
   });
 
-  it('PUT /facebook/token returns 400 when the page is not in /me/accounts', async () => {
+  it('PUT /facebook/token returns 400 when the page token is not available', async () => {
     stubGraph(
       jsonRes({ access_token: 'long-lived-user-token' }),
-      jsonRes({ data: [{ id: 'some-other-page', access_token: 'nope' }] }),
+      jsonRes({ error: { code: 100, message: 'Unsupported get request' } }),
     );
     const r = await request(app)
       .put('/facebook/token')
@@ -111,7 +111,7 @@ describe('Facebook feed API', () => {
       .set('Authorization', `Bearer ${authUtils.createJWT({ _id: user._id })}`)
       .send({ userToken: 'short-lived' });
     expect(r.status).toBe(400);
-    expect(r.body.message).toMatch(/page not found/i);
+    expect(r.body.message).toMatch(/Unsupported get request/i);
   });
 
   it('PUT /facebook/token returns 400 on a failed token exchange', async () => {
@@ -184,7 +184,7 @@ describe('Facebook feed API', () => {
   it('serves a second page independently via ?pageId and stores its own token', async () => {
     const fb = stubGraph(
       jsonRes({ access_token: 'long-lived-user-token' }),
-      jsonRes({ data: [{ id: WJ, access_token: 'WJ-PAGE-TOKEN' }] }),
+      jsonRes({ access_token: 'WJ-PAGE-TOKEN' }),
       jsonRes({ data: [{ id: 'w1', message: 'WebJam post' }] }),
     );
     const r = await request(app)


### PR DESCRIPTION
## Root cause (confirmed live)

Seeding the WebJamLLC token kept failing with `Reconnect failed → page not found in /me/accounts`. Diagnosed with a real user token: **WebJamLLC is a "New Pages Experience" page and does not appear in `/me/accounts`** even though the user is an admin (only the classic CollegeLutheran page shows). But querying the page node directly returns a valid page token:

```
GET /365007513885497?fields=access_token  →  {"name":"Web Jam LLC","access_token":"EAA..."}
```

## Fix

`exchangeForPageToken` now reads the page token from **`GET /{pageId}?fields=access_token`** instead of scanning `/me/accounts`. Works for both classic and New-Pages-Experience pages and returns the same page token, so CollegeLutheran is unaffected.

## Tests
- Updated the facebook specs to stub the page-node call; all 16 pass. eslint clean.

Unblocks the WebJamLLC reconnect (JaMmusic#1110 / web-jam-back#799).

🤖 Generated with [Claude Code](https://claude.com/claude-code)