### PR TITLE
feat(auth): expire browser-login JWT after 24h (#829)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -47,12 +47,18 @@ const findUserById = async (req: AuthRequest): Promise<void> => {
   }
 };
 
+// Interactive browser logins expire after 24h (web-jam-back#829) — short enough
+// to limit a leaked/forgotten token, long enough to cover a working day. The 14-
+// day window was too long. AI-agent service tokens (createServiceJWT, no exp)
+// are a separate path and unaffected.
+const LOGIN_TOKEN_TTL_SECONDS = 24 * 60 * 60;
+
 const createJWT = (user: { _id: string }): string => {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const payload: JwtPayload = {
     sub: user._id,
     iat: nowSeconds,
-    exp: nowSeconds + 14 * 24 * 60 * 60,
+    exp: nowSeconds + LOGIN_TOKEN_TTL_SECONDS,
   };
   return jwt.encode(payload, process.env.HashString || /* istanbul ignore next */'');
 };

--- a/test/unit/authUtils.spec.ts
+++ b/test/unit/authUtils.spec.ts
@@ -19,6 +19,8 @@ describe('the authUtils', () => {
     expect(payload).toBeDefined();
     const decoded = jwt.decode(payload, config.hashString || '');
     expect(decoded.sub).toBe(user._id);
+    // Browser login expires 24h after issue (web-jam-back#829).
+    expect(decoded.exp - decoded.iat).toBe(24 * 60 * 60);
   });
   it('creates a service token without an exp claim', () => {
     const user = { _id: 'svc-id' };


### PR DESCRIPTION
Shortens the interactive browser-login token lifetime from **14 days → 24h** — the 14-day window was longer than needed for a small admin app.

## Change
- `authUtils.createJWT`: `exp` now `nowSeconds + LOGIN_TOKEN_TTL_SECONDS` (24h), via a named constant.
- **AI-agent service tokens unaffected** — `createServiceJWT` still mints no-`exp` tokens (e.g. `web-jam-llm`).

## Effect
Admins re-login ~once a day (no refresh-token flow — single access token by design; appropriate for this app's scale). Shrinks a leaked/forgotten-token window ~14×.

## Testing
- `authUtils.spec.ts`: asserts `exp - iat === 24h`; service-token no-`exp` test still passes.
- tsc + eslint clean.

Closes #829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)