### PR TITLE
feat(venue): proper venueType tagging so outreach selects targets by tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -38,6 +38,7 @@ interface VenueBody {
   phone?: string;
   website?: string;
   status?: string;
+  outreachEligible?: boolean;
   notes?: string;
   lastContacted?: string;
   actor?: string;
@@ -111,6 +112,10 @@ class VenueController extends Controller {
     if (typeof query.status === 'string') filter.status = query.status;
     else filter.status = { $ne: 'archived' };
     if (typeof query.venueType === 'string') filter.venueType = query.venueType;
+    // Outreach targeting (#843): ?outreachEligible=true returns only vetted
+    // venues — the pool #844's approval flow proposes from.
+    if (query.outreachEligible === 'true') filter.outreachEligible = true;
+    else if (query.outreachEligible === 'false') filter.outreachEligible = false;
     return filter;
   }
 

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -34,6 +34,12 @@ const venueSchema = new Schema({
   status: {
     type: String, required: false, enum: ['active', 'archived'], default: 'active',
   },
+  // Outreach targeting gate (#843/#844). A venue is only ever selected as an
+  // outreach target when it has been VETTED: `outreachEligible` true AND a
+  // `venueType` set. Defaults to FALSE so no venue can be auto-pitched until a
+  // human has explicitly tagged + enabled it ("approval required by default" at
+  // the venue level — never auto-select an unvetted venue).
+  outreachEligible: { type: Boolean, required: false, default: false },
   notes: { type: String, required: false },
   lastContacted: { type: Date, required: false },
   // The AI agent or human that last wrote this record (#818 `actor` field — one

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -190,5 +190,30 @@ describe('Venue Controller', () => {
       const f = (controller as any).constructor.buildListFilter({ status: 'archived', venueType: 'Originals' });
       expect(f).toEqual({ status: 'archived', venueType: 'Originals' });
     });
+
+    it('filters by outreachEligible (#843) — only vetted venues', () => {
+      const f = (controller as any).constructor.buildListFilter({ outreachEligible: 'true' });
+      expect(f).toMatchObject({ outreachEligible: true });
+      const g = (controller as any).constructor.buildListFilter({ outreachEligible: 'false' });
+      expect(g).toMatchObject({ outreachEligible: false });
+    });
+  });
+
+  describe('outreachEligible tagging (#843)', () => {
+    it('persists outreachEligible on create (passes through ...body)', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      const create = vi.fn(() => Promise.resolve({ _id: 'v9' }));
+      c.model.create = create;
+      await c.createVenue({ user: 'a', body: { name: 'The Spot', venueType: 'Originals', outreachEligible: true } }, resStub);
+      expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({ outreachEligible: true, venueType: 'Originals' });
+    });
+
+    it('lets a venue be tagged eligible via update', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateVenue({ user: 'a', params: { id }, body: { outreachEligible: true } }, resStub);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ outreachEligible: true }));
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds outreachEligible (Boolean, default FALSE) to the venue model so a venue can never be selected as an outreach target until a human has vetted it — set a venueType AND flipped outreachEligible on. Default-false means nothing is auto-pitchable; this is 'approval required by default' at the venue level (post-incident redesign, #844). GET /venue?outreachEligible=true returns only the vetted pool #844 will propose from; create/update persist the flag. Classifying the existing 77 venues is a human vetting step, intentionally NOT auto-applied. Version 2.0.28 -> 2.0.29.

Part of #843

## How to test locally
Run npm test (eslint ./src + vitest --coverage, 90/90/80/80 gate). New tests cover the buildListFilter outreachEligible branch and create/update persistence of the flag.

## Test evidence
npm test -> 254 passed, exit 0. Coverage 90.54 stmts / 82.45 branch / 84.84 func / 91.21 lines -> clears the gate. tsc -p tsconfig.prod.json clean, eslint ./src clean.

🤖 Work by Claude Code — Opus 4.8