### PR TITLE
feat(outreach): approval-gated sending — draft-first, no unapproved sends

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -40,6 +40,11 @@ export const CAPABILITIES = [
   'outreach:create',
   'outreach:edit',
   'outreach:delete',
+  // Approval gate (#844). `outreach:approve` is the ONLY capability that can
+  // actually send a pitch (approve a draft, or override the draft step). It is
+  // deliberately NOT granted to the web-jam-llm AI agent — agents may DRAFT but
+  // never send; only a human admin approves. Post-incident: no unapproved sends.
+  'outreach:approve',
 ] as const;
 
 export type Capability = (typeof CAPABILITIES)[number];

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -16,10 +16,11 @@ import { MAX_STEP, nextTouchDueAfter } from './cadence.js';
 // InquiryController CC precedent). Maria's address is the same one inquiries CC.
 const PITCH_CC = ['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com'];
 
-// An active campaign — a pitch already out for this venue + window — must not be
-// re-sent (no double-pitching). Declined / no-response / booked are terminal, so
-// only these two block a new send.
-const ACTIVE_STATUSES = ['sent', 'replied'];
+// An active campaign blocks a new pitch for the same venue + window (no
+// double-pitching). A pending `draft` counts too — you can't queue two drafts
+// for the same venue + dates. Declined / rejected / no-response / booked are
+// terminal and don't block.
+const ACTIVE_STATUSES = ['draft', 'sent', 'replied'];
 
 const ALLOWED_ROLES = ['JaM-admin', 'Developer'];
 const OUTREACH_WRITE_CAPS = ['outreach:create', 'outreach:edit', 'outreach:delete'];
@@ -38,6 +39,9 @@ interface SendBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
+  // #844: a caller holding outreach:approve may set this to send immediately,
+  // skipping the draft step (the only sanctioned bypass).
+  override?: boolean;
 }
 
 interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
@@ -47,9 +51,10 @@ interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; foot
 interface FollowUp { sentAt?: Date; messageId?: string; step?: number }
 interface OutreachDoc {
   _id?: unknown; venueId?: unknown; sentAt?: Date; step?: number; targetDates?: string; followUps?: FollowUp[];
+  status?: string; templateUsed?: string; bookingPeriod?: string;
 }
 
-const OUTREACH_STATUSES = ['sent', 'replied', 'declined', 'booked', 'no-response'];
+const OUTREACH_STATUSES = ['draft', 'rejected', 'sent', 'replied', 'declined', 'booked', 'no-response'];
 
 // An explicit `actor` (stamped by the MCP server / agent) wins; otherwise fall
 // back to the authenticated token subject.
@@ -220,7 +225,10 @@ class OutreachController extends Controller {
   // Load + validate the venue and template for a send and run the dedup guard.
   // Returns a ready context, or an error envelope for sendPitch to relay. Pulls
   // the bulk of the branching out of sendPitch.
-  async resolvePitch(body: SendBody): Promise<PitchContext> {
+  // `skipDedup` is set when re-resolving an EXISTING draft (approve/preview) —
+  // there the draft itself is the "active" outreach, so the dedup check would
+  // wrongly match it. Only a brand-new draft runs the dedup guard.
+  async resolvePitch(body: SendBody, skipDedup = false): Promise<PitchContext> {
     let venue: VenueDoc | null;
     try { venue = await venueModel.findById(body.venueId || '') as unknown as VenueDoc | null; } catch (e) {
       return { error: { status: 500, message: (e as Error).message } };
@@ -238,19 +246,57 @@ class OutreachController extends Controller {
     }
     if (!template) return { error: { status: 400, message: `no active template for type ${type}` } };
 
-    // Dedup guard — refuse if a pitch is already live for this venue + window.
-    let dupe;
-    try {
-      dupe = await this.model.findOne({ venueId: body.venueId, targetDates: body.targetDates, status: { $in: ACTIVE_STATUSES } });
-    } catch (e) { return { error: { status: 500, message: (e as Error).message } }; }
-    if (dupe) {
-      return { error: { status: 409, message: 'an active outreach already exists for this venue and target dates', outreach: dupe } };
+    if (!skipDedup) {
+      // Dedup guard — refuse if a draft/live pitch already exists for this venue + window.
+      let dupe;
+      try {
+        dupe = await this.model.findOne({ venueId: body.venueId, targetDates: body.targetDates, status: { $in: ACTIVE_STATUSES } });
+      } catch (e) { return { error: { status: 500, message: (e as Error).message } }; }
+      if (dupe) {
+        return { error: { status: 409, message: 'an active outreach already exists for this venue and target dates', outreach: dupe } };
+      }
     }
     return { venue, template, type };
   }
 
-  // POST /outreach/send — render a template for a venue, email the pitch
-  // (CC Josh + Maria, footer photo inline), and write the outreach record.
+  // The single place an email actually leaves: render + send + write/update the
+  // outreach record as `sent` with cadence touch 1. Used ONLY by the approval
+  // path and the explicit override path (#844). `existingId` set => update that
+  // draft; null => create a fresh sent record (override). Returns the Express res.
+  async finalizeSend(
+    res: Response, venue: VenueDoc, template: TemplateDoc, type: string, body: SendBody, actor: string, existingId: string | null,
+  ): Promise<unknown> {
+    const { subject, html, attachments } = buildPitchEmail(venue, template, body);
+    let sent: { messageId: string };
+    try {
+      sent = await sendMail({ to: venue.email || '', cc: body.cc || PITCH_CC, subject, html, attachments });
+    } catch (e) { return res.status(502).json({ message: `email send failed: ${(e as Error).message}` }); }
+
+    const sentAt = new Date();
+    const fields = {
+      templateUsed: type, targetDates: body.targetDates, bookingPeriod: body.bookingPeriod,
+      sentAt, status: 'sent', messageId: sent.messageId, sentBy: actor, lastModifiedBy: actor,
+      step: 1, nextTouchDue: nextTouchDueAfter(1, sentAt),
+    };
+    let record;
+    try {
+      record = existingId
+        ? await this.model.findByIdAndUpdate(existingId, fields)
+        : await this.model.create({ venueId: String(venue._id), ...fields });
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+
+    // Best-effort: stamp the venue's lastContacted (non-critical, swallow errors).
+    try {
+      await venueModel.findByIdAndUpdate(String(venue._id), { lastContacted: new Date(), lastModifiedBy: actor });
+    } catch { /* best-effort */ }
+    return res.status(existingId ? 200 : 201).json(record);
+  }
+
+  // POST /outreach/send — DRAFT-FIRST (#844, post-incident). By default this does
+  // NOT email anyone: it resolves the venue/template and writes a `draft` outreach
+  // record awaiting human approval. An email only goes out later via
+  // /outreach/:id/approve. The one bypass: a caller holding `outreach:approve`
+  // may pass `override: true` to send immediately (the explicit-override case).
   async sendPitch(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, ['outreach:create']);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -265,41 +311,75 @@ class OutreachController extends Controller {
     const ctx = await this.resolvePitch(body);
     if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message, outreach: ctx.error.outreach });
     const { venue, template, type } = ctx as Required<PitchContext>;
-
-    const { subject, html, attachments } = buildPitchEmail(venue, template, body);
     const actor = resolveActor(req, body);
-    let sent: { messageId: string };
-    try {
-      sent = await sendMail({
-        to: venue.email || '', cc: body.cc || PITCH_CC, subject, html, attachments,
-      });
-    } catch (e) { return res.status(502).json({ message: `email send failed: ${(e as Error).message}` }); }
 
-    const sentAt = new Date();
-    let record;
+    if (body.override === true) {
+      const approveErr = await this.authorize(req, ['outreach:approve']);
+      if (approveErr) return res.status(403).json({ message: 'override requires the outreach:approve capability' });
+      return this.finalizeSend(res, venue, template, type, body, actor, null);
+    }
+
+    let draft;
     try {
-      record = await this.model.create({
-        venueId: body.venueId,
-        templateUsed: type,
-        targetDates: body.targetDates,
-        sentAt,
-        status: 'sent',
-        messageId: sent.messageId,
-        sentBy: actor,
-        lastModifiedBy: actor,
-        // Cadence (#824): the pitch is touch 1; schedule the first follow-up.
-        step: 1,
-        nextTouchDue: nextTouchDueAfter(1, sentAt),
+      draft = await this.model.create({
+        venueId: body.venueId, templateUsed: type, targetDates: body.targetDates,
+        bookingPeriod: body.bookingPeriod, status: 'draft', sentBy: actor, lastModifiedBy: actor,
       });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    return res.status(201).json({ message: 'draft created — requires approval before it sends', outreach: draft });
+  }
 
-    // Best-effort: stamp the venue's lastContacted so the UI/cadence can sort by
-    // it. A failure here must not undo a successful send, so it is swallowed.
-    try {
-      await venueModel.findByIdAndUpdate(String(body.venueId), { lastContacted: new Date(), lastModifiedBy: actor });
-    } catch { /* best-effort: lastContacted is non-critical */ }
+  // POST /outreach/:id/approve — the ONLY normal path that sends. Requires
+  // `outreach:approve` (a human admin; the AI agent does NOT hold it). Renders +
+  // sends the reviewed draft's email and flips it to `sent`.
+  async approveOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:approve']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Approve id is invalid' });
+    let rec: OutreachDoc | null;
+    try { rec = await this.model.findById(req.params.id) as unknown as OutreachDoc | null; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!rec) return res.status(400).json({ message: 'outreach not found' });
+    if (rec.status !== 'draft') return res.status(400).json({ message: `only a draft can be approved (status is ${rec.status})` });
 
-    return res.status(201).json(record);
+    const ctx = await this.resolvePitch({ venueId: String(rec.venueId), templateType: rec.templateUsed, targetDates: rec.targetDates }, true);
+    if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
+    const { venue, template, type } = ctx as Required<PitchContext>;
+    const body = { targetDates: rec.targetDates, bookingPeriod: rec.bookingPeriod } as SendBody;
+    return this.finalizeSend(res, venue, template, type, body, resolveActor(req, (req.body || {}) as SendBody), req.params.id);
+  }
+
+  // POST /outreach/:id/reject — a human declines a draft (requires outreach:approve).
+  async rejectOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:approve']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Reject id is invalid' });
+    const update = { status: 'rejected', lastModifiedBy: resolveActor(req, (req.body || {}) as SendBody) };
+    let doc;
+    try { doc = await this.model.findByIdAndUpdate(req.params.id, update); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!doc) return res.status(400).json({ message: 'outreach not found' });
+    return res.status(200).json(doc);
+  }
+
+  // GET /outreach/:id/preview — render the exact email a draft would send, WITHOUT
+  // sending. Lets the approval UI (#1133) show Josh the real copy before he approves.
+  async previewOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, OUTREACH_WRITE_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Preview id is invalid' });
+    let rec: OutreachDoc | null;
+    try { rec = await this.model.findById(req.params.id) as unknown as OutreachDoc | null; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!rec) return res.status(400).json({ message: 'outreach not found' });
+    const ctx = await this.resolvePitch({ venueId: String(rec.venueId), templateType: rec.templateUsed, targetDates: rec.targetDates }, true);
+    if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
+    const { venue, template } = ctx as Required<PitchContext>;
+    const { subject, html } = buildPitchEmail(venue, template, { targetDates: rec.targetDates, bookingPeriod: rec.bookingPeriod } as SendBody);
+    return res.status(200).json({ to: venue.email, cc: PITCH_CC, subject, html });
   }
 
   // Send one due email follow-up for an outreach record and reschedule it, or

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -31,6 +31,27 @@ router.route('/')
     void action();
   });
 
+// Approval gate (#844): approve = the only normal path that sends; reject =
+// decline a draft; preview = render the exact copy without sending (for the
+// approval UI). Above /:id so the action segments aren't parsed as ids.
+router.route('/:id/approve')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'approveOutreach', controller, authUtils);
+    void action();
+  });
+
+router.route('/:id/reject')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'rejectOutreach', controller, authUtils);
+    void action();
+  });
+
+router.route('/:id/preview')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'previewOutreach', controller, authUtils);
+    void action();
+  });
+
 router.route('/:id')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'getOutreach', controller, authUtils);

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -27,12 +27,18 @@ const outreachSchema = new Schema({
   venueId: { type: Schema.Types.ObjectId, ref: 'Venue', required: true },
   templateUsed: { type: String, required: false, trim: true },
   targetDates: { type: String, required: false, trim: true },
+  // Stored so an approved draft re-renders the EXACT copy that was reviewed
+  // (#844) — same template + venue + targetDates + bookingPeriod => same email.
+  bookingPeriod: { type: String, required: false, trim: true },
   sentAt: { type: Date, required: false, default: Date.now },
+  // `draft` = proposed, awaiting human approval — NOTHING has been emailed yet
+  // (#844). `rejected` = a human declined the draft. Only an approval moves a
+  // draft to `sent` (the point at which the email actually goes out).
   status: {
     type: String,
     required: false,
-    enum: ['sent', 'replied', 'declined', 'booked', 'no-response'],
-    default: 'sent',
+    enum: ['draft', 'rejected', 'sent', 'replied', 'declined', 'booked', 'no-response'],
+    default: 'draft',
   },
   messageId: { type: String, required: false, trim: true },
   gmailThreadId: { type: String, required: false, trim: true },

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -130,64 +130,194 @@ describe('Outreach Controller', () => {
     });
   });
 
-  describe('sendPitch dedup guard', () => {
-    it('409s when an active outreach already exists for the venue + window', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'existing', status: 'sent' }));
+  describe('sendPitch — draft-first (#844)', () => {
+    it('creates a DRAFT and sends NOTHING by default', async () => {
+      await c.sendPitch({
+        user: 'opus', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', actor: 'opus' },
+      }, resStub);
+      expect(status).toBe(201);
+      expect(sendMail).not.toHaveBeenCalled();
+      const rec = (c.model.create as any).mock.calls[0][0];
+      expect(rec.status).toBe('draft');
+      expect(rec.templateUsed).toBe('Originals');
+      expect(rec.messageId).toBeUndefined();
+      expect(payload.message).toMatch(/approval/i);
+    });
+
+    it('dedup-guards against an existing draft/live pitch (409), incl. drafts', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'existing', status: 'draft' }));
       await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(409);
       expect(sendMail).not.toHaveBeenCalled();
-      const filter = (c.model.findOne as any).mock.calls[0][0];
-      expect(filter.status).toEqual({ $in: ['sent', 'replied'] });
-    });
-  });
-
-  describe('sendPitch success', () => {
-    it('personalizes, CCs Josh + Maria, attaches the footer, and writes the record', async () => {
-      const venueId = validVenue()._id;
-      await c.sendPitch({
-        user: 'opus', body: { venueId, targetDates: 'Fri Aug 14 – Sun Aug 16', bookingPeriod: 'late-summer', actor: 'opus' },
-      }, resStub);
-
-      expect(status).toBe(201);
-      const mail = sendMail.mock.calls[0][0] as any;
-      expect(mail.to).toBe('booking@spotonkirk.com');
-      expect(mail.cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
-      expect(mail.subject).toBe('Performance Inquiry for The Spot on Kirk');
-      expect(mail.html).toContain('Hi Pat,');
-      expect(mail.html).toContain('late-summer');
-      expect(mail.html).toContain('Fri Aug 14 – Sun Aug 16');
-      expect(mail.html).not.toContain('[');
-      expect(mail.html).toContain('cid:footerphoto');
-      expect(mail.attachments[0].cid).toBe('footerphoto');
-
-      const rec = (c.model.create as any).mock.calls[0][0];
-      expect(rec.venueId).toBe(venueId);
-      expect(rec.templateUsed).toBe('Originals');
-      expect(rec.status).toBe('sent');
-      expect(rec.messageId).toBe('mid-123');
-      expect(rec.sentBy).toBe('opus');
-      expect((venueModel as any).findByIdAndUpdate).toHaveBeenCalled();
+      expect((c.model.findOne as any).mock.calls[0][0].status).toEqual({ $in: ['draft', 'sent', 'replied'] });
     });
 
-    it('honors an explicit templateType over the venue type', async () => {
+    it('honors an explicit templateType (still a draft)', async () => {
       const findOne = vi.fn(() => Promise.resolve(validTemplate({ type: 'MidRangeCafeBar' })));
       (templateModel as any).findOne = findOne;
       await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', templateType: 'MidRangeCafeBar' } }, resStub);
       expect(status).toBe(201);
       expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar', active: true });
+      expect(sendMail).not.toHaveBeenCalled();
     });
 
-    it('502s and writes no record when the send fails', async () => {
-      sendMail.mockRejectedValueOnce(new Error('smtp down'));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
-      expect(status).toBe(502);
-      expect(c.model.create).not.toHaveBeenCalled();
+    it('refuses override without outreach:approve (403, no send)', async () => {
+      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
+      expect(status).toBe(403);
+      expect(sendMail).not.toHaveBeenCalled();
     });
 
-    it('succeeds even when the lastContacted stamp fails (best-effort)', async () => {
-      (venueModel as any).findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('write conflict')));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+    it('override + outreach:approve sends immediately as a sent record', async () => {
+      asAgent(['outreach:create', 'outreach:approve']);
+      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
       expect(status).toBe(201);
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      const rec = (c.model.create as any).mock.calls[0][0];
+      expect(rec.status).toBe('sent');
+      expect(rec.step).toBe(1);
+    });
+  });
+
+  describe('approveOutreach (#844) — the only normal send path', () => {
+    const draft = (over = {}) => ({
+      _id: 'd1', venueId: validVenue()._id, templateUsed: 'Originals', targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', status: 'draft', ...over,
+    });
+    beforeEach(() => { c.model.findByIdAndUpdate = vi.fn((id: string, f: any) => Promise.resolve({ _id: id, ...f })); });
+
+    it('403s without outreach:approve — the agent cannot approve', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.approveOutreach({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(403);
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('renders + sends + flips draft to sent + schedules cadence', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(draft()));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(200);
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      expect((sendMail.mock.calls[0][0] as any).cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
+      const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
+      expect(upd.status).toBe('sent');
+      expect(upd.messageId).toBe('mid-123');
+      expect(upd.step).toBe(1);
+      expect(upd.nextTouchDue).toBeInstanceOf(Date);
+    });
+
+    it('400s when the record is not a draft', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(draft({ status: 'sent' })));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(400);
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('400s when the draft is not found', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(null));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('502s when the approved send fails', async () => {
+      asAgent(['outreach:approve']);
+      sendMail.mockRejectedValueOnce(new Error('smtp'));
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(draft()));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(502);
+    });
+
+    it('400s on an invalid id', async () => {
+      asAgent(['outreach:approve']);
+      await c.approveOutreach({ user: 'josh', params: { id: 'bad' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('500s when the lookup throws', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('relays a resolve error if the venue went archived since drafting', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(draft()));
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
+      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(400);
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('override create-record path still stamps cadence (finalizeSend create branch)', async () => {
+      asAgent(['outreach:create', 'outreach:approve']);
+      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
+      const rec = (c.model.create as any).mock.calls[0][0];
+      expect(rec.nextTouchDue).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('rejectOutreach + previewOutreach (#844)', () => {
+    it('reject 403s without outreach:approve', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.rejectOutreach({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('reject marks a draft rejected', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id, status: 'rejected' }));
+      c.model.findByIdAndUpdate = upd;
+      await c.rejectOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(200);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ status: 'rejected' }));
+    });
+
+    it('preview renders the exact email without sending', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({
+        _id: id, venueId: validVenue()._id, templateUsed: 'Originals', targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', status: 'draft',
+      }));
+      await c.previewOutreach({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(200);
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(payload.subject).toContain('The Spot on Kirk');
+      expect(payload.html).toContain('Hi Pat,');
+      expect(payload.cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
+    });
+
+    it('reject 400s on an invalid id', async () => {
+      asAgent(['outreach:approve']);
+      await c.rejectOutreach({ user: 'josh', params: { id: 'bad' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('reject 400s when not found', async () => {
+      asAgent(['outreach:approve']);
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve(null));
+      await c.rejectOutreach({ user: 'josh', params: { id } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('preview 400s on an invalid id', async () => {
+      await c.previewOutreach({ user: 'a', params: { id: 'bad' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('preview 400s when the draft is not found', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(null));
+      await c.previewOutreach({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(400);
     });
   });
 
@@ -278,15 +408,8 @@ describe('Outreach Controller', () => {
     });
   });
 
-  describe('sendPitch schedules the first follow-up', () => {
-    it('stamps step 1 + a nextTouchDue on the new record', async () => {
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
-      expect(status).toBe(201);
-      const rec = (c.model.create as any).mock.calls[0][0];
-      expect(rec.step).toBe(1);
-      expect(rec.nextTouchDue).toBeInstanceOf(Date);
-    });
-  });
+  // (Cadence touch 1 / nextTouchDue is stamped at APPROVAL now, not at draft —
+  // asserted in the approveOutreach block above.)
 
   describe('advanceCadence (#824)', () => {
     const dueRecord = (over = {}) => ({


### PR DESCRIPTION
## Summary
Post-incident approval gate. POST /outreach/send no longer emails — by default it writes a DRAFT outreach record awaiting human approval; nothing sends until approved. New outreach:approve capability is the only thing that can send and is NOT granted to the web-jam-llm agent (agents draft, humans approve; admins pass via role fallback). Adds POST /outreach/:id/approve (the only normal send path: render+email+draft->sent+schedule cadence), /reject, and GET /:id/preview (render exact copy without sending, for the approval UI #1133). Explicit override: a holder of outreach:approve may pass override:true to send immediately. Status gains draft/rejected; dedup also blocks duplicate drafts; drafts re-render identically at approval. Version 2.0.29 -> 2.0.30.

Part of #844

## How to test locally
npm test (eslint ./src + vitest --coverage, 90/90/80/80 gate). New tests cover draft-default (no send), dedup incl drafts, override-requires-approve, approve (send + cadence + 400/500/502 paths + archived-since-draft), reject, preview, and the capability guard requiring outreach:approve be registered.

## Test evidence
npm test -> 269 passed, exit 0. Coverage 90.17 stmts / 83.2 branch / 83.9 func / 90.78 lines -> clears the gate. tsc -p tsconfig.prod.json clean, eslint ./src clean. capabilities guard passes with outreach:approve registered (NOT granted to web-jam-llm).

🤖 Work by Claude Code — Opus 4.8