### PR TITLE
fix(auth): register outreach:* capabilities + guard test (follow-up to #823)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -32,6 +32,14 @@ export const CAPABILITIES = [
   'template:create',
   'template:edit',
   'template:delete',
+  // Booking-outreach send + log management (web-jam-back#823). Granted to the
+  // shared web-jam-llm AI-agent identity so agents (and the JaMmusic admin UI)
+  // can run POST /outreach/send and CRUD the outreach log; humans pass via the
+  // admin role fallback. No `outreach:read` — same convention as venue/template:
+  // reads are gated by holding any outreach write capability (or the admin role).
+  'outreach:create',
+  'outreach:edit',
+  'outreach:delete',
 ] as const;
 
 export type Capability = (typeof CAPABILITIES)[number];

--- a/test/unit/auth/capabilities.spec.ts
+++ b/test/unit/auth/capabilities.spec.ts
@@ -1,4 +1,20 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
 import capabilities, { CAPABILITIES, isValidCapability, validatePrivileges } from '../../../src/auth/capabilities.js';
+
+// Recursively collect every *-controller.ts under src/.
+function controllerFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...controllerFiles(full));
+    else if (entry.name.endsWith('-controller.ts') || entry.name.endsWith('Controller.ts')) out.push(full);
+  }
+  return out;
+}
+
+// Quoted capability literals a controller gates on, e.g. 'outreach:create'.
+const CAP_LITERAL = /['"]([a-z][\w-]*:(?:create|edit|delete|email))['"]/g;
 
 describe('capabilities registry', () => {
   it('exposes the canonical list', () => {
@@ -6,6 +22,27 @@ describe('capabilities registry', () => {
     expect(CAPABILITIES).toContain('gig:create');
     expect(CAPABILITIES).toContain('song:create');
     expect(CAPABILITIES).toContain('book:delete');
+  });
+
+  it('includes the outreach:* caps (web-jam-back#823/#836)', () => {
+    for (const cap of ['outreach:create', 'outreach:edit', 'outreach:delete']) {
+      expect(isValidCapability(cap)).toBe(true);
+    }
+  });
+
+  // Guard against the #823 miss: a controller gating on a capability that was
+  // never registered grants nothing and silently vanishes from the Admin UI.
+  // Every capability literal referenced by a controller must be in the registry.
+  it('registers every capability a controller gates on', () => {
+    const registered = new Set<string>(CAPABILITIES);
+    const unregistered: { file: string; cap: string }[] = [];
+    for (const file of controllerFiles(path.resolve(process.cwd(), 'src'))) {
+      const src = readFileSync(file, 'utf8');
+      for (const match of src.matchAll(CAP_LITERAL)) {
+        if (!registered.has(match[1])) unregistered.push({ file: path.basename(file), cap: match[1] });
+      }
+    }
+    expect(unregistered).toEqual([]);
   });
 
   it('includes the new gig:* caps and keeps legacy tour:* valid during migration', () => {


### PR DESCRIPTION
## Summary
Registers the outreach:create/edit/delete capabilities in src/auth/capabilities.ts — #823 gated the outreach controller on them but never added them to the registry, so grants failed validation and the JaMmusic Admin UI couldn't offer them. Also adds a guard test that walks every *-controller.ts and asserts each capability literal it gates on is present in CAPABILITIES, so a future unregistered capability fails CI instead of silently vanishing from the Admin UI. Version bumped 2.0.25 -> 2.0.26.

Closes #836

## How to test locally
Run `npm test` (eslint ./src + vitest run --coverage with the 90% gate). Expected all green. Separately verified the new guard fails when a referenced cap is unregistered.

## Test evidence
npm test -> 240 passed (240) (was 238; +outreach:* registry test +controller-cap guard); All files 90.52% stmts | 82.57% branch | 84.97% func | 91.21% lines; coverage gate green; eslint ./src clean. Negative check: temporarily removing 'outreach:create' from CAPABILITIES made the guard test fail ('registers every capability a controller gates on'), then restored.

🤖 Work by Claude Code — Opus 4.8