### PR TITLE
feat(outreach): batch target-list approval (approve/edit selected venues — NOT per-email)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.23",
+  "version": "2.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.23",
+      "version": "2.0.31",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-config-facade.ts
+++ b/src/model/outreach/outreach-config-facade.ts
@@ -1,0 +1,6 @@
+import Model from '../../lib/facade.js';
+import outreachConfigSchema from './outreach-config-schema.js';
+
+class OutreachConfigModel extends Model {}
+
+export default new OutreachConfigModel(outreachConfigSchema);

--- a/src/model/outreach/outreach-config-schema.ts
+++ b/src/model/outreach/outreach-config-schema.ts
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const options = {
+  timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
+};
+
+// Singleton config for the outreach batch flow (#844). One document, identified
+// by `key: 'outreach'`. `autoApprove`: when true, an agent holding
+// outreach:create may send a batch WITHOUT a human outreach:approve — used once
+// Josh trusts the venue tagging. Default false: every batch requires human
+// approval until that trust is established (the post-incident safe default).
+const outreachConfigSchema = new Schema({
+  key: { type: String, required: true, unique: true, default: 'outreach' },
+  autoApprove: { type: Boolean, required: false, default: false },
+  lastModifiedBy: { type: String, required: false },
+}, options);
+
+export default mongoose.models.OutreachConfig || mongoose.model('OutreachConfig', outreachConfigSchema);

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -7,6 +7,7 @@ import Controller from '#src/lib/controller.js';
 import { Icontroller } from '#src/lib/routeUtils.js';
 import { sendMail } from '#src/lib/mailer.js';
 import outreachModel from './outreach-facade.js';
+import outreachConfigModel from './outreach-config-facade.js';
 import venueModel from '../venue/venue-facade.js';
 import templateModel from '../template/template-facade.js';
 import userModel from '../user/user-facade.js';
@@ -17,13 +18,17 @@ import { MAX_STEP, nextTouchDueAfter } from './cadence.js';
 const PITCH_CC = ['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com'];
 
 // An active campaign blocks a new pitch for the same venue + window (no
-// double-pitching). A pending `draft` counts too — you can't queue two drafts
-// for the same venue + dates. Declined / rejected / no-response / booked are
-// terminal and don't block.
-const ACTIVE_STATUSES = ['draft', 'sent', 'replied'];
+// double-pitching). sent / replied are active; declined / no-response / booked
+// are terminal and don't block.
+const ACTIVE_STATUSES = ['sent', 'replied'];
 
 const ALLOWED_ROLES = ['JaM-admin', 'Developer'];
-const OUTREACH_WRITE_CAPS = ['outreach:create', 'outreach:edit', 'outreach:delete'];
+// Read/list endpoints: any outreach capability (incl. a pure approver) gets in.
+const OUTREACH_ANY_CAPS = ['outreach:create', 'outreach:edit', 'outreach:delete', 'outreach:approve'];
+// Door gate for the send paths: a creator OR an approver may attempt; canSend()
+// then decides whether it actually goes out (approver always; creator only when
+// auto-approve is on).
+const OUTREACH_SEND_CAPS = ['outreach:create', 'outreach:approve'];
 
 interface AuthedUser { userType?: string; privileges?: string[] }
 type AuthRequest = Request & { user?: string };
@@ -31,6 +36,8 @@ type AuthIdRequest = Request<{ id: string }> & { user?: string };
 type AuthzError = { status: number; message: string; outreach?: unknown };
 type AuthzResult = AuthzError | null;
 interface PitchContext { error?: AuthzError; venue?: VenueDoc; template?: TemplateDoc; type?: string }
+interface ResolveOpts { skipDedup?: boolean; requireEligible?: boolean }
+type SendResult = { ok: true; record: unknown } | { ok: false; status: number; message: string };
 
 interface SendBody {
   venueId?: string;
@@ -39,14 +46,28 @@ interface SendBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
-  // #844: a caller holding outreach:approve may set this to send immediately,
-  // skipping the draft step (the only sanctioned bypass).
-  override?: boolean;
 }
 
+// #844 — batch target-list approval. The approval gate is the TARGET SELECTION
+// (which vetted venues are in the batch), NOT individual emails. A human holding
+// outreach:approve sends the approved list; an agent (outreach:create only) can
+// send a batch ONLY when auto-approve is configured ON.
+interface BatchBody {
+  venueIds?: string[];
+  templateType?: string;
+  targetDates?: string;
+  bookingPeriod?: string;
+  actor?: string;
+  cc?: string | string[];
+}
+
+interface ConfigBody { autoApprove?: boolean; actor?: string }
 interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
 
-interface VenueDoc { _id?: unknown; name?: string; email?: string; contactName?: string; venueType?: string; status?: string }
+interface VenueDoc {
+  _id?: unknown; name?: string; email?: string; contactName?: string;
+  venueType?: string; status?: string; outreachEligible?: boolean;
+}
 interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
 interface FollowUp { sentAt?: Date; messageId?: string; step?: number }
 interface OutreachDoc {
@@ -54,7 +75,7 @@ interface OutreachDoc {
   status?: string; templateUsed?: string; bookingPeriod?: string;
 }
 
-const OUTREACH_STATUSES = ['draft', 'rejected', 'sent', 'replied', 'declined', 'booked', 'no-response'];
+const OUTREACH_STATUSES = ['sent', 'replied', 'declined', 'booked', 'no-response'];
 
 // An explicit `actor` (stamped by the MCP server / agent) wins; otherwise fall
 // back to the authenticated token subject.
@@ -168,6 +189,27 @@ class OutreachController extends Controller {
     return checkAccess(user, required);
   }
 
+  // Read the singleton auto-approve config (#844). Absent doc => auto-approve OFF
+  // (the safe default — every batch needs a human until Josh turns it on).
+  async getConfig(): Promise<{ autoApprove: boolean }> {
+    const cfg = await outreachConfigModel.findOne({ key: 'outreach' }) as { autoApprove?: boolean } | null;
+    return { autoApprove: !!(cfg && cfg.autoApprove) };
+  }
+
+  // Send authorization (#844): a human holding outreach:approve may always send;
+  // anyone else (an agent with only outreach:create, already checked by the
+  // caller) may send ONLY when auto-approve is configured ON. Returns null when
+  // sending is allowed, else the error to relay.
+  async canSend(req: AuthRequest): Promise<AuthzResult> {
+    const approveErr = await this.authorize(req, ['outreach:approve']);
+    if (!approveErr) return null;
+    if (approveErr.status !== 403) return approveErr;
+    let cfg: { autoApprove: boolean };
+    try { cfg = await this.getConfig(); } catch (e) { return { status: 500, message: (e as Error).message }; }
+    if (!cfg.autoApprove) return { status: 403, message: 'sending requires approval — auto-approve is off' };
+    return null;
+  }
+
   static buildListFilter(query: Record<string, unknown>): Record<string, unknown> {
     const filter: Record<string, unknown> = {};
     if (typeof query.venueId === 'string') filter.venueId = query.venueId;
@@ -177,7 +219,7 @@ class OutreachController extends Controller {
 
   // GET /outreach — list outreach records (filters: venueId, status).
   async listOutreach(req: AuthRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, OUTREACH_WRITE_CAPS);
+    const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     const query = (req.query || {}) as Record<string, unknown>;
     let records: Record<string, unknown>[];
@@ -189,7 +231,7 @@ class OutreachController extends Controller {
 
   // GET /outreach/:id
   async getOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, OUTREACH_WRITE_CAPS);
+    const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Find id is invalid' });
     let doc;
@@ -223,18 +265,21 @@ class OutreachController extends Controller {
   }
 
   // Load + validate the venue and template for a send and run the dedup guard.
-  // Returns a ready context, or an error envelope for sendPitch to relay. Pulls
-  // the bulk of the branching out of sendPitch.
-  // `skipDedup` is set when re-resolving an EXISTING draft (approve/preview) —
-  // there the draft itself is the "active" outreach, so the dedup check would
-  // wrongly match it. Only a brand-new draft runs the dedup guard.
-  async resolvePitch(body: SendBody, skipDedup = false): Promise<PitchContext> {
+  // Returns a ready context, or an error envelope for the caller to relay.
+  // requireEligible (default true): the venue must be VETTED (outreachEligible) —
+  // the core #844 safety guard. Turned off for preview, which is read-only.
+  // skipDedup (default false): suppress the "already-pitched" check (preview).
+  async resolvePitch(body: SendBody, opts: ResolveOpts = {}): Promise<PitchContext> {
+    const { skipDedup = false, requireEligible = true } = opts;
     let venue: VenueDoc | null;
     try { venue = await venueModel.findById(body.venueId || '') as unknown as VenueDoc | null; } catch (e) {
       return { error: { status: 500, message: (e as Error).message } };
     }
     if (!venue) return { error: { status: 400, message: 'venue not found' } };
     if (venue.status === 'archived') return { error: { status: 400, message: 'venue is archived' } };
+    if (requireEligible && !venue.outreachEligible) {
+      return { error: { status: 400, message: 'venue is not outreach-eligible (not vetted)' } };
+    }
     if (!venue.email) return { error: { status: 400, message: 'venue has no email to pitch' } };
 
     const type = (body.templateType || venue.venueType || '').trim();
@@ -247,7 +292,6 @@ class OutreachController extends Controller {
     if (!template) return { error: { status: 400, message: `no active template for type ${type}` } };
 
     if (!skipDedup) {
-      // Dedup guard — refuse if a draft/live pitch already exists for this venue + window.
       let dupe;
       try {
         dupe = await this.model.findOne({ venueId: body.venueId, targetDates: body.targetDates, status: { $in: ACTIVE_STATUSES } });
@@ -259,46 +303,38 @@ class OutreachController extends Controller {
     return { venue, template, type };
   }
 
-  // The single place an email actually leaves: render + send + write/update the
-  // outreach record as `sent` with cadence touch 1. Used ONLY by the approval
-  // path and the explicit override path (#844). `existingId` set => update that
-  // draft; null => create a fresh sent record (override). Returns the Express res.
-  async finalizeSend(
-    res: Response, venue: VenueDoc, template: TemplateDoc, type: string, body: SendBody, actor: string, existingId: string | null,
-  ): Promise<unknown> {
+  // The single place an email actually leaves: render + send + write the outreach
+  // record as `sent` with cadence touch 1. Returns a result envelope so both the
+  // single-send and batch paths can relay/aggregate it.
+  async performSend(venue: VenueDoc, template: TemplateDoc, type: string, body: SendBody, actor: string): Promise<SendResult> {
     const { subject, html, attachments } = buildPitchEmail(venue, template, body);
     let sent: { messageId: string };
     try {
       sent = await sendMail({ to: venue.email || '', cc: body.cc || PITCH_CC, subject, html, attachments });
-    } catch (e) { return res.status(502).json({ message: `email send failed: ${(e as Error).message}` }); }
+    } catch (e) { return { ok: false, status: 502, message: `email send failed: ${(e as Error).message}` }; }
 
     const sentAt = new Date();
     const fields = {
-      templateUsed: type, targetDates: body.targetDates, bookingPeriod: body.bookingPeriod,
+      venueId: String(venue._id), templateUsed: type, targetDates: body.targetDates, bookingPeriod: body.bookingPeriod,
       sentAt, status: 'sent', messageId: sent.messageId, sentBy: actor, lastModifiedBy: actor,
       step: 1, nextTouchDue: nextTouchDueAfter(1, sentAt),
     };
     let record;
-    try {
-      record = existingId
-        ? await this.model.findByIdAndUpdate(existingId, fields)
-        : await this.model.create({ venueId: String(venue._id), ...fields });
-    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    try { record = await this.model.create(fields); } catch (e) { return { ok: false, status: 500, message: (e as Error).message }; }
 
     // Best-effort: stamp the venue's lastContacted (non-critical, swallow errors).
     try {
       await venueModel.findByIdAndUpdate(String(venue._id), { lastContacted: new Date(), lastModifiedBy: actor });
     } catch { /* best-effort */ }
-    return res.status(existingId ? 200 : 201).json(record);
+    return { ok: true, record };
   }
 
-  // POST /outreach/send — DRAFT-FIRST (#844, post-incident). By default this does
-  // NOT email anyone: it resolves the venue/template and writes a `draft` outreach
-  // record awaiting human approval. An email only goes out later via
-  // /outreach/:id/approve. The one bypass: a caller holding `outreach:approve`
-  // may pass `override: true` to send immediately (the explicit-override case).
+  // POST /outreach/send — send ONE pitch immediately to a vetted venue (#844). No
+  // draft step: the venue being outreachEligible is the approval. Authz: a human
+  // (outreach:approve) always; an agent (outreach:create) only when auto-approve
+  // is ON. Use /outreach/batch for a whole approved target list.
   async sendPitch(req: AuthRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, ['outreach:create']);
+    const guardErr = await this.authorize(req, OUTREACH_SEND_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     const body = (req.body || {}) as SendBody;
     if (!body.venueId || !mongoose.Types.ObjectId.isValid(body.venueId)) {
@@ -307,79 +343,121 @@ class OutreachController extends Controller {
     if (!body.targetDates || !body.targetDates.trim()) {
       return res.status(400).json({ message: 'targetDates is required' });
     }
+    const sendErr = await this.canSend(req);
+    if (sendErr) return res.status(sendErr.status).json({ message: sendErr.message });
 
     const ctx = await this.resolvePitch(body);
     if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message, outreach: ctx.error.outreach });
     const { venue, template, type } = ctx as Required<PitchContext>;
+    const result = await this.performSend(venue, template, type, body, resolveActor(req, body));
+    if (!result.ok) return res.status(result.status).json({ message: result.message });
+    return res.status(201).json(result.record);
+  }
+
+  // POST /outreach/batch — send the approved target list (#844). Body:
+  // { venueIds[], targetDates, bookingPeriod?, templateType? }. Same authz as
+  // /send. Each venue is independently resolved (eligibility + dedup) and sent;
+  // failures are collected in `skipped` rather than aborting the batch.
+  async sendBatch(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, OUTREACH_SEND_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    const body = (req.body || {}) as BatchBody;
+    if (!Array.isArray(body.venueIds) || body.venueIds.length === 0) {
+      return res.status(400).json({ message: 'venueIds (non-empty array) is required' });
+    }
+    if (!body.targetDates || !body.targetDates.trim()) {
+      return res.status(400).json({ message: 'targetDates is required' });
+    }
+    const sendErr = await this.canSend(req);
+    if (sendErr) return res.status(sendErr.status).json({ message: sendErr.message });
+
     const actor = resolveActor(req, body);
-
-    if (body.override === true) {
-      const approveErr = await this.authorize(req, ['outreach:approve']);
-      if (approveErr) return res.status(403).json({ message: 'override requires the outreach:approve capability' });
-      return this.finalizeSend(res, venue, template, type, body, actor, null);
+    const result: { requested: number; sent: number; skipped: { venueId: string; reason: string }[]; records: unknown[] } = {
+      requested: body.venueIds.length, sent: 0, skipped: [], records: [],
+    };
+    for (const venueId of body.venueIds) {
+      if (!mongoose.Types.ObjectId.isValid(venueId)) { result.skipped.push({ venueId, reason: 'invalid id' }); continue; }
+      const sendBody = { targetDates: body.targetDates, bookingPeriod: body.bookingPeriod, cc: body.cc };
+      // eslint-disable-next-line no-await-in-loop
+      const ctx = await this.resolvePitch({ venueId, templateType: body.templateType, ...sendBody });
+      if (ctx.error) { result.skipped.push({ venueId, reason: ctx.error.message }); continue; }
+      const { venue, template, type } = ctx as Required<PitchContext>;
+      // eslint-disable-next-line no-await-in-loop
+      const r = await this.performSend(venue, template, type, sendBody, actor);
+      if (!r.ok) { result.skipped.push({ venueId, reason: r.message }); continue; }
+      result.sent += 1; result.records.push(r.record);
     }
+    return res.status(200).json(result);
+  }
 
-    let draft;
+  // GET /outreach/candidates — propose the target list (#844): vetted
+  // (outreachEligible), non-archived venues with an email, minus any that already
+  // have an active outreach for the given targetDates. Read-only. Optional query:
+  // targetDates (to exclude already-pitched venues for that window).
+  async getCandidates(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    let venues: { _id?: unknown }[];
     try {
-      draft = await this.model.create({
-        venueId: body.venueId, templateUsed: type, targetDates: body.targetDates,
-        bookingPeriod: body.bookingPeriod, status: 'draft', sentBy: actor, lastModifiedBy: actor,
-      });
+      venues = await venueModel.find({ outreachEligible: true, status: { $ne: 'archived' }, email: { $nin: [null, ''] } });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
-    return res.status(201).json({ message: 'draft created — requires approval before it sends', outreach: draft });
+
+    const targetDates = typeof (req.query || {}).targetDates === 'string' ? (req.query as { targetDates: string }).targetDates : undefined;
+    let handled = new Set<string>();
+    if (targetDates) {
+      let active: { venueId?: unknown }[];
+      try { active = await this.model.find({ targetDates, status: { $in: ACTIVE_STATUSES } }); } catch (e) {
+        return res.status(500).json({ message: (e as Error).message });
+      }
+      handled = new Set(active.map((a) => String(a.venueId)));
+    }
+    const candidates = venues.filter((v) => !handled.has(String(v._id)));
+    return res.status(200).json(candidates);
   }
 
-  // POST /outreach/:id/approve — the ONLY normal path that sends. Requires
-  // `outreach:approve` (a human admin; the AI agent does NOT hold it). Renders +
-  // sends the reviewed draft's email and flips it to `sent`.
-  async approveOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, ['outreach:approve']);
+  // GET /outreach/preview — render the exact email a venue would get, WITHOUT
+  // sending and WITHOUT requiring eligibility, so the approval UI (#1133) can
+  // show Josh the real copy while he curates the list. Query: venueId (required),
+  // templateType?, targetDates?, bookingPeriod?.
+  async previewByVenue(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
-    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Approve id is invalid' });
-    let rec: OutreachDoc | null;
-    try { rec = await this.model.findById(req.params.id) as unknown as OutreachDoc | null; } catch (e) {
-      return res.status(500).json({ message: (e as Error).message });
-    }
-    if (!rec) return res.status(400).json({ message: 'outreach not found' });
-    if (rec.status !== 'draft') return res.status(400).json({ message: `only a draft can be approved (status is ${rec.status})` });
-
-    const ctx = await this.resolvePitch({ venueId: String(rec.venueId), templateType: rec.templateUsed, targetDates: rec.targetDates }, true);
-    if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
-    const { venue, template, type } = ctx as Required<PitchContext>;
-    const body = { targetDates: rec.targetDates, bookingPeriod: rec.bookingPeriod } as SendBody;
-    return this.finalizeSend(res, venue, template, type, body, resolveActor(req, (req.body || {}) as SendBody), req.params.id);
-  }
-
-  // POST /outreach/:id/reject — a human declines a draft (requires outreach:approve).
-  async rejectOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, ['outreach:approve']);
-    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
-    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Reject id is invalid' });
-    const update = { status: 'rejected', lastModifiedBy: resolveActor(req, (req.body || {}) as SendBody) };
-    let doc;
-    try { doc = await this.model.findByIdAndUpdate(req.params.id, update); } catch (e) {
-      return res.status(500).json({ message: (e as Error).message });
-    }
-    if (!doc) return res.status(400).json({ message: 'outreach not found' });
-    return res.status(200).json(doc);
-  }
-
-  // GET /outreach/:id/preview — render the exact email a draft would send, WITHOUT
-  // sending. Lets the approval UI (#1133) show Josh the real copy before he approves.
-  async previewOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
-    const guardErr = await this.authorize(req, OUTREACH_WRITE_CAPS);
-    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
-    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Preview id is invalid' });
-    let rec: OutreachDoc | null;
-    try { rec = await this.model.findById(req.params.id) as unknown as OutreachDoc | null; } catch (e) {
-      return res.status(500).json({ message: (e as Error).message });
-    }
-    if (!rec) return res.status(400).json({ message: 'outreach not found' });
-    const ctx = await this.resolvePitch({ venueId: String(rec.venueId), templateType: rec.templateUsed, targetDates: rec.targetDates }, true);
+    const q = (req.query || {}) as { venueId?: string; templateType?: string; targetDates?: string; bookingPeriod?: string };
+    if (!q.venueId || !mongoose.Types.ObjectId.isValid(q.venueId)) return res.status(400).json({ message: 'valid venueId is required' });
+    const ctx = await this.resolvePitch(
+      { venueId: q.venueId, templateType: q.templateType, targetDates: q.targetDates, bookingPeriod: q.bookingPeriod },
+      { skipDedup: true, requireEligible: false },
+    );
     if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
     const { venue, template } = ctx as Required<PitchContext>;
-    const { subject, html } = buildPitchEmail(venue, template, { targetDates: rec.targetDates, bookingPeriod: rec.bookingPeriod } as SendBody);
+    const { subject, html } = buildPitchEmail(venue, template, { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod } as SendBody);
     return res.status(200).json({ to: venue.email, cc: PITCH_CC, subject, html });
+  }
+
+  // GET /outreach/config — read the auto-approve setting (#844).
+  async getOutreachConfig(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    let cfg: { autoApprove: boolean };
+    try { cfg = await this.getConfig(); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    return res.status(200).json(cfg);
+  }
+
+  // PUT /outreach/config — toggle auto-approve (#844). Only the human approver
+  // (outreach:approve) may change the trust setting; an agent cannot self-grant.
+  async setOutreachConfig(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:approve']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    const body = (req.body || {}) as ConfigBody;
+    if (typeof body.autoApprove !== 'boolean') return res.status(400).json({ message: 'autoApprove (boolean) is required' });
+    const actor = resolveActor(req, body);
+    const doc = { key: 'outreach', autoApprove: body.autoApprove, lastModifiedBy: actor };
+    let cfg: { autoApprove?: boolean } | null;
+    try {
+      cfg = await outreachConfigModel.findOneAndUpdate({ key: 'outreach' }, doc);
+      if (!cfg) cfg = await outreachConfigModel.create(doc) as { autoApprove?: boolean };
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    return res.status(200).json({ autoApprove: !!(cfg && cfg.autoApprove) });
   }
 
   // Send one due email follow-up for an outreach record and reschedule it, or

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -3,22 +3,56 @@ import controller from './outreach-controller.js';
 import authUtils from '../../auth/authUtils.js';
 import routeUtils from '../../lib/routeUtils.js';
 
-// Outreach log + send-pitch (web-jam-back#823). Booking-outreach data, NOT
-// public. Every route runs makeAction → ensureAuthenticated (populates req.user
-// from the token); the controller then does the per-capability outreach:* check
-// (privilege-first, admin-role fallback), same as venue (#819) / template (#822).
+// Outreach log + batch send-pitch (web-jam-back#823, reworked to batch target-
+// list approval in #844). Booking-outreach data, NOT public. Every route runs
+// makeAction → ensureAuthenticated (populates req.user from the token); the
+// controller then does the per-capability outreach:* check (privilege-first,
+// admin-role fallback), same as venue (#819) / template (#822).
 const router = express.Router();
 
-// POST /outreach/send — render a template for a venue and email the pitch. Above
-// /:id so "send" isn't parsed as an id.
+// Static routes are declared above /:id so words like "send" / "batch" aren't
+// parsed as an id.
+
+// POST /outreach/send — send ONE pitch immediately to a vetted venue (#844).
 router.route('/send')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'sendPitch', controller, authUtils);
     void action();
   });
 
-// POST /outreach/advance — cadence engine tick (#824). Above /:id so "advance"
-// isn't parsed as an id. Driven on a schedule by the Deno Cron (#100).
+// POST /outreach/batch — send the approved target list (#844).
+router.route('/batch')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'sendBatch', controller, authUtils);
+    void action();
+  });
+
+// GET /outreach/candidates — propose the eligible target list (#844).
+router.route('/candidates')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'getCandidates', controller, authUtils);
+    void action();
+  });
+
+// GET /outreach/preview — render a venue's pitch email without sending (#844).
+router.route('/preview')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'previewByVenue', controller, authUtils);
+    void action();
+  });
+
+// GET/PUT /outreach/config — read/toggle auto-approve (#844).
+router.route('/config')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'getOutreachConfig', controller, authUtils);
+    void action();
+  })
+  .put((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'setOutreachConfig', controller, authUtils);
+    void action();
+  });
+
+// POST /outreach/advance — cadence engine tick (#824). Driven by the Deno Cron (#100).
 router.route('/advance')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'advanceCadence', controller, authUtils);
@@ -28,27 +62,6 @@ router.route('/advance')
 router.route('/')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'listOutreach', controller, authUtils);
-    void action();
-  });
-
-// Approval gate (#844): approve = the only normal path that sends; reject =
-// decline a draft; preview = render the exact copy without sending (for the
-// approval UI). Above /:id so the action segments aren't parsed as ids.
-router.route('/:id/approve')
-  .post((req, res) => {
-    const action = routeUtils.makeAction(req, res, 'approveOutreach', controller, authUtils);
-    void action();
-  });
-
-router.route('/:id/reject')
-  .post((req, res) => {
-    const action = routeUtils.makeAction(req, res, 'rejectOutreach', controller, authUtils);
-    void action();
-  });
-
-router.route('/:id/preview')
-  .get((req, res) => {
-    const action = routeUtils.makeAction(req, res, 'previewOutreach', controller, authUtils);
     void action();
   });
 

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -27,18 +27,19 @@ const outreachSchema = new Schema({
   venueId: { type: Schema.Types.ObjectId, ref: 'Venue', required: true },
   templateUsed: { type: String, required: false, trim: true },
   targetDates: { type: String, required: false, trim: true },
-  // Stored so an approved draft re-renders the EXACT copy that was reviewed
-  // (#844) — same template + venue + targetDates + bookingPeriod => same email.
+  // The booking window pitched (e.g. "August"); stored on the sent record so the
+  // copy and any cadence follow-ups stay consistent with what went out.
   bookingPeriod: { type: String, required: false, trim: true },
   sentAt: { type: Date, required: false, default: Date.now },
-  // `draft` = proposed, awaiting human approval — NOTHING has been emailed yet
-  // (#844). `rejected` = a human declined the draft. Only an approval moves a
-  // draft to `sent` (the point at which the email actually goes out).
+  // Campaign lifecycle. #844 reworked outreach to BATCH target-list approval —
+  // the approval gate is the venue selection, not a per-email draft — so the
+  // `draft`/`rejected` states are gone. A record exists only once an email has
+  // actually gone out (`sent`), then advances via replies/cadence.
   status: {
     type: String,
     required: false,
-    enum: ['draft', 'rejected', 'sent', 'replied', 'declined', 'booked', 'no-response'],
-    default: 'draft',
+    enum: ['sent', 'replied', 'declined', 'booked', 'no-response'],
+    default: 'sent',
   },
   messageId: { type: String, required: false, trim: true },
   gmailThreadId: { type: String, required: false, trim: true },

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -11,10 +11,12 @@ const { default: controller } = await import('#src/model/outreach/outreach-contr
 const { default: userModel } = await import('#src/model/user/user-facade.js');
 const { default: venueModel } = await import('#src/model/venue/venue-facade.js');
 const { default: templateModel } = await import('#src/model/template/template-facade.js');
+const { default: configModel } = await import('#src/model/outreach/outreach-config-facade.js');
 
 const c = controller as any;
+const oid = () => new mongoose.Types.ObjectId().toString();
 
-describe('Outreach Controller', () => {
+describe('Outreach Controller (#844 batch model)', () => {
   let status = 0;
   let payload: any;
   const resStub: any = {
@@ -24,17 +26,20 @@ describe('Outreach Controller', () => {
     },
   };
 
+  // Default actor = the AI agent: create/edit/delete but NOT approve.
   const asAgent = (privileges = ['outreach:create', 'outreach:edit', 'outreach:delete']) => {
     (userModel as any).findById = vi.fn(() => Promise.resolve({ privileges }));
   };
+  const asApprover = () => asAgent(['outreach:approve']);
 
   const validVenue = (over = {}) => ({
-    _id: new mongoose.Types.ObjectId().toString(),
+    _id: oid(),
     name: 'The Spot on Kirk',
     email: 'booking@spotonkirk.com',
     contactName: 'Pat',
     venueType: 'Originals',
     status: 'active',
+    outreachEligible: true,
     ...over,
   });
 
@@ -53,16 +58,22 @@ describe('Outreach Controller', () => {
     sendMail.mockResolvedValue({ messageId: 'mid-123' });
     asAgent();
     (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue()));
+    (venueModel as any).find = vi.fn(() => Promise.resolve([]));
     (venueModel as any).findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
     (templateModel as any).findOne = vi.fn(() => Promise.resolve(validTemplate()));
+    (configModel as any).findOne = vi.fn(() => Promise.resolve(null)); // auto-approve OFF by default
+    (configModel as any).findOneAndUpdate = vi.fn((_q: any, u: any) => Promise.resolve({ ...u }));
+    (configModel as any).create = vi.fn((d: any) => Promise.resolve({ ...d }));
     c.model.findOne = vi.fn(() => Promise.resolve(null));
+    c.model.find = vi.fn(() => Promise.resolve([]));
     c.model.create = vi.fn((doc: any) => Promise.resolve({ _id: 'o1', ...doc }));
+    c.model.findByIdAndUpdate = vi.fn((id: string, f: any) => Promise.resolve({ _id: id, ...f }));
   });
 
   describe('authorize', () => {
-    it('403s when the outreach:create capability is missing', async () => {
+    it('403s when no send capability is held', async () => {
       asAgent(['outreach:edit']);
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(403);
       expect(payload.message).toContain('outreach:create');
     });
@@ -75,13 +86,12 @@ describe('Outreach Controller', () => {
 
     it('allows a privilege-less admin via role fallback', async () => {
       (userModel as any).findById = vi.fn(() => Promise.resolve({ userType: 'JaM-admin', privileges: [] }));
-      c.model.find = vi.fn(() => Promise.resolve([]));
       await c.listOutreach({ user: 'a', query: {} }, resStub);
       expect(status).toBe(200);
     });
   });
 
-  describe('sendPitch validation', () => {
+  describe('sendPitch — validation', () => {
     it('rejects a missing/invalid venueId', async () => {
       await c.sendPitch({ user: 'a', body: { targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
@@ -89,242 +99,127 @@ describe('Outreach Controller', () => {
     });
 
     it('rejects missing targetDates', async () => {
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid() } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('targetDates');
     });
 
     it('400s when the venue is not found', async () => {
+      asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.resolve(null));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('venue not found');
     });
 
     it('400s when the venue is archived', async () => {
+      asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('archived');
     });
 
+    it('400s when the venue is NOT outreach-eligible (the #844 safety guard)', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ outreachEligible: false })));
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('not outreach-eligible');
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
     it('400s when the venue has no email', async () => {
+      asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ email: '' })));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('no email');
     });
 
     it('400s when no template type can be resolved', async () => {
+      asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ venueType: '' })));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('venueType');
     });
 
     it('400s when no active template exists for the type', async () => {
+      asApprover();
       (templateModel as any).findOne = vi.fn(() => Promise.resolve(null));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('no active template');
     });
   });
 
-  describe('sendPitch — draft-first (#844)', () => {
-    it('creates a DRAFT and sends NOTHING by default', async () => {
-      await c.sendPitch({
-        user: 'opus', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', actor: 'opus' },
-      }, resStub);
-      expect(status).toBe(201);
-      expect(sendMail).not.toHaveBeenCalled();
-      const rec = (c.model.create as any).mock.calls[0][0];
-      expect(rec.status).toBe('draft');
-      expect(rec.templateUsed).toBe('Originals');
-      expect(rec.messageId).toBeUndefined();
-      expect(payload.message).toMatch(/approval/i);
-    });
+  describe('sendPitch — authorization to send (canSend)', () => {
+    const body = () => ({ venueId: oid(), targetDates: 'Aug 14-16', bookingPeriod: 'August' });
 
-    it('dedup-guards against an existing draft/live pitch (409), incl. drafts', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'existing', status: 'draft' }));
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
-      expect(status).toBe(409);
-      expect(sendMail).not.toHaveBeenCalled();
-      expect((c.model.findOne as any).mock.calls[0][0].status).toEqual({ $in: ['draft', 'sent', 'replied'] });
-    });
-
-    it('honors an explicit templateType (still a draft)', async () => {
-      const findOne = vi.fn(() => Promise.resolve(validTemplate({ type: 'MidRangeCafeBar' })));
-      (templateModel as any).findOne = findOne;
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', templateType: 'MidRangeCafeBar' } }, resStub);
-      expect(status).toBe(201);
-      expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar', active: true });
-      expect(sendMail).not.toHaveBeenCalled();
-    });
-
-    it('refuses override without outreach:approve (403, no send)', async () => {
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
+    it('403s an agent when auto-approve is OFF (no send)', async () => {
+      await c.sendPitch({ user: 'opus', body: body() }, resStub);
       expect(status).toBe(403);
+      expect(payload.message).toMatch(/auto-approve is off/);
       expect(sendMail).not.toHaveBeenCalled();
     });
 
-    it('override + outreach:approve sends immediately as a sent record', async () => {
-      asAgent(['outreach:create', 'outreach:approve']);
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
+    it('an approver sends immediately as a sent record', async () => {
+      asApprover();
+      await c.sendPitch({ user: 'josh', body: body() }, resStub);
       expect(status).toBe(201);
       expect(sendMail).toHaveBeenCalledTimes(1);
+      expect((sendMail.mock.calls[0][0] as any).cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
       const rec = (c.model.create as any).mock.calls[0][0];
       expect(rec.status).toBe('sent');
       expect(rec.step).toBe(1);
+      expect(rec.nextTouchDue).toBeInstanceOf(Date);
+    });
+
+    it('an agent sends when auto-approve is ON', async () => {
+      (configModel as any).findOne = vi.fn(() => Promise.resolve({ autoApprove: true }));
+      await c.sendPitch({ user: 'opus', body: body() }, resStub);
+      expect(status).toBe(201);
+      expect(sendMail).toHaveBeenCalledTimes(1);
+    });
+
+    it('500s when the auto-approve config read throws', async () => {
+      (configModel as any).findOne = vi.fn(() => Promise.reject(new Error('cfg down')));
+      await c.sendPitch({ user: 'opus', body: body() }, resStub);
+      expect(status).toBe(500);
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('dedup-guards an existing active pitch (409, no send)', async () => {
+      asApprover();
+      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'existing', status: 'sent' }));
+      await c.sendPitch({ user: 'a', body: body() }, resStub);
+      expect(status).toBe(409);
+      expect(sendMail).not.toHaveBeenCalled();
+      expect((c.model.findOne as any).mock.calls[0][0].status).toEqual({ $in: ['sent', 'replied'] });
+    });
+
+    it('honors an explicit templateType', async () => {
+      asApprover();
+      const findOne = vi.fn(() => Promise.resolve(validTemplate({ type: 'MidRangeCafeBar' })));
+      (templateModel as any).findOne = findOne;
+      await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16', templateType: 'MidRangeCafeBar' } }, resStub);
+      expect(status).toBe(201);
+      expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar', active: true });
     });
   });
 
-  describe('approveOutreach (#844) — the only normal send path', () => {
-    const draft = (over = {}) => ({
-      _id: 'd1', venueId: validVenue()._id, templateUsed: 'Originals', targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', status: 'draft', ...over,
-    });
-    beforeEach(() => { c.model.findByIdAndUpdate = vi.fn((id: string, f: any) => Promise.resolve({ _id: id, ...f })); });
+  describe('sendPitch — error handling', () => {
+    const send = () => c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
 
-    it('403s without outreach:approve — the agent cannot approve', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
-      await c.approveOutreach({ user: 'a', params: { id } }, resStub);
-      expect(status).toBe(403);
-      expect(sendMail).not.toHaveBeenCalled();
-    });
-
-    it('renders + sends + flips draft to sent + schedules cadence', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(draft()));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(200);
-      expect(sendMail).toHaveBeenCalledTimes(1);
-      expect((sendMail.mock.calls[0][0] as any).cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
-      const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
-      expect(upd.status).toBe('sent');
-      expect(upd.messageId).toBe('mid-123');
-      expect(upd.step).toBe(1);
-      expect(upd.nextTouchDue).toBeInstanceOf(Date);
-    });
-
-    it('400s when the record is not a draft', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(draft({ status: 'sent' })));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(400);
-      expect(sendMail).not.toHaveBeenCalled();
-    });
-
-    it('400s when the draft is not found', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(null));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(400);
-    });
-
-    it('502s when the approved send fails', async () => {
-      asAgent(['outreach:approve']);
-      sendMail.mockRejectedValueOnce(new Error('smtp'));
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(draft()));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(502);
-    });
-
-    it('400s on an invalid id', async () => {
-      asAgent(['outreach:approve']);
-      await c.approveOutreach({ user: 'josh', params: { id: 'bad' } }, resStub);
-      expect(status).toBe(400);
-    });
-
-    it('500s when the lookup throws', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.reject(new Error('db down')));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
+    it('500s when authorize itself throws', async () => {
+      (userModel as any).findById = vi.fn(() => Promise.reject(new Error('auth down')));
+      await send();
       expect(status).toBe(500);
     });
 
-    it('relays a resolve error if the venue went archived since drafting', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(draft()));
-      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
-      await c.approveOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(400);
-      expect(sendMail).not.toHaveBeenCalled();
-    });
-
-    it('override create-record path still stamps cadence (finalizeSend create branch)', async () => {
-      asAgent(['outreach:create', 'outreach:approve']);
-      await c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16', override: true } }, resStub);
-      const rec = (c.model.create as any).mock.calls[0][0];
-      expect(rec.nextTouchDue).toBeInstanceOf(Date);
-    });
-  });
-
-  describe('rejectOutreach + previewOutreach (#844)', () => {
-    it('reject 403s without outreach:approve', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
-      await c.rejectOutreach({ user: 'a', params: { id } }, resStub);
-      expect(status).toBe(403);
-    });
-
-    it('reject marks a draft rejected', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      const upd = vi.fn(() => Promise.resolve({ _id: id, status: 'rejected' }));
-      c.model.findByIdAndUpdate = upd;
-      await c.rejectOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(200);
-      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ status: 'rejected' }));
-    });
-
-    it('preview renders the exact email without sending', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve({
-        _id: id, venueId: validVenue()._id, templateUsed: 'Originals', targetDates: 'Aug 14-16', bookingPeriod: 'late-summer', status: 'draft',
-      }));
-      await c.previewOutreach({ user: 'a', params: { id } }, resStub);
-      expect(status).toBe(200);
-      expect(sendMail).not.toHaveBeenCalled();
-      expect(payload.subject).toContain('The Spot on Kirk');
-      expect(payload.html).toContain('Hi Pat,');
-      expect(payload.cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
-    });
-
-    it('reject 400s on an invalid id', async () => {
-      asAgent(['outreach:approve']);
-      await c.rejectOutreach({ user: 'josh', params: { id: 'bad' } }, resStub);
-      expect(status).toBe(400);
-    });
-
-    it('reject 400s when not found', async () => {
-      asAgent(['outreach:approve']);
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve(null));
-      await c.rejectOutreach({ user: 'josh', params: { id } }, resStub);
-      expect(status).toBe(400);
-    });
-
-    it('preview 400s on an invalid id', async () => {
-      await c.previewOutreach({ user: 'a', params: { id: 'bad' } }, resStub);
-      expect(status).toBe(400);
-    });
-
-    it('preview 400s when the draft is not found', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
-      c.model.findById = vi.fn(() => Promise.resolve(null));
-      await c.previewOutreach({ user: 'a', params: { id } }, resStub);
-      expect(status).toBe(400);
-    });
-  });
-
-  describe('sendPitch error handling', () => {
-    const send = () => c.sendPitch({ user: 'a', body: { venueId: validVenue()._id, targetDates: 'Aug 14-16' } }, resStub);
-
     it('500s when the venue lookup throws', async () => {
+      asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.reject(new Error('db down')));
       await send();
       expect(status).toBe(500);
@@ -332,26 +227,223 @@ describe('Outreach Controller', () => {
     });
 
     it('500s when the template lookup throws', async () => {
+      asApprover();
       (templateModel as any).findOne = vi.fn(() => Promise.reject(new Error('tpl down')));
       await send();
       expect(status).toBe(500);
     });
 
     it('500s when the dedup lookup throws', async () => {
+      asApprover();
       c.model.findOne = vi.fn(() => Promise.reject(new Error('dedup down')));
       await send();
       expect(status).toBe(500);
     });
 
     it('500s when the record write throws', async () => {
+      asApprover();
       c.model.create = vi.fn(() => Promise.reject(new Error('insert down')));
       await send();
       expect(status).toBe(500);
     });
 
-    it('500s when authorize itself throws', async () => {
-      (userModel as any).findById = vi.fn(() => Promise.reject(new Error('auth down')));
+    it('502s when the email send fails', async () => {
+      asApprover();
+      sendMail.mockRejectedValueOnce(new Error('smtp'));
       await send();
+      expect(status).toBe(502);
+    });
+  });
+
+  describe('sendBatch (#844)', () => {
+    it('403s without a send capability', async () => {
+      asAgent(['outreach:edit']);
+      await c.sendBatch({ user: 'a', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('400s when venueIds is missing or empty', async () => {
+      await c.sendBatch({ user: 'a', body: { targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('venueIds');
+      await c.sendBatch({ user: 'a', body: { venueIds: [], targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('400s when targetDates is missing', async () => {
+      await c.sendBatch({ user: 'a', body: { venueIds: [oid()] } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('targetDates');
+    });
+
+    it('403s an agent when auto-approve is OFF', async () => {
+      await c.sendBatch({ user: 'opus', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(403);
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('sends to every approved venue and reports the summary', async () => {
+      asApprover();
+      await c.sendBatch({ user: 'josh', body: { venueIds: [oid(), oid()], targetDates: 'Aug 14-16', bookingPeriod: 'August' } }, resStub);
+      expect(status).toBe(200);
+      expect(sendMail).toHaveBeenCalledTimes(2);
+      expect(payload).toMatchObject({ requested: 2, sent: 2 });
+      expect(payload.skipped).toHaveLength(0);
+      expect(payload.records).toHaveLength(2);
+    });
+
+    it('skips an invalid id but still sends the valid one', async () => {
+      asApprover();
+      await c.sendBatch({ user: 'josh', body: { venueIds: ['bad', oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(payload.sent).toBe(1);
+      expect(payload.skipped).toEqual([{ venueId: 'bad', reason: 'invalid id' }]);
+    });
+
+    it('skips an ineligible venue (collected, batch continues)', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn()
+        .mockResolvedValueOnce(validVenue())
+        .mockResolvedValueOnce(validVenue({ outreachEligible: false }));
+      await c.sendBatch({ user: 'josh', body: { venueIds: [oid(), oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(payload.sent).toBe(1);
+      expect(payload.skipped).toHaveLength(1);
+      expect(payload.skipped[0].reason).toContain('not outreach-eligible');
+    });
+
+    it('skips a venue whose send fails', async () => {
+      asApprover();
+      sendMail.mockRejectedValueOnce(new Error('smtp down'));
+      await c.sendBatch({ user: 'josh', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(payload.sent).toBe(0);
+      expect(payload.skipped).toHaveLength(1);
+      expect(payload.skipped[0].reason).toContain('email send failed');
+    });
+
+    it('lets an agent batch-send when auto-approve is ON', async () => {
+      (configModel as any).findOne = vi.fn(() => Promise.resolve({ autoApprove: true }));
+      await c.sendBatch({ user: 'opus', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.sent).toBe(1);
+    });
+  });
+
+  describe('getCandidates (#844)', () => {
+    it('403s without an outreach capability', async () => {
+      asAgent(['venue:create']);
+      await c.getCandidates({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('returns the eligible venues', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
+      await c.getCandidates({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toHaveLength(2);
+      expect((venueModel as any).find).toHaveBeenCalledWith(expect.objectContaining({ outreachEligible: true }));
+    });
+
+    it('excludes venues already pitched for the target dates', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
+      c.model.find = vi.fn(() => Promise.resolve([{ venueId: 'a' }]));
+      await c.getCandidates({ user: 'a', query: { targetDates: 'Aug 14-16' } }, resStub);
+      expect(payload).toHaveLength(1);
+      expect(payload[0]._id).toBe('b');
+    });
+
+    it('500s when the venue query throws', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.getCandidates({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('500s when the active-outreach query throws', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+      c.model.find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.getCandidates({ user: 'a', query: { targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(500);
+    });
+  });
+
+  describe('previewByVenue (#844)', () => {
+    it('renders the exact email without sending', async () => {
+      await c.previewByVenue({ user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(200);
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(payload.subject).toContain('The Spot on Kirk');
+      expect(payload.html).toContain('Hi Pat,');
+      expect(payload.cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
+    });
+
+    it('previews even a non-eligible venue (read-only, requireEligible off)', async () => {
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ outreachEligible: false })));
+      await c.previewByVenue({ user: 'a', query: { venueId: oid() } }, resStub);
+      expect(status).toBe(200);
+    });
+
+    it('400s on an invalid venueId', async () => {
+      await c.previewByVenue({ user: 'a', query: { venueId: 'bad' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('400s when the venue is not found', async () => {
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(null));
+      await c.previewByVenue({ user: 'a', query: { venueId: oid() } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('venue not found');
+    });
+  });
+
+  describe('config — auto-approve (#844)', () => {
+    it('reads the default (OFF) when no doc exists', async () => {
+      await c.getOutreachConfig({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toEqual({ autoApprove: false });
+    });
+
+    it('reads ON when the doc says so', async () => {
+      (configModel as any).findOne = vi.fn(() => Promise.resolve({ autoApprove: true }));
+      await c.getOutreachConfig({ user: 'a', query: {} }, resStub);
+      expect(payload).toEqual({ autoApprove: true });
+    });
+
+    it('500s when the config read throws', async () => {
+      (configModel as any).findOne = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.getOutreachConfig({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('only an approver may set it (agent 403s)', async () => {
+      await c.setOutreachConfig({ user: 'opus', body: { autoApprove: true } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('400s when autoApprove is not a boolean', async () => {
+      asApprover();
+      await c.setOutreachConfig({ user: 'josh', body: {} }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('sets the flag (upsert returns the doc)', async () => {
+      asApprover();
+      await c.setOutreachConfig({ user: 'josh', body: { autoApprove: true } }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toEqual({ autoApprove: true });
+    });
+
+    it('creates the doc when none exists yet', async () => {
+      asApprover();
+      (configModel as any).findOneAndUpdate = vi.fn(() => Promise.resolve(null));
+      (configModel as any).create = vi.fn(() => Promise.resolve({ autoApprove: false }));
+      await c.setOutreachConfig({ user: 'josh', body: { autoApprove: false } }, resStub);
+      expect(status).toBe(200);
+      expect((configModel as any).create).toHaveBeenCalled();
+      expect(payload).toEqual({ autoApprove: false });
+    });
+
+    it('500s when the write throws', async () => {
+      asApprover();
+      (configModel as any).findOneAndUpdate = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.setOutreachConfig({ user: 'josh', body: { autoApprove: true } }, resStub);
       expect(status).toBe(500);
     });
   });
@@ -363,62 +455,78 @@ describe('Outreach Controller', () => {
     });
 
     it('rejects an invalid status', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
-      await c.updateOutreach({ user: 'a', params: { id }, body: { status: 'bogus' } }, resStub);
+      await c.updateOutreach({ user: 'a', params: { id: oid() }, body: { status: 'bogus' } }, resStub);
       expect(status).toBe(400);
       expect(payload.message).toContain('status not valid');
     });
 
     it('updates status + threadId', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
+      const id = oid();
       const upd = vi.fn(() => Promise.resolve({ _id: id, status: 'booked' }));
       c.model.findByIdAndUpdate = upd;
       await c.updateOutreach({ user: 'agent', params: { id }, body: { status: 'booked', gmailThreadId: 't1' } }, resStub);
       expect(status).toBe(200);
       expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ status: 'booked', gmailThreadId: 't1', lastModifiedBy: 'agent' }));
     });
+
+    it('500s when the update throws', async () => {
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.updateOutreach({ user: 'a', params: { id: oid() }, body: { status: 'booked' } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('400s when the record is not found', async () => {
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve(null));
+      await c.updateOutreach({ user: 'a', params: { id: oid() }, body: { status: 'booked' } }, resStub);
+      expect(status).toBe(400);
+    });
   });
 
-  describe('getOutreach', () => {
-    it('rejects an invalid id', async () => {
+  describe('getOutreach / listOutreach', () => {
+    it('getOutreach rejects an invalid id', async () => {
       await c.getOutreach({ user: 'a', params: { id: 'bad' } }, resStub);
       expect(status).toBe(400);
     });
 
-    it('returns a found record', async () => {
-      const id = new mongoose.Types.ObjectId().toString();
+    it('getOutreach returns a found record', async () => {
+      const id = oid();
       c.model.findById = vi.fn(() => Promise.resolve({ _id: id, status: 'sent' }));
       await c.getOutreach({ user: 'a', params: { id } }, resStub);
       expect(status).toBe(200);
       expect(payload.status).toBe('sent');
     });
-  });
 
-  describe('listOutreach / buildListFilter', () => {
-    it('filters by venueId and status', () => {
+    it('getOutreach 400s when nothing is found', async () => {
+      c.model.findById = vi.fn(() => Promise.resolve(null));
+      await c.getOutreach({ user: 'a', params: { id: oid() } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('buildListFilter filters by venueId and status', () => {
       const f = (controller as any).constructor.buildListFilter({ venueId: 'v1', status: 'sent' });
       expect(f).toEqual({ venueId: 'v1', status: 'sent' });
     });
 
-    it('returns the collection', async () => {
+    it('listOutreach returns the collection', async () => {
       c.model.find = vi.fn(() => Promise.resolve([{ status: 'sent' }]));
       await c.listOutreach({ user: 'a', query: {} }, resStub);
       expect(status).toBe(200);
       expect(payload).toHaveLength(1);
     });
-  });
 
-  // (Cadence touch 1 / nextTouchDue is stamped at APPROVAL now, not at draft —
-  // asserted in the approveOutreach block above.)
+    it('listOutreach 500s when the query throws', async () => {
+      c.model.find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.listOutreach({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(500);
+    });
+  });
 
   describe('advanceCadence (#824)', () => {
     const dueRecord = (over = {}) => ({
-      _id: 'o1', venueId: validVenue()._id, sentAt: new Date('2026-06-01T12:00:00Z'), step: 1, targetDates: 'Aug 14-16', followUps: [], ...over,
+      _id: 'o1', venueId: oid(), sentAt: new Date('2026-06-01T12:00:00Z'), step: 1, targetDates: 'Aug 14-16', followUps: [], ...over,
     });
 
-    beforeEach(() => {
-      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
-    });
+    beforeEach(() => { c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({})); });
 
     it('403s without the outreach:edit capability', async () => {
       asAgent(['outreach:create']);


### PR DESCRIPTION
## Summary
Rework outreach from the per-email draft/approve gate (#847) to BATCH target-list approval (Josh's redesign): the approval gate is the venue SELECTION, not individual emails. The server refuses any venue that isn't outreachEligible (the core safety guard that kills the 5-mis-sent class). New: GET /outreach/candidates (propose eligible list), POST /outreach/batch (send approved list), GET /outreach/preview (render a venue email without sending), GET/PUT /outreach/config (persistent auto-approve flag, default OFF — when ON an agent with outreach:create may batch-send without a human approver). Removed the draft/rejected statuses and /:id/approve|reject per-email routes. Single POST /outreach/send kept as an immediate one-venue send.

Closes #844

## How to test locally
npm test   # eslint ./src + vitest run --coverage

## Test evidence
npm test → Test Files 24 passed (24), Tests 290 passed (290), EXIT=0. Coverage: Statements 90.67%, Branches 83.93%, Functions 83.56%, Lines 91.26% — all above the 90/80/80/90 gate. eslint + tsc --noEmit (tsconfig.prod) both clean.

🤖 Work by Claude Code — Opus 4.8