### PR TITLE
feat(outreach): DELETE /outreach/:id route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.32",
+      "version": "2.0.33",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -269,6 +269,23 @@ class OutreachController extends Controller {
     return res.status(200).json(doc);
   }
 
+  // DELETE /outreach/:id — hard-delete an outreach record (#857). Outreach is a
+  // log, not a venue, so a bad / test / mis-sent record is removed outright
+  // rather than archived. Requires outreach:delete.
+  async deleteOutreach(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:delete']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Delete id is invalid' });
+    }
+    let doc;
+    try { doc = await this.model.findByIdAndDelete(req.params.id); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!doc) return res.status(400).json({ message: 'Id Not Found' });
+    return res.status(200).json(doc);
+  }
+
   // Load + validate the venue and template for a send and run the dedup guard.
   // Returns a ready context, or an error envelope for the caller to relay.
   // requireEligible (default true): the venue must be VETTED (outreachEligible) —

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -73,6 +73,10 @@ router.route('/:id')
   .put((req, res) => {
     const action = routeUtils.makeAction(req, res, 'updateOutreach', controller, authUtils);
     void action();
+  })
+  .delete((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'deleteOutreach', controller, authUtils);
+    void action();
   });
 
 export default router;

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -499,6 +499,41 @@ describe('Outreach Controller (#844 batch model)', () => {
     });
   });
 
+  describe('deleteOutreach (#857)', () => {
+    it('403s without the outreach:delete capability', async () => {
+      asAgent(['outreach:edit']);
+      await c.deleteOutreach({ user: 'a', params: { id: oid() } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('400s on an invalid id', async () => {
+      await c.deleteOutreach({ user: 'a', params: { id: 'bad' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('deletes a found record', async () => {
+      const id = oid();
+      const del = vi.fn(() => Promise.resolve({ _id: id, status: 'sent' }));
+      c.model.findByIdAndDelete = del;
+      await c.deleteOutreach({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(200);
+      expect(del).toHaveBeenCalledWith(id);
+      expect(payload._id).toBe(id);
+    });
+
+    it('400s when the record is not found', async () => {
+      c.model.findByIdAndDelete = vi.fn(() => Promise.resolve(null));
+      await c.deleteOutreach({ user: 'a', params: { id: oid() } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('500s when the delete throws', async () => {
+      c.model.findByIdAndDelete = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.deleteOutreach({ user: 'a', params: { id: oid() } }, resStub);
+      expect(status).toBe(500);
+    });
+  });
+
   describe('getOutreach / listOutreach', () => {
     it('getOutreach rejects an invalid id', async () => {
       await c.getOutreach({ user: 'a', params: { id: 'bad' } }, resStub);


### PR DESCRIPTION
## Summary
Add DELETE /outreach/:id (gated outreach:delete) to hard-delete an outreach record — outreach is a log, not a venue, so it deletes outright (no soft-archive). Fills the gap surfaced cleaning up #850 (a leftover smoke-test record stuck at status=sent could not be removed). Returns the deleted doc; 400 on invalid/unknown id, 500 on db error.

Closes #857

## How to test locally
npm test   # eslint ./src + vitest run --coverage

## Test evidence
npm test → 24 files, 297 tests passed, EXIT=0. Coverage Statements 90.63% / Branches 84.28% / Functions 83.25% / Lines 91.17% (over the 90/80/80/90 gate). lint + tsc clean. New deleteOutreach has 5 tests (403/400-invalid/200/400-notfound/500).

🤖 Work by Claude Code — Opus 4.8