### PR TITLE
fix(test): repair 8 TypeScript errors in test specs (tsc fails; breaks downstream e2e)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.37",
+      "version": "2.0.38",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -25,7 +25,7 @@
     "build:front": "./postinstallJaM.sh && rimraf ./JaMmusic/src && rimraf ./JaMmusic/test",
     "postinstall": "npm run rmrf && tsc -p tsconfig.prod.json && npm run copy:assets && npm run build:front",
     "start": "node build/src/index.js",
-    "typecheck": "tsc --noEmit -p tsconfig.prod.json",
+    "typecheck": "tsc --noEmit -p tsconfig.prod.json && tsc --noEmit",
     "cleanup": "rimraf yarn.lock && rimraf package-lock.json && rimraf node_modules && rimraf JaMmusic && rimraf build && rimraf coverage",
     "cleaninstall": "npm install -g npm@latest && npm install -g rimraf && npm run cleanup && npm cache clean --force && npm install",
     "smoketest": "npm run cleanup && npm install --omit=dev",

--- a/test/unit/facebook/index.spec.ts
+++ b/test/unit/facebook/index.spec.ts
@@ -133,7 +133,7 @@ describe('Facebook feed API', () => {
   });
 
   it('updateFacebookCache keeps the last good cache and emails once on a dead token (190)', async () => {
-    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue(undefined);
+    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue({ messageId: 'test' });
     await FacebookToken.create({ pageId: CLC, value: 'PAGE-TOKEN' });
 
     // First a healthy refresh to populate the cache.
@@ -152,7 +152,7 @@ describe('Facebook feed API', () => {
   });
 
   it('re-arms the alert after a successful refresh', async () => {
-    vi.spyOn(mailer, 'sendMail').mockResolvedValue(undefined);
+    vi.spyOn(mailer, 'sendMail').mockResolvedValue({ messageId: 'test' });
     await FacebookToken.create({ pageId: CLC, value: 'PAGE-TOKEN' });
     stubGraph(jsonRes({ error: { code: 190, message: 'expired' } }), jsonRes({ data: [{ id: 'p2' }] }));
     await updateFacebookCache();
@@ -162,7 +162,7 @@ describe('Facebook feed API', () => {
   });
 
   it('ignores non-190 Graph errors without emailing', async () => {
-    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue(undefined);
+    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue({ messageId: 'test' });
     await FacebookToken.create({ pageId: CLC, value: 'PAGE-TOKEN' });
     stubGraph(jsonRes({ error: { code: 4, message: 'rate limited' } }));
     await updateFacebookCache();
@@ -207,7 +207,7 @@ describe('Facebook feed API', () => {
   });
 
   it('names the specific page in the dead-token alert email', async () => {
-    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue(undefined);
+    const mail = vi.spyOn(mailer, 'sendMail').mockResolvedValue({ messageId: 'test' });
     await FacebookToken.create({ pageId: WJ, value: 'WJ-TOKEN' });
     stubGraph(jsonRes({ error: { code: 190, message: 'expired' } }));
     await updateFacebookCache();

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -177,7 +177,7 @@ describe('Outreach Controller (#844 batch model)', () => {
       await c.sendPitch({ user: 'josh', body: body() }, resStub);
       expect(status).toBe(201);
       expect(sendMail).toHaveBeenCalledTimes(1);
-      expect((sendMail.mock.calls[0][0] as any).cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
+      expect((sendMail as any).mock.calls[0][0].cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
       const rec = (c.model.create as any).mock.calls[0][0];
       expect(rec.status).toBe('sent');
       expect(rec.step).toBe(1);
@@ -530,7 +530,7 @@ describe('Outreach Controller (#844 batch model)', () => {
       c.model.findByIdAndUpdate = upd;
       await c.updateOutreach({ user: 'josh', params: { id }, body: { status: 'no-response' } }, resStub);
       expect(status).toBe(200);
-      expect(upd.mock.calls[0][1].nextTouchDue).toBeNull();
+      expect((upd as any).mock.calls[0][1].nextTouchDue).toBeNull();
     });
 
     it('leaves nextTouchDue untouched when no terminal status is set', async () => {
@@ -538,7 +538,7 @@ describe('Outreach Controller (#844 batch model)', () => {
       const upd = vi.fn(() => Promise.resolve({ _id: id }));
       c.model.findByIdAndUpdate = upd;
       await c.updateOutreach({ user: 'josh', params: { id }, body: { gmailThreadId: 't9' } }, resStub);
-      expect(upd.mock.calls[0][1]).not.toHaveProperty('nextTouchDue');
+      expect((upd as any).mock.calls[0][1]).not.toHaveProperty('nextTouchDue');
     });
 
     it('500s when the update throws', async () => {


### PR DESCRIPTION
## Summary
Repairs 8 TypeScript errors in web-jam-back's own test specs that a full `tsc` flags: facebook/index.spec mocked sendMail resolving `undefined` (its return type is now `{messageId}`), and outreach-controller.spec indexed `mock.calls[0][n]` on untyped mocks. These slipped onto main because web-jam-back's CI typecheck used tsconfig.prod.json (src only) and vitest doesn't type-check — so they only surfaced downstream in CollegeLutheran's e2e (which clones web-jam-back main and runs a full `npx tsc`). Also extends the `typecheck` script to run the full `tsc --noEmit` (incl tests) so this class is caught here, at the source.

Closes #872

## How to test locally
From web-jam-back/: `npm run typecheck` (now prod + full incl tests) → expect exit 0; `npx tsc --noEmit` → 0 errors; `npm test` (eslint, jscpd, vitest+coverage) → all pass, coverage over the 90/80/80/90 gate.

## Test evidence
npm run typecheck → exit 0 (tsc -p tsconfig.prod.json && tsc --noEmit, the latter covering tests). npm test green: eslint clean, jscpd ok, full vitest suite passed. Coverage — Statements 91.4%, Branches 84.25%, Functions 84.34%, Lines 91.99% (over the gate).

🤖 Work by Claude Code — Opus 4.8