### PR TITLE
feat(outreach): follow-up cadence engine (auto emails + Google Calendar call-tasks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/cadence.ts
+++ b/src/model/outreach/cadence.ts
@@ -1,0 +1,28 @@
+// Email follow-up cadence (web-jam-back#824). Day offsets from the original
+// pitch (`sentAt`) at which each EMAIL touch goes out. Index 0 is the pitch
+// itself (#823 sendPitch, step 1); follow-ups are day 3 (step 2) and day 12
+// (step 3). The research-informed CALL touches (days 7/18) are added with the
+// server-side Google Calendar work (#825) — this module is email-only.
+//
+// `step` counts touches already completed (1 = pitch sent). After the final
+// email touch we wait PARK_GRACE_DAYS, then park the outreach as `no-response`.
+export const EMAIL_TOUCH_DAYS = [0, 3, 12];
+export const PARK_GRACE_DAYS = 7;
+export const MAX_STEP = EMAIL_TOUCH_DAYS.length; // 3
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// When should the next action happen for an outreach whose last completed touch
+// is `step`? Returns the due Date, or null once everything (incl. the park
+// check) is behind us. While `step` is below the last touch it's the next
+// email's date; at the last touch it's the park-check date (last touch +
+// grace); beyond that it's null.
+export function nextTouchDueAfter(step: number, sentAt: Date): Date | null {
+  let days: number | null;
+  if (step < EMAIL_TOUCH_DAYS.length) days = EMAIL_TOUCH_DAYS[step];
+  else if (step === EMAIL_TOUCH_DAYS.length) days = EMAIL_TOUCH_DAYS[EMAIL_TOUCH_DAYS.length - 1] + PARK_GRACE_DAYS;
+  else days = null;
+  return days === null ? null : new Date(sentAt.getTime() + days * DAY_MS);
+}
+
+export default { EMAIL_TOUCH_DAYS, PARK_GRACE_DAYS, MAX_STEP, nextTouchDueAfter };

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -10,6 +10,7 @@ import outreachModel from './outreach-facade.js';
 import venueModel from '../venue/venue-facade.js';
 import templateModel from '../template/template-facade.js';
 import userModel from '../user/user-facade.js';
+import { MAX_STEP, nextTouchDueAfter } from './cadence.js';
 
 // Every gig pitch CCs Josh + Maria so they see each send land (mirrors the
 // InquiryController CC precedent). Maria's address is the same one inquiries CC.
@@ -43,6 +44,10 @@ interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
 
 interface VenueDoc { _id?: unknown; name?: string; email?: string; contactName?: string; venueType?: string; status?: string }
 interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
+interface FollowUp { sentAt?: Date; messageId?: string; step?: number }
+interface OutreachDoc {
+  _id?: unknown; venueId?: unknown; sentAt?: Date; step?: number; targetDates?: string; followUps?: FollowUp[];
+}
 
 const OUTREACH_STATUSES = ['sent', 'replied', 'declined', 'booked', 'no-response'];
 
@@ -108,6 +113,38 @@ function buildPitchEmail(venue: VenueDoc, template: TemplateDoc, body: SendBody)
   let html = personalize(template.bodyHtml || '', venue, body);
   const attachments = [];
   const assetPath = template.footerPhotoRef ? resolveFooterAsset(template.footerPhotoRef) : null;
+  /* istanbul ignore else */
+  if (assetPath) {
+    html += footerHtml();
+    attachments.push({ filename: 'josh-maria.jpg', path: assetPath, cid: 'footerphoto' });
+  }
+  return { subject, html, attachments };
+}
+
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+function fmtDate(d: Date): string { return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`; }
+
+// Build a cadence follow-up email (#824) for an outreach record: a short,
+// personalized nudge referencing the original pitch date + target window, with
+// the same inline-CID footer photo as the pitch.
+function buildFollowUpEmail(venue: VenueDoc, outreach: OutreachDoc): {
+  subject: string; html: string; attachments: { filename: string; path: string; cid: string }[];
+} {
+  const contact = venue.contactName || 'there';
+  const venueName = venue.name || 'your venue';
+  const dates = outreach.targetDates || 'an upcoming date';
+  const orig = outreach.sentAt ? fmtDate(new Date(outreach.sentAt)) : 'earlier this season';
+  const subject = `Following up — Josh & Maria at ${venueName}`;
+  let html = [
+    `<p>Hi ${contact},</p>`,
+    `<p>Just following up on my note from ${orig} about Josh &amp; Maria — my wife and I are a husband-wife `
+      + `acoustic duo here in Salem, VA. We'd still love to be considered for a slot at ${venueName} around ${dates}.</p>`,
+    "<p>Completely understand if the calendar's full; even a later window would be great. "
+      + 'Happy to send more live samples or work around your schedule.</p>',
+    '<p>Best,<br>Josh &amp; Maria<br>540-494-8035<br><a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>',
+  ].join('\n');
+  const attachments = [];
+  const assetPath = resolveFooterAsset('footer-josh-maria');
   /* istanbul ignore else */
   if (assetPath) {
     html += footerHtml();
@@ -238,17 +275,21 @@ class OutreachController extends Controller {
       });
     } catch (e) { return res.status(502).json({ message: `email send failed: ${(e as Error).message}` }); }
 
+    const sentAt = new Date();
     let record;
     try {
       record = await this.model.create({
         venueId: body.venueId,
         templateUsed: type,
         targetDates: body.targetDates,
-        sentAt: new Date(),
+        sentAt,
         status: 'sent',
         messageId: sent.messageId,
         sentBy: actor,
         lastModifiedBy: actor,
+        // Cadence (#824): the pitch is touch 1; schedule the first follow-up.
+        step: 1,
+        nextTouchDue: nextTouchDueAfter(1, sentAt),
       });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
 
@@ -259,6 +300,58 @@ class OutreachController extends Controller {
     } catch { /* best-effort: lastContacted is non-critical */ }
 
     return res.status(201).json(record);
+  }
+
+  // Send one due email follow-up for an outreach record and reschedule it, or
+  // park it as no-response once the sequence is exhausted. Returns the per-record
+  // outcome ('sent' | 'parked' | 'skipped'). Helper for advanceCadence.
+  async processDue(o: OutreachDoc): Promise<'sent' | 'parked' | 'skipped'> {
+    if ((o.step || 1) >= MAX_STEP) {
+      try {
+        await this.model.findByIdAndUpdate(String(o._id), { status: 'no-response', nextTouchDue: null, lastModifiedBy: 'cadence-engine' });
+        return 'parked';
+      } catch { return 'skipped'; }
+    }
+    let venue: VenueDoc | null;
+    try { venue = await venueModel.findById(String(o.venueId)) as unknown as VenueDoc | null; } catch { return 'skipped'; }
+    if (!venue || venue.status === 'archived' || !venue.email) return 'skipped';
+
+    const touchNum = (o.step || 1) + 1;
+    const { subject, html, attachments } = buildFollowUpEmail(venue, o);
+    let sent: { messageId: string };
+    try { sent = await sendMail({ to: venue.email, cc: PITCH_CC, subject, html, attachments }); } catch { return 'skipped'; }
+
+    const followUps = [...(o.followUps || []), { sentAt: new Date(), messageId: sent.messageId, step: touchNum }];
+    try {
+      await this.model.findByIdAndUpdate(String(o._id), {
+        step: touchNum,
+        nextTouchDue: nextTouchDueAfter(touchNum, new Date(o.sentAt || Date.now())),
+        followUps,
+        lastModifiedBy: 'cadence-engine',
+      });
+      return 'sent';
+    } catch { return 'skipped'; }
+  }
+
+  // POST /outreach/advance — cadence tick. Sends every email follow-up that's due
+  // (status 'sent', nextTouchDue <= now), reschedules it, and parks exhausted
+  // sequences as no-response. Meant to be hit on a schedule (Deno Cron, #100).
+  // Reply-detection + call touches arrive with the Google integration (#825); for
+  // now a venue reply is marked by hand via PUT /outreach/:id, which halts it.
+  async advanceCadence(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:edit']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    const now = new Date();
+    let due: OutreachDoc[];
+    try { due = await this.model.find({ status: 'sent', nextTouchDue: { $ne: null, $lte: now } }) as unknown as OutreachDoc[]; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    const result = { processed: due.length, sent: 0, parked: 0, skipped: 0 };
+    for (const o of due) {
+      const outcome = await this.processDue(o); // eslint-disable-line no-await-in-loop
+      result[outcome] += 1;
+    }
+    return res.status(200).json(result);
   }
 }
 

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -17,6 +17,14 @@ router.route('/send')
     void action();
   });
 
+// POST /outreach/advance — cadence engine tick (#824). Above /:id so "advance"
+// isn't parsed as an id. Driven on a schedule by the Deno Cron (#100).
+router.route('/advance')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'advanceCadence', controller, authUtils);
+    void action();
+  });
+
 router.route('/')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'listOutreach', controller, authUtils);

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -20,6 +20,7 @@ const options = {
 const followUpSchema = new Schema({
   sentAt: { type: Date, required: false },
   messageId: { type: String, required: false },
+  step: { type: Number, required: false },
 }, { _id: false });
 
 const outreachSchema = new Schema({
@@ -38,6 +39,13 @@ const outreachSchema = new Schema({
   // Which AI agent or human sent this pitch (#818 `actor` field).
   sentBy: { type: String, required: false, trim: true },
   followUps: { type: [followUpSchema], required: false, default: [] },
+  // Cadence engine (#824). `step` is the touch number already sent (1 = the
+  // pitch). `nextTouchDue` is when the next email follow-up should go out; the
+  // advance endpoint sends everything due and bumps these. Null nextTouchDue =
+  // no more touches scheduled (sequence finished or halted). Call touches
+  // (days 7/18) are added with the Google Calendar work (#825).
+  step: { type: Number, required: false, default: 1 },
+  nextTouchDue: { type: Date, required: false, default: null },
   lastModifiedBy: { type: String, required: false },
 }, options);
 

--- a/test/unit/outreach/cadence.spec.ts
+++ b/test/unit/outreach/cadence.spec.ts
@@ -1,0 +1,31 @@
+import {
+  EMAIL_TOUCH_DAYS, PARK_GRACE_DAYS, MAX_STEP, nextTouchDueAfter,
+} from '#src/model/outreach/cadence.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const base = new Date('2026-06-01T12:00:00.000Z');
+const daysAfter = (d: Date) => Math.round((d.getTime() - base.getTime()) / DAY);
+
+describe('cadence', () => {
+  it('defaults to the email-only 3-touch schedule', () => {
+    expect(EMAIL_TOUCH_DAYS).toEqual([0, 3, 12]);
+    expect(MAX_STEP).toBe(3);
+    expect(PARK_GRACE_DAYS).toBe(7);
+  });
+
+  it('schedules the next email touch after the pitch (step 1 -> day 3)', () => {
+    expect(daysAfter(nextTouchDueAfter(1, base) as Date)).toBe(3);
+  });
+
+  it('schedules the third touch after the second (step 2 -> day 12)', () => {
+    expect(daysAfter(nextTouchDueAfter(2, base) as Date)).toBe(12);
+  });
+
+  it('schedules a park-check after the final touch (step 3 -> last + grace = day 19)', () => {
+    expect(daysAfter(nextTouchDueAfter(3, base) as Date)).toBe(19);
+  });
+
+  it('returns null once the park check is past (step beyond the schedule)', () => {
+    expect(nextTouchDueAfter(4, base)).toBeNull();
+  });
+});

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -277,4 +277,80 @@ describe('Outreach Controller', () => {
       expect(payload).toHaveLength(1);
     });
   });
+
+  describe('sendPitch schedules the first follow-up', () => {
+    it('stamps step 1 + a nextTouchDue on the new record', async () => {
+      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(201);
+      const rec = (c.model.create as any).mock.calls[0][0];
+      expect(rec.step).toBe(1);
+      expect(rec.nextTouchDue).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('advanceCadence (#824)', () => {
+    const dueRecord = (over = {}) => ({
+      _id: 'o1', venueId: validVenue()._id, sentAt: new Date('2026-06-01T12:00:00Z'), step: 1, targetDates: 'Aug 14-16', followUps: [], ...over,
+    });
+
+    beforeEach(() => {
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
+    });
+
+    it('403s without the outreach:edit capability', async () => {
+      asAgent(['outreach:create']);
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('sends a due follow-up and reschedules the record', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toMatchObject({ processed: 1, sent: 1, parked: 0, skipped: 0 });
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
+      expect(upd.step).toBe(2);
+      expect(upd.nextTouchDue).toBeInstanceOf(Date);
+      expect(upd.followUps).toHaveLength(1);
+      expect(upd.followUps[0].step).toBe(2);
+    });
+
+    it('parks an exhausted sequence as no-response (no send)', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 3 })]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, parked: 1 });
+      expect(sendMail).not.toHaveBeenCalled();
+      const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
+      expect(upd.status).toBe('no-response');
+      expect(upd.nextTouchDue).toBeNull();
+    });
+
+    it('skips a record whose venue is archived or has no email', async () => {
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1, sent: 0 });
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('skips a record when its follow-up send fails', async () => {
+      sendMail.mockRejectedValueOnce(new Error('smtp down'));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1 });
+    });
+
+    it('500s when the due query throws', async () => {
+      c.model.find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('reports an empty tick when nothing is due', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 0, sent: 0, parked: 0, skipped: 0 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Email-only slice of the cadence engine (#824). The outreach record gains step + nextTouchDue; sendPitch stamps step 1 and schedules the first follow-up. cadence.ts defines the email schedule (days 0/3/12) and nextTouchDueAfter, parking a sequence as no-response PARK_GRACE_DAYS after the last touch. New POST /outreach/advance (gated outreach:edit) sends every due email follow-up, reschedules it, and parks exhausted sequences, returning a {processed,sent,parked,skipped} summary — intended to be driven on a schedule by the Deno Cron (#100). Call touches (days 7/18) and automatic reply-detection are deferred to the Google integration (#825); until then a venue reply is halted by hand via PUT /outreach/:id. Version 2.0.27 -> 2.0.28.

Part of #824

## How to test locally
Run `npm test` (eslint ./src + vitest run --coverage, 90/90/80/80 gate). Expected all green; new cadence.spec covers the schedule math and the advance/processDue tests cover send-due, park-exhausted, skip-archived, skip-on-send-failure, 500-on-query-error, and empty-tick.

## Test evidence
npm test -> 251 passed (251), exit 0. Coverage All files 90.51% stmts | 82.22% branch | 84.84% func | 91.19% lines -> clears the gate. eslint ./src clean, tsc -p tsconfig.prod.json clean. (One pre-existing flaky book-router test gave a transient 401 on one run; passed 12/12 on re-run and on the final full run — unrelated to this change.)

🤖 Work by Claude Code — Opus 4.8