### PR TITLE
feat(outreach): pick the email template by venueType + relationship stage

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,15 @@
+{
+  "threshold": 5,
+  "reporters": ["console"],
+  "absolute": true,
+  "gitignore": true,
+  "format": ["typescript", "javascript"],
+  "ignore": [
+    "**/*.spec.ts",
+    "**/*.test.*",
+    "**/node_modules/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/*.csv"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,11 +46,12 @@
         "eslint-plugin-security": "^4.0.0",
         "eslint-plugin-sonarjs": "^4.0.3",
         "globals": "^17.5.0",
+        "jscpd": "^5.0.11",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": "24.16.0"
+        "node": "24.17.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2081,6 +2082,99 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cpd-darwin-arm64": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-arm64/-/cpd-darwin-arm64-5.0.11.tgz",
+      "integrity": "sha512-3QvH+4Dv7A7esVFM2tsRVWN3kn9EDu8dMYog6gYAVsCtxEf4xyxAwS/ef6LjC7/dh4+ATADFbg3H09A2fD//Qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-darwin-x64": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-darwin-x64/-/cpd-darwin-x64-5.0.11.tgz",
+      "integrity": "sha512-OvgM2ps0OFR5jUzx7+FK9URdJGxUzzM5KKk2F1V3vf1LooGDKwkivfIDyKsqEwp37zcbyUo7COvBpJXOT0dZmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/cpd-linux-arm64-gnu": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-arm64-gnu/-/cpd-linux-arm64-gnu-5.0.11.tgz",
+      "integrity": "sha512-pXMINibAeruglni8ZajlXEefZHDs7QFSG+vPtkBDu7uiIMpNU8aoktgO2vP+PbIRFD0vHkqTMb64kDtIOqQcwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-gnu": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-gnu/-/cpd-linux-x64-gnu-5.0.11.tgz",
+      "integrity": "sha512-rQ7DuF0lH1HLzjGxlE0aEP2ycfhXgZH/CLSeS7FXNJ38lRVp+iXkrlcrrY6mC4WW/NgbL+DkF7/0lv3tFvGmvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-linux-x64-musl": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-linux-x64-musl/-/cpd-linux-x64-musl-5.0.11.tgz",
+      "integrity": "sha512-Yh+7Go5+fA++I5ssAZg7gUkDCT5CxnzCPvrspbwDrfnwaY6nNM5g1C6Vs0+GJhsspuAKwydJl4nf7jkxzMwRQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/cpd-windows-x64-msvc": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/cpd-windows-x64-msvc/-/cpd-windows-x64-msvc-5.0.11.tgz",
+      "integrity": "sha512-uV6w85qdfE0WJsrLcGw9A4Kv9ovSnlXZCybMK0esvuiJ7clgaZmDiDPozt5PvrOOShkK/NxzTZSORBSdVnquHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3371,6 +3465,27 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jscpd": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.11.tgz",
+      "integrity": "sha512-NfLrFJHRM6rIf3oVcdZ4sfhMVop1qxi5r8aC99lpj55YC8hiWaN4VmzU2wcXTwoAo+NS4npXPs9EVEQJ6jyRlg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jscpd": "run-jscpd.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "cpd-darwin-arm64": "5.0.11",
+        "cpd-darwin-x64": "5.0.11",
+        "cpd-linux-arm64-gnu": "5.0.11",
+        "cpd-linux-x64-gnu": "5.0.11",
+        "cpd-linux-x64-musl": "5.0.11",
+        "cpd-windows-x64-msvc": "5.0.11"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.33",
+      "version": "2.0.34",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "cleaninstall": "npm install -g npm@latest && npm install -g rimraf && npm run cleanup && npm cache clean --force && npm install",
     "smoketest": "npm run cleanup && npm install --omit=dev",
     "node:debug": "node --inspect-brk index.js",
-    "test": "eslint ./src && rimraf coverage && npm run test:unit",
+    "jscpd": "jscpd src",
+    "test": "eslint ./src && npm run jscpd && rimraf coverage && npm run test:unit",
     "test:lint": "eslint ./src --fix",
     "test:local": "npm run test:lint && rimraf coverage && npm run test:unit",
     "test:unit": "vitest run --coverage",
@@ -78,6 +79,7 @@
     "eslint-plugin-security": "^4.0.0",
     "eslint-plugin-sonarjs": "^4.0.3",
     "globals": "^17.5.0",
+    "jscpd": "^5.0.11",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -67,6 +67,7 @@ interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
 interface VenueDoc {
   _id?: unknown; name?: string; email?: string; contactName?: string;
   venueType?: string; status?: string; outreachEligible?: boolean;
+  bookingStatus?: string; relationshipStage?: string; templateOverride?: string;
 }
 interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
 interface FollowUp { sentAt?: Date; messageId?: string; step?: number }
@@ -286,6 +287,29 @@ class OutreachController extends Controller {
     return res.status(200).json(doc);
   }
 
+  // Resolve a venue's relationship stage (#848). An explicit venue.relationshipStage
+  // wins; otherwise auto-derive: a currently-booked venue, or one with a prior
+  // outreach that got a reply or a booking, is `returning`; everything else is `cold`.
+  async resolveStage(venue: VenueDoc): Promise<'cold' | 'returning'> {
+    if (venue.relationshipStage === 'cold' || venue.relationshipStage === 'returning') return venue.relationshipStage;
+    if (venue.bookingStatus === 'booked') return 'returning';
+    const prior = await this.model.findOne({ venueId: String(venue._id), status: { $in: ['replied', 'booked'] } });
+    return prior ? 'returning' : 'cold';
+  }
+
+  // Pick the active template for a type + stage (#848). Cold also matches legacy
+  // templates with no stage set. A `returning` request with no returning variant
+  // yet falls back to the cold template, so sends never break before the
+  // returning copy is authored.
+  async findTemplate(type: string, stage: 'cold' | 'returning'): Promise<TemplateDoc | null> { // eslint-disable-line class-methods-use-this
+    const coldMatch = { type, active: true, $or: [{ stage: 'cold' }, { stage: { $exists: false } }, { stage: null }] };
+    if (stage === 'returning') {
+      const returning = await templateModel.findOne({ type, active: true, stage: 'returning' }) as unknown as TemplateDoc | null;
+      if (returning) return returning;
+    }
+    return await templateModel.findOne(coldMatch) as unknown as TemplateDoc | null;
+  }
+
   // Load + validate the venue and template for a send and run the dedup guard.
   // Returns a ready context, or an error envelope for the caller to relay.
   // requireEligible (default true): the venue must be VETTED (outreachEligible) —
@@ -304,15 +328,7 @@ class OutreachController extends Controller {
     }
     if (!venue.email) return { error: { status: 400, message: 'venue has no email to pitch' } };
 
-    const type = (body.templateType || venue.venueType || '').trim();
-    if (!type) return { error: { status: 400, message: 'no templateType and venue has no venueType' } };
-
-    let template: TemplateDoc | null;
-    try { template = await templateModel.findOne({ type, active: true }) as unknown as TemplateDoc | null; } catch (e) {
-      return { error: { status: 500, message: (e as Error).message } };
-    }
-    if (!template) return { error: { status: 400, message: `no active template for type ${type}` } };
-
+    // Dedup guard first — refuse a duplicate before doing template work.
     if (!skipDedup) {
       let dupe;
       try {
@@ -322,6 +338,20 @@ class OutreachController extends Controller {
         return { error: { status: 409, message: 'an active outreach already exists for this venue and target dates', outreach: dupe } };
       }
     }
+
+    // Template type: explicit caller value > per-venue override > venue's type (#848).
+    const type = (body.templateType || venue.templateOverride || venue.venueType || '').trim();
+    if (!type) return { error: { status: 400, message: 'no templateType and venue has no venueType' } };
+
+    let template: TemplateDoc | null;
+    try {
+      const stage = await this.resolveStage(venue);
+      template = await this.findTemplate(type, stage);
+    } catch (e) {
+      return { error: { status: 500, message: (e as Error).message } };
+    }
+    if (!template) return { error: { status: 400, message: `no active template for type ${type}` } };
+
     return { venue, template, type };
   }
 

--- a/src/model/template/template-controller.ts
+++ b/src/model/template/template-controller.ts
@@ -6,6 +6,7 @@ import templateModel from './template-facade.js';
 import userModel from '../user/user-facade.js';
 
 const TEMPLATE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar', 'OnlineForm'];
+const TEMPLATE_STAGES = ['cold', 'returning'];
 
 // Role fallback for human admins who authorize by role (no privileges array).
 // AI agents pass via the template:* capabilities on the shared web-jam-llm
@@ -25,6 +26,7 @@ type AuthzResult = AuthzError | null;
 interface TemplateBody {
   _id?: string;
   type?: string;
+  stage?: string;
   subject?: string;
   bodyHtml?: string;
   footerPhotoRef?: string;
@@ -46,6 +48,7 @@ function validateBody(body: TemplateBody, partial: boolean): string {
     if (!body.type || !body.type.trim()) return 'type is required';
   }
   if (body.type !== undefined && TEMPLATE_TYPES.indexOf(body.type) === -1) return 'type not valid';
+  if (body.stage !== undefined && TEMPLATE_STAGES.indexOf(body.stage) === -1) return 'stage not valid';
   return '';
 }
 
@@ -80,6 +83,7 @@ class TemplateController extends Controller {
   static buildListFilter(query: Record<string, unknown>): Record<string, unknown> {
     const filter: Record<string, unknown> = {};
     if (typeof query.type === 'string') filter.type = query.type;
+    if (typeof query.stage === 'string') filter.stage = query.stage;
     if (query.active === 'true') filter.active = true;
     if (query.active === 'false') filter.active = false;
     return filter;
@@ -108,10 +112,11 @@ class TemplateController extends Controller {
     return res.status(200).json(doc);
   }
 
-  // One template per type — dedupe on `type` so re-creating a known type updates
-  // it instead of duplicating.
+  // One template per (type, stage) — dedupe on both so re-creating a known
+  // type+stage updates it instead of duplicating (#848). A body without a stage
+  // defaults to `cold`, matching the schema default.
   async findDuplicate(body: TemplateBody): Promise<Record<string, unknown> | null> {
-    return this.model.findOne({ type: body.type });
+    return this.model.findOne({ type: body.type, stage: body.stage || 'cold' });
   }
 
   // POST /template — create a template, or upsert onto the existing one for that

--- a/src/model/template/template-schema.ts
+++ b/src/model/template/template-schema.ts
@@ -17,8 +17,17 @@ const templateSchema = new Schema({
   type: {
     type: String,
     required: true,
-    unique: true,
     enum: ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar', 'OnlineForm'],
+  },
+  // Relationship stage (#848): `cold` = first contact, `returning` = "we've
+  // played here, would love to come back". A template is now keyed by type +
+  // stage, so each venue type can have a different cold vs. returning pitch.
+  // Existing single-per-type templates default to `cold`.
+  stage: {
+    type: String,
+    required: false,
+    enum: ['cold', 'returning'],
+    default: 'cold',
   },
   subject: { type: String, required: false, trim: true },
   bodyHtml: { type: String, required: false },
@@ -27,5 +36,8 @@ const templateSchema = new Schema({
   // The AI agent or human that last wrote this record (#818 `actor` field).
   lastModifiedBy: { type: String, required: false },
 }, options);
+
+// One template per (type, stage) — replaces the old `type`-unique constraint (#848).
+templateSchema.index({ type: 1, stage: 1 }, { unique: true });
 
 export default mongoose.models.Template || mongoose.model('Template', templateSchema);

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -47,6 +47,8 @@ interface VenueBody {
   lastVerified?: string;
   contactVerified?: boolean;
   notes?: string;
+  relationshipStage?: string;
+  templateOverride?: string;
   lastContacted?: string;
   actor?: string;
 }
@@ -79,6 +81,10 @@ function validateBody(body: VenueBody, partial: boolean): string {
   if (body.venueType !== undefined && VENUE_TYPES.indexOf(body.venueType) === -1) return 'venueType not valid';
   if (body.status !== undefined && STATUS_OPTIONS.indexOf(body.status) === -1) return 'status not valid';
   if (body.bookingStatus !== undefined && BOOKING_STATUSES.indexOf(body.bookingStatus) === -1) return 'bookingStatus not valid';
+  if (body.relationshipStage !== undefined && body.relationshipStage !== ''
+    && ['cold', 'returning'].indexOf(body.relationshipStage) === -1) return 'relationshipStage not valid';
+  if (body.templateOverride !== undefined && body.templateOverride !== ''
+    && VENUE_TYPES.indexOf(body.templateOverride) === -1) return 'templateOverride not valid';
   if (body.email !== undefined && body.email !== '' && !EMAIL_RE.test(String(body.email).trim().toLowerCase())) {
     return 'A valid email is required';
   }

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -60,6 +60,13 @@ const venueSchema = new Schema({
   lastVerified: { type: Date, required: false },
   contactVerified: { type: Boolean, required: false, default: false },
   notes: { type: String, required: false },
+  // Template-selection inputs (#848). `relationshipStage` overrides the
+  // auto-derived cold/returning stage when set; left unset = auto-derive
+  // (booked / prior replied-or-booked outreach => returning, else cold).
+  // `templateOverride` forces a specific template type for special cases,
+  // beating the venue's own venueType.
+  relationshipStage: { type: String, required: false, enum: ['cold', 'returning'] },
+  templateOverride: { type: String, required: false, enum: ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'] },
   lastContacted: { type: Date, required: false },
   // The AI agent or human that last wrote this record (#818 `actor` field — one
   // shared agent identity authenticates, but each write records who acted).

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -205,7 +205,7 @@ describe('Outreach Controller (#844 batch model)', () => {
       (templateModel as any).findOne = findOne;
       await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16', templateType: 'MidRangeCafeBar' } }, resStub);
       expect(status).toBe(201);
-      expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar', active: true });
+      expect(findOne).toHaveBeenCalledWith(expect.objectContaining({ type: 'MidRangeCafeBar', active: true }));
     });
   });
 
@@ -252,6 +252,53 @@ describe('Outreach Controller (#844 batch model)', () => {
       sendMail.mockRejectedValueOnce(new Error('smtp'));
       await send();
       expect(status).toBe(502);
+    });
+  });
+
+  describe('template by stage (#848)', () => {
+    it('resolveStage: an explicit relationshipStage wins over auto-derive', async () => {
+      expect(await c.resolveStage(validVenue({ relationshipStage: 'returning' }))).toBe('returning');
+      expect(await c.resolveStage(validVenue({ relationshipStage: 'cold', bookingStatus: 'booked' }))).toBe('cold');
+    });
+
+    it('resolveStage: a booked venue auto-derives returning', async () => {
+      expect(await c.resolveStage(validVenue({ bookingStatus: 'booked' }))).toBe('returning');
+    });
+
+    it('resolveStage: a prior replied/booked outreach makes it returning', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'o', status: 'replied' }));
+      expect(await c.resolveStage(validVenue())).toBe('returning');
+    });
+
+    it('resolveStage: otherwise cold', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      expect(await c.resolveStage(validVenue())).toBe('cold');
+    });
+
+    it('findTemplate: uses the returning variant when present', async () => {
+      const findOne = vi.fn(() => Promise.resolve(validTemplate({ stage: 'returning' })));
+      (templateModel as any).findOne = findOne;
+      const t = await c.findTemplate('Originals', 'returning');
+      expect((t as any).stage).toBe('returning');
+      expect(findOne).toHaveBeenCalledWith({ type: 'Originals', active: true, stage: 'returning' });
+    });
+
+    it('findTemplate: returning falls back to cold when no returning variant exists', async () => {
+      const findOne = vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(validTemplate());
+      (templateModel as any).findOne = findOne;
+      const t = await c.findTemplate('Originals', 'returning');
+      expect(t).toBeTruthy();
+      expect(findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('send uses the per-venue templateOverride as the type', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ venueType: 'Originals', templateOverride: 'MidRangeCafeBar' })));
+      await c.sendPitch({ user: 'josh', body: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(201);
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).toBe('MidRangeCafeBar');
     });
   });
 

--- a/test/unit/template/template-controller.spec.ts
+++ b/test/unit/template/template-controller.spec.ts
@@ -84,12 +84,26 @@ describe('Template Controller', () => {
       expect(upd).toHaveBeenCalledWith('dup1', expect.objectContaining({ active: true }));
     });
 
-    it('dedupes by type', async () => {
+    it('dedupes by type + stage (defaults stage to cold)', async () => {
       const findOne = vi.fn(() => Promise.resolve(null));
       c.model.findOne = findOne;
       c.model.create = vi.fn(() => Promise.resolve({ _id: 'n' }));
       await c.createTemplate({ user: 'a', body: { type: 'MidRangeCafeBar' } }, resStub);
-      expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar' });
+      expect(findOne).toHaveBeenCalledWith({ type: 'MidRangeCafeBar', stage: 'cold' });
+    });
+
+    it('dedupes returning templates separately from cold', async () => {
+      const findOne = vi.fn(() => Promise.resolve(null));
+      c.model.findOne = findOne;
+      c.model.create = vi.fn(() => Promise.resolve({ _id: 'n' }));
+      await c.createTemplate({ user: 'a', body: { type: 'Originals', stage: 'returning' } }, resStub);
+      expect(findOne).toHaveBeenCalledWith({ type: 'Originals', stage: 'returning' });
+    });
+
+    it('rejects an invalid stage', async () => {
+      await c.createTemplate({ user: 'a', body: { type: 'Originals', stage: 'lukewarm' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('stage not valid');
     });
   });
 

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -62,6 +62,18 @@ describe('Venue Controller', () => {
       expect(payload.message).toContain('venueType');
     });
 
+    it('rejects an invalid relationshipStage (#848)', async () => {
+      await c.createVenue({ user: 'a', body: { name: 'X', relationshipStage: 'lukewarm' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('relationshipStage');
+    });
+
+    it('rejects an invalid templateOverride (#848)', async () => {
+      await c.createVenue({ user: 'a', body: { name: 'X', templateOverride: 'Bogus' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('templateOverride');
+    });
+
     it('rejects an invalid email', async () => {
       await c.createVenue({ user: 'a', body: { name: 'X', email: 'nope' } }, resStub);
       expect(status).toBe(400);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
     include: ['test/**/*.spec.ts'],
     bail: 1,
     mockReset: true,
+    // Integration specs share one Mongo test DB and some wipe whole collections
+    // (e.g. userModel.deleteMany({})). Run test files strictly sequentially so one
+    // file's cleanup can't wipe another file's auth user mid-request — the cause
+    // of the intermittent 401 in book-router's "should update one book".
+    fileParallelism: false,
     pool: 'forks',
     forks: { singleFork: true },
     coverage: {


### PR DESCRIPTION
## Summary
Template selection by venueType + relationship stage (post-incident proper selection). Templates keyed by (type, stage) — schema gains stage (cold|returning, default cold), type-unique becomes a (type,stage) compound unique index, dedup/list are stage-aware. Venue gains relationshipStage (explicit override; unset=auto-derive) + templateOverride (force a type). Send picks type = templateType > venue.templateOverride > venueType; stage = explicit else auto (booked or prior replied/booked outreach => returning, else cold). findTemplate falls back returning->cold (sends never break before returning copy exists; also matches legacy stage-less templates). POST-DEPLOY: set stage='cold' on the 3 existing prod templates (dedup match); sends already work via fallback. Venue-editor UI controls for the 2 new fields = small JaMmusic follow-up.

Closes #848

## How to test locally
npm test   # eslint ./src + vitest run --coverage

## Test evidence
npm test exit 0 → 24 files, 308 tests passed. Coverage Statements 90.71% / Branches 84.73% / Functions 83.41% / Lines 91.31% (over the 90/80/80/90 gate). lint + tsc clean. New #848 tests cover resolveStage (explicit/booked/prior-outreach/cold), findTemplate (returning + cold fallback), templateOverride, and stage validation on template + venue.

🤖 Work by Claude Code — Opus 4.8