### PR TITLE
feat(outreach): server-side Google Calendar call-task touches (#825)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,79 @@
+import Debug from 'debug';
+
+// Server-side Google Calendar integration (gig-outreach #825). Lets the cadence
+// engine drop a "call task" onto Josh's calendar when a CALL touch comes due — a
+// phone call can't be auto-dialed like an email, so it lands as a dated, all-day
+// task carrying the phone script. Uses a long-lived OAuth refresh token (Calendar-
+// write scope only) Josh provisioned once and set on Heroku as the env vars
+// below; mirrors auth/google.ts's plain-fetch style (no googleapis SDK).
+const debug = Debug('web-jam-back:calendar');
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+// 'primary' = the authorising account's main calendar (Josh's).
+const CALENDAR_ID = 'primary';
+const eventsUrl = (calId: string): string => `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calId)}/events`;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface CallTaskInput {
+  date: Date; // the day the all-day task lands on
+  title: string; // event summary, e.g. "Call The Bridge re: August"
+  scriptBody: string; // the phone script — stored as the event description
+}
+export interface CalendarEventResult { id: string; htmlLink?: string }
+
+interface TokenResponse { access_token?: string }
+
+// Exchange the stored refresh token for a short-lived access token. The refresh
+// token never expires (the OAuth app is published, not in testing), so this is
+// the only network step needed before every calendar write.
+async function getAccessToken(): Promise<string> {
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_OAUTH_CLIENT_ID || '',
+    client_secret: process.env.GOOGLE_OAUTH_CLIENT_SECRET || '',
+    refresh_token: process.env.GOOGLE_OAUTH_REFRESH_TOKEN || '',
+    grant_type: 'refresh_token',
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: params,
+  });
+  if (!res.ok) throw new Error(`google token exchange failed: ${res.status} ${res.statusText}`);
+  const body = await res.json() as TokenResponse;
+  if (!body || !body.access_token) throw new Error('google token exchange returned no access_token');
+  return body.access_token;
+}
+
+// YYYY-MM-DD (UTC) for an all-day Calendar event. All-day events take a bare
+// `date` (no time/zone), so a call task is a whole-day to-do rather than a timed
+// meeting — and there's no timezone math to get wrong (tests pin TZ=UTC).
+function ymd(d: Date): string { return d.toISOString().slice(0, 10); }
+
+// Create an all-day call-task event on Josh's primary calendar, with the phone
+// script as the event description. Returns the created event's id + link. Throws
+// on any failure so the caller (cadence processDue) can swallow it into a
+// 'skipped' outcome rather than crash the cron tick.
+export async function createCallTaskEvent(input: CallTaskInput): Promise<CalendarEventResult> {
+  const accessToken = await getAccessToken();
+  // All-day events are half-open: `end.date` is exclusive, so it's the next day.
+  const event = {
+    summary: input.title,
+    description: input.scriptBody,
+    start: { date: ymd(input.date) },
+    end: { date: ymd(new Date(input.date.getTime() + DAY_MS)) },
+    reminders: { useDefault: true },
+  };
+  const res = await fetch(eventsUrl(CALENDAR_ID), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(event),
+  });
+  if (!res.ok) throw new Error(`google calendar insert failed: ${res.status} ${res.statusText}`);
+  const body = await res.json() as { id?: string; htmlLink?: string };
+  if (!body || !body.id) throw new Error('google calendar insert returned no event id');
+  debug('created call-task event %s', body.id);
+  return { id: body.id, htmlLink: body.htmlLink };
+}
+
+export default { createCallTaskEvent };

--- a/src/model/outreach/cadence.ts
+++ b/src/model/outreach/cadence.ts
@@ -1,28 +1,46 @@
-// Email follow-up cadence (web-jam-back#824). Day offsets from the original
-// pitch (`sentAt`) at which each EMAIL touch goes out. Index 0 is the pitch
-// itself (#823 sendPitch, step 1); follow-ups are day 3 (step 2) and day 12
-// (step 3). The research-informed CALL touches (days 7/18) are added with the
-// server-side Google Calendar work (#825) — this module is email-only.
+// Outreach follow-up cadence (web-jam-back#824 email slice + #825 call touches).
+// A single interleaved touch schedule, by day-offset from the original pitch
+// (`sentAt`). Index 0 is the pitch itself (#823 sendPitch, step 1). EMAIL touches
+// go out through the mailer; CALL touches (#825) drop an all-day "call task" onto
+// Josh's Google Calendar carrying a phone script, since a call can't be
+// auto-dialed. Day offsets are strictly increasing so the cron fires touches in
+// order as each `nextTouchDue` comes up.
 //
-// `step` counts touches already completed (1 = pitch sent). After the final
-// email touch we wait PARK_GRACE_DAYS, then park the outreach as `no-response`.
-export const EMAIL_TOUCH_DAYS = [0, 3, 12];
+// `step` counts touches already completed (1 = pitch sent), so the NEXT touch is
+// always TOUCHES[step]. After the final touch we wait PARK_GRACE_DAYS, then park
+// the outreach as `no-response`.
+export type TouchType = 'email' | 'call';
+export interface Touch { day: number; type: TouchType }
+
+// Research-informed 5-touch sequence: emails day 0/3/12, calls day 7/18.
+export const TOUCHES: Touch[] = [
+  { day: 0, type: 'email' },
+  { day: 3, type: 'email' },
+  { day: 7, type: 'call' },
+  { day: 12, type: 'email' },
+  { day: 18, type: 'call' },
+];
 export const PARK_GRACE_DAYS = 7;
-export const MAX_STEP = EMAIL_TOUCH_DAYS.length; // 3
+export const MAX_STEP = TOUCHES.length; // 5
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// The next touch for an outreach whose last completed touch is `step` — i.e.
+// TOUCHES[step]. Null once the schedule is exhausted (the remaining work is just
+// the park check, which carries no touch).
+export function touchAt(step: number): Touch | null {
+  return TOUCHES[step] || null;
+}
+
 // When should the next action happen for an outreach whose last completed touch
-// is `step`? Returns the due Date, or null once everything (incl. the park
-// check) is behind us. While `step` is below the last touch it's the next
-// email's date; at the last touch it's the park-check date (last touch +
-// grace); beyond that it's null.
+// is `step`? Below the last touch: that touch's date. At the last touch: the
+// park-check date (last touch + grace). Beyond that: null.
 export function nextTouchDueAfter(step: number, sentAt: Date): Date | null {
   let days: number | null;
-  if (step < EMAIL_TOUCH_DAYS.length) days = EMAIL_TOUCH_DAYS[step];
-  else if (step === EMAIL_TOUCH_DAYS.length) days = EMAIL_TOUCH_DAYS[EMAIL_TOUCH_DAYS.length - 1] + PARK_GRACE_DAYS;
+  if (step < TOUCHES.length) days = TOUCHES[step].day;
+  else if (step === TOUCHES.length) days = TOUCHES[TOUCHES.length - 1].day + PARK_GRACE_DAYS;
   else days = null;
   return days === null ? null : new Date(sentAt.getTime() + days * DAY_MS);
 }
 
-export default { EMAIL_TOUCH_DAYS, PARK_GRACE_DAYS, MAX_STEP, nextTouchDueAfter };
+export default { TOUCHES, PARK_GRACE_DAYS, MAX_STEP, touchAt, nextTouchDueAfter };

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -6,12 +6,13 @@ import { fileURLToPath } from 'url';
 import Controller from '#src/lib/controller.js';
 import { Icontroller } from '#src/lib/routeUtils.js';
 import { sendMail } from '#src/lib/mailer.js';
+import { createCallTaskEvent } from '#src/lib/calendar.js';
 import outreachModel from './outreach-facade.js';
 import outreachConfigModel from './outreach-config-facade.js';
 import venueModel from '../venue/venue-facade.js';
 import templateModel from '../template/template-facade.js';
 import userModel from '../user/user-facade.js';
-import { MAX_STEP, nextTouchDueAfter } from './cadence.js';
+import { MAX_STEP, nextTouchDueAfter, touchAt } from './cadence.js';
 
 // Every gig pitch CCs Josh + Maria so they see each send land (mirrors the
 // InquiryController CC precedent). Maria's address is the same one inquiries CC.
@@ -65,12 +66,12 @@ interface ConfigBody { autoApprove?: boolean; actor?: string }
 interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
 
 interface VenueDoc {
-  _id?: unknown; name?: string; email?: string; contactName?: string;
+  _id?: unknown; name?: string; email?: string; contactName?: string; phone?: string;
   venueType?: string; status?: string; outreachEligible?: boolean;
   bookingStatus?: string; relationshipStage?: string; templateOverride?: string;
 }
 interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
-interface FollowUp { sentAt?: Date; messageId?: string; step?: number }
+interface FollowUp { sentAt?: Date; type?: string; messageId?: string; eventId?: string; step?: number }
 interface OutreachDoc {
   _id?: unknown; venueId?: unknown; sentAt?: Date; step?: number; targetDates?: string; followUps?: FollowUp[];
   status?: string; templateUsed?: string; bookingPeriod?: string;
@@ -178,6 +179,37 @@ function buildFollowUpEmail(venue: VenueDoc, outreach: OutreachDoc): {
     attachments.push({ filename: 'josh-maria.jpg', path: assetPath, cid: 'footerphoto' });
   }
   return { subject, html, attachments };
+}
+
+// Title + phone-script body for a CALL touch (#825), used as the Google Calendar
+// event's summary + description. A call can't be auto-dialed, so the cadence
+// lands a dated task carrying a ready-to-read script. Plain text (a calendar
+// description, not HTML); the venue phone is included when known.
+function buildCallTitle(venue: VenueDoc, outreach: OutreachDoc): string {
+  const dates = outreach.targetDates || 'upcoming dates';
+  return `Call ${venue.name || 'venue'} re: ${dates}`;
+}
+
+function buildCallScript(venue: VenueDoc, outreach: OutreachDoc): string {
+  const contact = venue.contactName || 'whoever books music';
+  const venueName = venue.name || 'the venue';
+  const dates = outreach.targetDates || 'an upcoming date';
+  const phone = venue.phone ? `Phone: ${venue.phone}` : 'Phone: (not on file — look up before calling)';
+  return [
+    `Follow-up call to ${venueName} — ask for ${contact}.`,
+    phone,
+    '',
+    'Script:',
+    `"Hi, this is Josh from Josh & Maria — my wife and I are a husband-wife acoustic duo here in `
+      + `Salem, VA. I emailed about playing a slot at ${venueName} around ${dates} and wanted to follow `
+      + `up to see if that's something you book."`,
+    '',
+    '- If interested: offer to send live samples + work around their calendar.',
+    '- If full: ask about a later window or being kept on file.',
+    '- If voicemail: leave the above + 540-494-8035 and joshandmariamusic.com.',
+    '',
+    'After the call, mark the outreach replied/declined/booked in the admin (PUT /outreach/:id).',
+  ].join('\n');
 }
 
 class OutreachController extends Controller {
@@ -512,26 +544,11 @@ class OutreachController extends Controller {
     return res.status(200).json({ autoApprove: !!(cfg && cfg.autoApprove) });
   }
 
-  // Send one due email follow-up for an outreach record and reschedule it, or
-  // park it as no-response once the sequence is exhausted. Returns the per-record
-  // outcome ('sent' | 'parked' | 'skipped'). Helper for advanceCadence.
-  async processDue(o: OutreachDoc): Promise<'sent' | 'parked' | 'skipped'> {
-    if ((o.step || 1) >= MAX_STEP) {
-      try {
-        await this.model.findByIdAndUpdate(String(o._id), { status: 'no-response', nextTouchDue: null, lastModifiedBy: 'cadence-engine' });
-        return 'parked';
-      } catch { return 'skipped'; }
-    }
-    let venue: VenueDoc | null;
-    try { venue = await venueModel.findById(String(o.venueId)) as unknown as VenueDoc | null; } catch { return 'skipped'; }
-    if (!venue || venue.status === 'archived' || !venue.email) return 'skipped';
-
-    const touchNum = (o.step || 1) + 1;
-    const { subject, html, attachments } = buildFollowUpEmail(venue, o);
-    let sent: { messageId: string };
-    try { sent = await sendMail({ to: venue.email, cc: PITCH_CC, subject, html, attachments }); } catch { return 'skipped'; }
-
-    const followUps = [...(o.followUps || []), { sentAt: new Date(), messageId: sent.messageId, step: touchNum }];
+  // Append a completed touch and reschedule (or finish) the record. Returns
+  // false on a write failure so the caller can report 'skipped'. Shared by the
+  // email and call touch handlers.
+  async recordTouch(o: OutreachDoc, touchNum: number, followUp: FollowUp): Promise<boolean> {
+    const followUps = [...(o.followUps || []), followUp];
     try {
       await this.model.findByIdAndUpdate(String(o._id), {
         step: touchNum,
@@ -539,15 +556,68 @@ class OutreachController extends Controller {
         followUps,
         lastModifiedBy: 'cadence-engine',
       });
-      return 'sent';
-    } catch { return 'skipped'; }
+      return true;
+    } catch { return false; }
   }
 
-  // POST /outreach/advance — cadence tick. Sends every email follow-up that's due
-  // (status 'sent', nextTouchDue <= now), reschedules it, and parks exhausted
-  // sequences as no-response. Meant to be hit on a schedule (Deno Cron, #100).
-  // Reply-detection + call touches arrive with the Google integration (#825); for
-  // now a venue reply is marked by hand via PUT /outreach/:id, which halts it.
+  // EMAIL touch: send the follow-up nudge and record it. Skips a venue with no
+  // address (the pitch needs an inbox; a call touch does not).
+  async doEmailTouch(o: OutreachDoc, venue: VenueDoc, touchNum: number): Promise<'sent' | 'skipped'> {
+    if (!venue.email) return 'skipped';
+    const { subject, html, attachments } = buildFollowUpEmail(venue, o);
+    let sent: { messageId: string };
+    try { sent = await sendMail({ to: venue.email, cc: PITCH_CC, subject, html, attachments }); } catch { return 'skipped'; }
+    const ok = await this.recordTouch(o, touchNum, { sentAt: new Date(), type: 'email', messageId: sent.messageId, step: touchNum });
+    return ok ? 'sent' : 'skipped';
+  }
+
+  // CALL touch (#825): drop an all-day call-task event on Josh's calendar with
+  // the phone script, then record it. The event lands on the touch's scheduled
+  // day, or today if the cron is running it late (a call task in the past is no
+  // use). A missing/failed Google credential just skips the touch (caught here)
+  // rather than crashing the whole tick.
+  async doCallTouch(o: OutreachDoc, venue: VenueDoc, touchNum: number): Promise<'called' | 'skipped'> {
+    const step = o.step || 1;
+    const scheduled = nextTouchDueAfter(step, new Date(o.sentAt || Date.now())) || /* istanbul ignore next */ new Date();
+    const now = new Date();
+    const date = scheduled.getTime() > now.getTime() ? scheduled : now;
+    let event: { id: string };
+    try {
+      event = await createCallTaskEvent({ date, title: buildCallTitle(venue, o), scriptBody: buildCallScript(venue, o) });
+    } catch { return 'skipped'; }
+    const ok = await this.recordTouch(o, touchNum, { sentAt: new Date(), type: 'call', eventId: event.id, step: touchNum });
+    return ok ? 'called' : 'skipped';
+  }
+
+  // Action one due touch for an outreach record, or park it as no-response once
+  // the sequence is exhausted. Branches on the next touch type (#825): EMAIL
+  // sends a follow-up; CALL creates a Google Calendar call task. Returns the
+  // per-record outcome. Helper for advanceCadence.
+  async processDue(o: OutreachDoc): Promise<'sent' | 'called' | 'parked' | 'skipped'> {
+    const step = o.step || 1;
+    if (step >= MAX_STEP) {
+      try {
+        await this.model.findByIdAndUpdate(String(o._id), { status: 'no-response', nextTouchDue: null, lastModifiedBy: 'cadence-engine' });
+        return 'parked';
+      } catch { return 'skipped'; }
+    }
+    let venue: VenueDoc | null;
+    try { venue = await venueModel.findById(String(o.venueId)) as unknown as VenueDoc | null; } catch { return 'skipped'; }
+    if (!venue || venue.status === 'archived') return 'skipped';
+
+    const touch = touchAt(step); // the touch about to be actioned
+    const touchNum = step + 1;
+    if (touch && touch.type === 'call') return this.doCallTouch(o, venue, touchNum);
+    return this.doEmailTouch(o, venue, touchNum);
+  }
+
+  // POST /outreach/advance — cadence tick. Actions every touch that's due
+  // (status 'sent', nextTouchDue <= now): EMAIL touches send a follow-up, CALL
+  // touches create a Google Calendar call task (#825); each is rescheduled, and
+  // exhausted sequences are parked as no-response. Meant to be hit on a schedule
+  // (Deno Cron, #100). Reply-detection (the gmail half of #825) still arrives
+  // later; for now a venue reply is marked by hand via PUT /outreach/:id, which
+  // halts the campaign.
   async advanceCadence(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, ['outreach:edit']);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -556,7 +626,7 @@ class OutreachController extends Controller {
     try { due = await this.model.find({ status: 'sent', nextTouchDue: { $ne: null, $lte: now } }) as unknown as OutreachDoc[]; } catch (e) {
       return res.status(500).json({ message: (e as Error).message });
     }
-    const result = { processed: due.length, sent: 0, parked: 0, skipped: 0 };
+    const result = { processed: due.length, sent: 0, called: 0, parked: 0, skipped: 0 };
     for (const o of due) {
       const outcome = await this.processDue(o); // eslint-disable-line no-await-in-loop
       result[outcome] += 1;

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -17,9 +17,14 @@ const options = {
 // the Gmail thread, backfilled later by the reply-detection job (#825/#100) —
 // nodemailer's SMTP send returns the Message-ID, not the thread id. `followUps`
 // records each later touch in this same campaign (cadence engine, #824).
+// One later touch in the campaign. `type` distinguishes an email follow-up from
+// a CALL touch (#825); a call has no messageId — `eventId` holds the Google
+// Calendar event created for the call task instead.
 const followUpSchema = new Schema({
   sentAt: { type: Date, required: false },
+  type: { type: String, required: false, enum: ['email', 'call'], default: 'email' },
   messageId: { type: String, required: false },
+  eventId: { type: String, required: false },
   step: { type: Number, required: false },
 }, { _id: false });
 
@@ -46,11 +51,10 @@ const outreachSchema = new Schema({
   // Which AI agent or human sent this pitch (#818 `actor` field).
   sentBy: { type: String, required: false, trim: true },
   followUps: { type: [followUpSchema], required: false, default: [] },
-  // Cadence engine (#824). `step` is the touch number already sent (1 = the
-  // pitch). `nextTouchDue` is when the next email follow-up should go out; the
-  // advance endpoint sends everything due and bumps these. Null nextTouchDue =
-  // no more touches scheduled (sequence finished or halted). Call touches
-  // (days 7/18) are added with the Google Calendar work (#825).
+  // Cadence engine (#824/#825). `step` is the touch number already completed
+  // (1 = the pitch). `nextTouchDue` is when the next touch (email or call) is
+  // due; the advance endpoint actions everything due and bumps these. Null
+  // nextTouchDue = no more touches scheduled (sequence finished or halted).
   step: { type: Number, required: false, default: 1 },
   nextTouchDue: { type: Date, required: false, default: null },
   lastModifiedBy: { type: String, required: false },

--- a/test/unit/lib/calendar.spec.ts
+++ b/test/unit/lib/calendar.spec.ts
@@ -1,0 +1,62 @@
+import { createCallTaskEvent } from '#src/lib/calendar.js';
+
+// Exercises the real fetch path (token exchange -> event insert) by stubbing the
+// global fetch, the same way google.spec.ts does — the lib does NOT no-op under
+// test, so this is genuine coverage of the Google calls.
+const okJson = (body: unknown) => ({ ok: true, json: async () => body });
+
+const validInput = () => ({
+  date: new Date('2026-07-15T00:00:00.000Z'),
+  title: 'Call The Bridge re: August',
+  scriptBody: 'Ask for Pat. Phone: 555-1212.',
+});
+
+describe('calendar.ts createCallTaskEvent', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('exchanges the refresh token then inserts an all-day event', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(okJson({ access_token: 'at-123' }))
+      .mockResolvedValueOnce(okJson({ id: 'evt-1', htmlLink: 'https://cal/evt-1' }));
+    vi.stubGlobal('fetch', fetch);
+
+    const res = await createCallTaskEvent(validInput());
+    expect(res).toEqual({ id: 'evt-1', htmlLink: 'https://cal/evt-1' });
+
+    // Token call first, calendar insert second (with the bearer token).
+    expect(fetch.mock.calls[0][0]).toContain('oauth2.googleapis.com/token');
+    const insert = fetch.mock.calls[1];
+    expect(insert[0]).toContain('/calendars/primary/events');
+    expect((insert[1] as any).headers.Authorization).toBe('Bearer at-123');
+    const body = JSON.parse((insert[1] as any).body);
+    expect(body.summary).toBe('Call The Bridge re: August');
+    expect(body.description).toContain('Ask for Pat');
+    // All-day, half-open range: end.date is the day AFTER start.date.
+    expect(body.start.date).toBe('2026-07-15');
+    expect(body.end.date).toBe('2026-07-16');
+  });
+
+  it('throws when the token exchange fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' }));
+    await expect(createCallTaskEvent(validInput())).rejects.toThrow(/token exchange failed/);
+  });
+
+  it('throws when the token response carries no access_token', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(okJson({})));
+    await expect(createCallTaskEvent(validInput())).rejects.toThrow(/no access_token/);
+  });
+
+  it('throws when the calendar insert fails', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(okJson({ access_token: 'at-123' }))
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' }));
+    await expect(createCallTaskEvent(validInput())).rejects.toThrow(/calendar insert failed/);
+  });
+
+  it('throws when the insert returns no event id', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(okJson({ access_token: 'at-123' }))
+      .mockResolvedValueOnce(okJson({})));
+    await expect(createCallTaskEvent(validInput())).rejects.toThrow(/no event id/);
+  });
+});

--- a/test/unit/outreach/cadence.spec.ts
+++ b/test/unit/outreach/cadence.spec.ts
@@ -1,5 +1,5 @@
 import {
-  EMAIL_TOUCH_DAYS, PARK_GRACE_DAYS, MAX_STEP, nextTouchDueAfter,
+  TOUCHES, PARK_GRACE_DAYS, MAX_STEP, nextTouchDueAfter, touchAt,
 } from '#src/model/outreach/cadence.js';
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -7,25 +7,42 @@ const base = new Date('2026-06-01T12:00:00.000Z');
 const daysAfter = (d: Date) => Math.round((d.getTime() - base.getTime()) / DAY);
 
 describe('cadence', () => {
-  it('defaults to the email-only 3-touch schedule', () => {
-    expect(EMAIL_TOUCH_DAYS).toEqual([0, 3, 12]);
-    expect(MAX_STEP).toBe(3);
+  it('is the interleaved 5-touch schedule: emails 0/3/12, calls 7/18', () => {
+    expect(TOUCHES).toEqual([
+      { day: 0, type: 'email' },
+      { day: 3, type: 'email' },
+      { day: 7, type: 'call' },
+      { day: 12, type: 'email' },
+      { day: 18, type: 'call' },
+    ]);
+    expect(MAX_STEP).toBe(5);
     expect(PARK_GRACE_DAYS).toBe(7);
   });
 
-  it('schedules the next email touch after the pitch (step 1 -> day 3)', () => {
+  it('day offsets are strictly increasing so touches fire in order', () => {
+    const days = TOUCHES.map((t) => t.day);
+    expect([...days].sort((a, b) => a - b)).toEqual(days);
+  });
+
+  it('touchAt returns the next touch (step = completed count) and null past the end', () => {
+    expect(touchAt(1)).toEqual({ day: 3, type: 'email' }); // after the pitch
+    expect(touchAt(2)).toEqual({ day: 7, type: 'call' });
+    expect(touchAt(4)).toEqual({ day: 18, type: 'call' });
+    expect(touchAt(5)).toBeNull();
+  });
+
+  it('schedules each touch in turn (step 1->3, 2->7, 3->12, 4->18)', () => {
     expect(daysAfter(nextTouchDueAfter(1, base) as Date)).toBe(3);
+    expect(daysAfter(nextTouchDueAfter(2, base) as Date)).toBe(7);
+    expect(daysAfter(nextTouchDueAfter(3, base) as Date)).toBe(12);
+    expect(daysAfter(nextTouchDueAfter(4, base) as Date)).toBe(18);
   });
 
-  it('schedules the third touch after the second (step 2 -> day 12)', () => {
-    expect(daysAfter(nextTouchDueAfter(2, base) as Date)).toBe(12);
-  });
-
-  it('schedules a park-check after the final touch (step 3 -> last + grace = day 19)', () => {
-    expect(daysAfter(nextTouchDueAfter(3, base) as Date)).toBe(19);
+  it('schedules a park-check after the final touch (step 5 -> last + grace = day 25)', () => {
+    expect(daysAfter(nextTouchDueAfter(5, base) as Date)).toBe(25);
   });
 
   it('returns null once the park check is past (step beyond the schedule)', () => {
-    expect(nextTouchDueAfter(4, base)).toBeNull();
+    expect(nextTouchDueAfter(6, base)).toBeNull();
   });
 });

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -7,6 +7,12 @@ vi.mock('#src/lib/mailer.js', () => ({
   default: { sendMail },
 }));
 
+const createCallTaskEvent = vi.fn(() => Promise.resolve({ id: 'evt-1' }));
+vi.mock('#src/lib/calendar.js', () => ({
+  createCallTaskEvent,
+  default: { createCallTaskEvent },
+}));
+
 const { default: controller } = await import('#src/model/outreach/outreach-controller.js');
 const { default: userModel } = await import('#src/model/user/user-facade.js');
 const { default: venueModel } = await import('#src/model/venue/venue-facade.js');
@@ -56,6 +62,8 @@ describe('Outreach Controller (#844 batch model)', () => {
     payload = undefined;
     sendMail.mockClear();
     sendMail.mockResolvedValue({ messageId: 'mid-123' });
+    createCallTaskEvent.mockClear();
+    createCallTaskEvent.mockResolvedValue({ id: 'evt-1' });
     asAgent();
     (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue()));
     (venueModel as any).find = vi.fn(() => Promise.resolve([]));
@@ -633,31 +641,63 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(status).toBe(403);
     });
 
-    it('sends a due follow-up and reschedules the record', async () => {
+    it('sends a due EMAIL follow-up (step 1 -> day-3 touch) and reschedules', async () => {
       c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
       await c.advanceCadence({ user: 'a' }, resStub);
       expect(status).toBe(200);
-      expect(payload).toMatchObject({ processed: 1, sent: 1, parked: 0, skipped: 0 });
+      expect(payload).toMatchObject({ processed: 1, sent: 1, called: 0, parked: 0, skipped: 0 });
       expect(sendMail).toHaveBeenCalledTimes(1);
+      expect(createCallTaskEvent).not.toHaveBeenCalled();
       const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
       expect(upd.step).toBe(2);
       expect(upd.nextTouchDue).toBeInstanceOf(Date);
       expect(upd.followUps).toHaveLength(1);
-      expect(upd.followUps[0].step).toBe(2);
+      expect(upd.followUps[0]).toMatchObject({ step: 2, type: 'email', messageId: 'mid-123' });
     });
 
-    it('parks an exhausted sequence as no-response (no send)', async () => {
-      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 3 })]));
+    it('creates a CALL task (step 2 -> day-7 touch) instead of an email', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 2 })]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, called: 1, sent: 0, skipped: 0 });
+      expect(createCallTaskEvent).toHaveBeenCalledTimes(1);
+      expect(sendMail).not.toHaveBeenCalled();
+      const arg = (createCallTaskEvent.mock.calls[0] as any)[0];
+      expect(arg.title).toContain('The Spot on Kirk');
+      expect(arg.scriptBody).toContain('Salem, VA');
+      expect(arg.date).toBeInstanceOf(Date);
+      const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
+      expect(upd.step).toBe(3);
+      expect(upd.followUps[0]).toMatchObject({ step: 3, type: 'call', eventId: 'evt-1' });
+    });
+
+    it('skips a CALL touch when the calendar insert fails (no crash)', async () => {
+      createCallTaskEvent.mockRejectedValueOnce(new Error('google down'));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 2 })]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1, called: 0 });
+    });
+
+    it('parks an exhausted sequence as no-response (no touch)', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 5 })]));
       await c.advanceCadence({ user: 'a' }, resStub);
       expect(payload).toMatchObject({ processed: 1, parked: 1 });
       expect(sendMail).not.toHaveBeenCalled();
+      expect(createCallTaskEvent).not.toHaveBeenCalled();
       const upd = (c.model.findByIdAndUpdate as any).mock.calls[0][1];
       expect(upd.status).toBe('no-response');
       expect(upd.nextTouchDue).toBeNull();
     });
 
-    it('skips a record whose venue is archived or has no email', async () => {
+    it('skips a record whose venue is archived', async () => {
       (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1, sent: 0 });
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('skips an EMAIL touch when its venue has no email', async () => {
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ email: '' })));
       c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
       await c.advanceCadence({ user: 'a' }, resStub);
       expect(payload).toMatchObject({ processed: 1, skipped: 1, sent: 0 });
@@ -666,6 +706,27 @@ describe('Outreach Controller (#844 batch model)', () => {
 
     it('skips a record when its follow-up send fails', async () => {
       sendMail.mockRejectedValueOnce(new Error('smtp down'));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1 });
+    });
+
+    it('skips when the reschedule write fails after a send', async () => {
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db write')));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1 });
+    });
+
+    it('skips when parking write fails', async () => {
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db write')));
+      c.model.find = vi.fn(() => Promise.resolve([dueRecord({ step: 5 })]));
+      await c.advanceCadence({ user: 'a' }, resStub);
+      expect(payload).toMatchObject({ processed: 1, skipped: 1, parked: 0 });
+    });
+
+    it('skips when the venue lookup throws', async () => {
+      (venueModel as any).findById = vi.fn(() => Promise.reject(new Error('db')));
       c.model.find = vi.fn(() => Promise.resolve([dueRecord()]));
       await c.advanceCadence({ user: 'a' }, resStub);
       expect(payload).toMatchObject({ processed: 1, skipped: 1 });


### PR DESCRIPTION
Part of #818. Delivers the **Calendar half of #825** — server-side Google Calendar so the cadence engine can autonomously drop **call-task events** on Josh's calendar when a CALL touch comes due.

## What's here
- **`src/lib/calendar.ts` — `createCallTaskEvent({ date, title, scriptBody })`.** Exchanges the stored refresh token for an access token, then inserts an **all-day** event on the `primary` calendar with the phone script as the description. Plain `fetch` (mirrors `auth/google.ts`); **no `googleapis` SDK / no new deps**. Throws on failure so the caller can swallow it.
- **Cadence is now one interleaved 5-touch schedule** (`cadence.ts`): emails day 0/3/12, **calls day 7/18** (was email-only, `MAX_STEP` 3→5). Day offsets strictly increasing so the cron fires touches in order.
- **`advanceCadence` branches on touch type.** EMAIL → follow-up email (unchanged). CALL → `createCallTaskEvent`, recorded on the outreach as a `followUp` with `type: 'call'` + `eventId`, then rescheduled. Result envelope gains a `called` counter. A missing/failed Google credential → that touch is `skipped`, never a crashed tick.
- **Schema:** `followUpSchema` gains `type` (email|call) + `eventId`.

## Credential
Reads the three `GOOGLE_OAUTH_*` env vars (client id, client secret, refresh token) — provisioned on `webjamsalem` 2026-06-23 (dedicated `webjam-outreach-calendar` client, published app = non-expiring token, `calendar.events` scope only).

## Deliberately deferred
The **`gmail.metadata` reply-detection** half (a later design addition to #825) is split to a follow-up issue — it needs a separate restricted-scope re-consent and is independent of the Calendar work.

## Tests
v2.0.36, **320 passing**, coverage **91.39 / 84.42 / 84.14 / 91.97** over the 90/80/80/90 gate. New `test/unit/lib/calendar.spec.ts` (stubs global fetch, real path 100% covered); cadence + advance specs updated for the interleaved schedule and call-touch branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
