### PR TITLE
chore(outreach): clean up the 5 mis-sent records + rework per-email gate PR #847

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.31",
+      "version": "2.0.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -255,6 +255,11 @@ class OutreachController extends Controller {
     }
     const update: Record<string, unknown> = { lastModifiedBy: resolveActor(req, body) };
     if (body.status !== undefined) update.status = body.status;
+    // Halting a campaign must clear any pending cadence touch so a halted record
+    // can NEVER fire a follow-up (#850). The cadence engine only advances `sent`
+    // records, so moving to any other status (replied/declined/booked/no-response)
+    // means there is no next touch — null it out rather than leave a stale date.
+    if (body.status !== undefined && body.status !== 'sent') update.nextTouchDue = null;
     if (body.gmailThreadId !== undefined) update.gmailThreadId = body.gmailThreadId;
     let doc;
     try { doc = await this.model.findByIdAndUpdate(req.params.id, update); } catch (e) {

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -469,6 +469,23 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ status: 'booked', gmailThreadId: 't1', lastModifiedBy: 'agent' }));
     });
 
+    it('nulls nextTouchDue when halting to a terminal status (#850)', async () => {
+      const id = oid();
+      const upd = vi.fn(() => Promise.resolve({ _id: id, status: 'no-response' }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateOutreach({ user: 'josh', params: { id }, body: { status: 'no-response' } }, resStub);
+      expect(status).toBe(200);
+      expect(upd.mock.calls[0][1].nextTouchDue).toBeNull();
+    });
+
+    it('leaves nextTouchDue untouched when no terminal status is set', async () => {
+      const id = oid();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateOutreach({ user: 'josh', params: { id }, body: { gmailThreadId: 't9' } }, resStub);
+      expect(upd.mock.calls[0][1]).not.toHaveProperty('nextTouchDue');
+    });
+
     it('500s when the update throws', async () => {
       c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db down')));
       await c.updateOutreach({ user: 'a', params: { id: oid() }, body: { status: 'booked' } }, resStub);


### PR DESCRIPTION
## Summary
Defensive half of #850: when an outreach record is moved to any non-'sent' status (replied/declined/booked/no-response), updateOutreach now nulls nextTouchDue so a halted campaign can never carry a stale pending touch. The cadence engine only advances 'sent' records, so the 5 mis-sent records (already no-response) are already safe from follow-ups — but they still held a 2026-06-24 nextTouchDue, a latent footgun this removes generally. NOTE: the actual data cleanup of those 5 prod records is a post-deploy step (PUT each once this is live); #850 stays open until that's done + verified.

Part of #850

## How to test locally
npm test   # eslint ./src + vitest run --coverage

## Test evidence
npm test → 24 files, 292 tests passed, EXIT=0. Coverage Statements 90.68% / Branches 84.13% / Functions 83.56% / Lines 91.27% (over the 90/80/80/90 gate). lint + tsc clean. (One pre-existing flaky test, book-router 'should update one book' — token/timing race on a real test DB, unrelated to this change — failed once then passed on re-run.)

🤖 Work by Claude Code — Opus 4.8