### PR TITLE
feat(venue): proper venueType tagging so outreach selects targets by tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -9,6 +9,7 @@ import gigModel from '../gig/gig-facade.js';
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s.@]+$/;
 const VENUE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'];
 const STATUS_OPTIONS = ['active', 'archived'];
+const BOOKING_STATUSES = ['booking', 'not-booking', 'booked'];
 
 // Role fallback for human admins who authorize by role (no privileges array).
 // AI agents pass via the venue:* capabilities on the shared web-jam-llm identity.
@@ -39,6 +40,12 @@ interface VenueBody {
   website?: string;
   status?: string;
   outreachEligible?: boolean;
+  inScope?: boolean;
+  bookingStatus?: string;
+  interested?: boolean;
+  payTier?: string;
+  lastVerified?: string;
+  contactVerified?: boolean;
   notes?: string;
   lastContacted?: string;
   actor?: string;
@@ -71,6 +78,7 @@ function validateBody(body: VenueBody, partial: boolean): string {
   }
   if (body.venueType !== undefined && VENUE_TYPES.indexOf(body.venueType) === -1) return 'venueType not valid';
   if (body.status !== undefined && STATUS_OPTIONS.indexOf(body.status) === -1) return 'status not valid';
+  if (body.bookingStatus !== undefined && BOOKING_STATUSES.indexOf(body.bookingStatus) === -1) return 'bookingStatus not valid';
   if (body.email !== undefined && body.email !== '' && !EMAIL_RE.test(String(body.email).trim().toLowerCase())) {
     return 'A valid email is required';
   }
@@ -113,9 +121,15 @@ class VenueController extends Controller {
     else filter.status = { $ne: 'archived' };
     if (typeof query.venueType === 'string') filter.venueType = query.venueType;
     // Outreach targeting (#843): ?outreachEligible=true returns only vetted
-    // venues — the pool #844's approval flow proposes from.
+    // venues — the pool #844's approval flow proposes from. The vetting tags
+    // below filter the candidate set further (in-scope, still booking, interested).
     if (query.outreachEligible === 'true') filter.outreachEligible = true;
     else if (query.outreachEligible === 'false') filter.outreachEligible = false;
+    if (query.inScope === 'true') filter.inScope = true;
+    else if (query.inScope === 'false') filter.inScope = false;
+    if (typeof query.bookingStatus === 'string') filter.bookingStatus = query.bookingStatus;
+    if (query.interested === 'true') filter.interested = true;
+    else if (query.interested === 'false') filter.interested = false;
     return filter;
   }
 

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -40,6 +40,25 @@ const venueSchema = new Schema({
   // human has explicitly tagged + enabled it ("approval required by default" at
   // the venue level — never auto-select an unvetted venue).
   outreachEligible: { type: Boolean, required: false, default: false },
+  // Vetting/disqualification tags (#843) — the data a human uses to decide
+  // outreachEligible, and that the selection logic (#844) checks. Derived from
+  // the criteria review of the 5 mis-sent venues:
+  // - inScope: is this a gig-booking venue at all? false = anthem/other (Salem
+  //   Red Sox, ODAC Tournament) — never a target.
+  // - bookingStatus: `booking` = open to booking; `not-booking` = closed / new
+  //   management that stopped (Radford); `booked` = currently full (Olde Salem).
+  // - interested: false = not worth pursuing (pay too low / declined — Harrisonburg).
+  // - payTier: free-text pay note. lastVerified: when the info was last checked
+  //   (stale venues get re-verified). contactVerified: is the contact confirmed
+  //   correct (Olde Salem went to the wrong person).
+  inScope: { type: Boolean, required: false, default: true },
+  bookingStatus: {
+    type: String, required: false, enum: ['booking', 'not-booking', 'booked'], default: 'booking',
+  },
+  interested: { type: Boolean, required: false, default: true },
+  payTier: { type: String, required: false, trim: true },
+  lastVerified: { type: Date, required: false },
+  contactVerified: { type: Boolean, required: false, default: false },
   notes: { type: String, required: false },
   lastContacted: { type: Date, required: false },
   // The AI agent or human that last wrote this record (#818 `actor` field — one

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -197,6 +197,44 @@ describe('Venue Controller', () => {
       const g = (controller as any).constructor.buildListFilter({ outreachEligible: 'false' });
       expect(g).toMatchObject({ outreachEligible: false });
     });
+
+    it('filters by the vetting tags inScope / bookingStatus / interested (#843)', () => {
+      const f = (controller as any).constructor.buildListFilter({ inScope: 'true', bookingStatus: 'booking', interested: 'true' });
+      expect(f).toMatchObject({ inScope: true, bookingStatus: 'booking', interested: true });
+      const g = (controller as any).constructor.buildListFilter({ inScope: 'false', interested: 'false' });
+      expect(g).toMatchObject({ inScope: false, interested: false });
+    });
+  });
+
+  describe('vetting tags (#843)', () => {
+    it('rejects an invalid bookingStatus', async () => {
+      await c.createVenue({ user: 'a', body: { name: 'X', bookingStatus: 'bogus' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('bookingStatus');
+    });
+
+    it('persists the vetting tags on create', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      const create = vi.fn(() => Promise.resolve({ _id: 'v10' }));
+      c.model.create = create;
+      await c.createVenue({
+        user: 'a',
+        body: {
+          name: 'Olde Salem', inScope: true, bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
+        },
+      }, resStub);
+      expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({
+        inScope: true, bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
+      });
+    });
+
+    it('lets the tags be set via update', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateVenue({ user: 'a', params: { id }, body: { inScope: false, interested: false } }, resStub);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ inScope: false, interested: false }));
+    });
   });
 
   describe('outreachEligible tagging (#843)', () => {


### PR DESCRIPTION
## Summary
Adds the venue vetting/tag fields the targeting criteria need (from the 5-venue review): inScope (is it a gig-booking venue at all), bookingStatus (booking/not-booking/booked), interested (worth pursuing), payTier, lastVerified, contactVerified. Settable on create/update and filterable via GET /venue, alongside the existing outreachEligible gate — so #844's selection draws only vetted, in-scope, still-booking, interested venues. Data model + filters only; classifying the 77 is the human enrichment step (#849). Version 2.0.29 -> 2.0.30.

Part of #843

## How to test locally
npm test (eslint ./src + vitest --coverage, 90/90/80/80 gate). New tests cover bookingStatus validation, the new buildListFilter branches, and create/update persistence of the tags.

## Test evidence
npm test -> 258 passed, exit 0. Coverage 90.64 stmts / 82.78 branch / 84.84 func / 91.27 lines -> clears the gate. tsc clean, eslint clean.

🤖 Work by Claude Code — Opus 4.8