### PR TITLE
feat(integration): Google Calendar call-tasks (DONE) + Gmail reply-detection (IMAP + AI-suggested venue update)

### DIFF
--- a/docs/gig-outreach-reply-detection.md
+++ b/docs/gig-outreach-reply-detection.md
@@ -1,0 +1,90 @@
+# Gig-outreach reply-detection (Gmail IMAP + Haiku)
+
+Reference: issue [#825](https://github.com/WebJamApps/web-jam-back/issues/825),
+backend PR [#875](https://github.com/WebJamApps/web-jam-back/pull/875). Part of the
+gig-outreach epic [#818](https://github.com/WebJamApps/web-jam-back/issues/818).
+
+## TL;DR
+
+When a venue replies to a booking pitch, the system detects it over **Gmail IMAP**
+(matched precisely by the pitch's RFC `Message-ID`), moves the outreach record to
+`replied` — which **halts the follow-up cadence** — stores a snippet of the reply,
+and asks **Claude Haiku** to *suggest* a venue status update for Josh to
+approve/edit/dismiss. **The AI never writes venue data on its own.**
+
+The feature is **dormant until the env vars below are set**; with them unset every
+piece is a safe no-op (no detection, no AI call).
+
+## One-time manual setup
+
+All on the **same Gmail account that sends the pitches** (`GMAIL_USER`, currently
+`joshua.v.sherman@gmail.com`) — replies land in that mailbox.
+
+1. **IMAP** — already on for personal Gmail (Google removed the enable/disable
+   toggle; the POP/IMAP settings page just shows behaviour options). Nothing to do.
+2. **2-Step Verification** must be on (required for app passwords):
+   <https://myaccount.google.com/signinoptions/twosv>.
+3. **Gmail app password** — <https://myaccount.google.com/apppasswords> → name it
+   `webjam-outreach-imap` → **Create** → copy the 16-character value and **remove
+   the spaces**. Save it in KeePass (shown once).
+4. **Anthropic API key** (paid — needs ≥ $5 of usage credits;
+   classification cost is a fraction of a cent per reply) —
+   <https://console.anthropic.com/settings/keys> → **Create Key** →
+   `webjam-outreach-haiku`. Save it in KeePass.
+5. **Set the config vars on `webjamsalem`** (each `set` restarts the dyno):
+
+   ```sh
+   heroku config:set GMAIL_IMAP_USER="joshua.v.sherman@gmail.com" -a webjamsalem
+   heroku config:set GMAIL_IMAP_APP_PASSWORD="<16 chars, no spaces>" -a webjamsalem
+   heroku config:set ANTHROPIC_API_KEY="sk-ant-..." -a webjamsalem
+   ```
+
+### Environment variables
+
+| Var | Purpose | Without it |
+| --- | --- | --- |
+| `GMAIL_IMAP_USER` | Gmail account to read replies from | IMAP scan is skipped (no detection) |
+| `GMAIL_IMAP_APP_PASSWORD` | Gmail app password for IMAP | IMAP scan is skipped (no detection) |
+| `ANTHROPIC_API_KEY` | Claude Haiku reply classification | replies still detected + cadence halted, but no AI suggestion attached |
+
+IMAP is used deliberately instead of the Gmail API: `gmail.metadata`/`readonly` are
+Google *restricted* scopes that would force a CASA security assessment on the
+published OAuth app. An app password is a separate auth path that sidesteps it.
+
+## Endpoints
+
+| Route | Cap | What it does |
+| --- | --- | --- |
+| `POST /outreach/check-replies` | `outreach:edit` | IMAP scan; matched replies → `replied` (halts cadence) + snippet + Haiku suggestion. Returns `{ checked, matched, classified }`. |
+| `GET /outreach/replies/pending` | any `outreach:*` | The "replies to review" queue: replied records with an unreviewed suggestion. |
+| `POST /outreach/:id/apply-suggestion` | `venue:edit` | Josh approves/edits/dismisses. Writes the venue's `bookingStatus`/`interested` (edited body values win over the AI's), marks the suggestion reviewed. `{ "dismiss": true }` reviews without writing. **The only path that turns a suggestion into a venue write.** |
+
+## The 30-second constraint
+
+`check-replies` runs inside a single Heroku web request, which has a hard **30s
+router timeout (H12)**. To stay under it, `findReplies` (`src/lib/imap-replies.ts`):
+
+- bounds every IMAP search with `SINCE` the earliest active pitch date (Gmail
+  scans only recent mail, not all-time over All Mail), and
+- races the whole scan against a **25s internal deadline**, returning whatever
+  matched so far if Gmail is slow (the next tick re-scans the rest).
+
+## Triggering & the cron
+
+Reply-detection is **not yet wired into the daily cron** — the Deno Cron
+([#100](https://github.com/WebJamApps/web-jam-tools/issues/100), in `web-jam-tools`)
+currently only hits `/outreach/advance`. Until it also calls `/outreach/check-replies`,
+run a scan manually (service token at `~/WebJamApps/web-jam-llms/web-jam-llm.token`):
+
+```sh
+TOKEN=$(cat ~/WebJamApps/web-jam-llms/web-jam-llm.token)
+curl -s -X POST https://webjamsalem.herokuapp.com/outreach/check-replies \
+  -H "Authorization: Bearer $TOKEN"
+curl -s https://webjamsalem.herokuapp.com/outreach/replies/pending \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Remaining for #825
+
+The JaMmusic AdminVenues "Replies to review" UI (consumes `replies/pending` +
+`apply-suggestion`) closes the issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.39",
+      "version": "2.0.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/imap-replies.ts
+++ b/src/lib/imap-replies.ts
@@ -14,7 +14,19 @@ const IMAP_HOST = 'imap.gmail.com';
 // All Mail, so a reply that's been read/archived/deleted-from-inbox still matches.
 const MAILBOX = '[Gmail]/All Mail';
 
-export interface OutreachRef { outreachId: string; messageId: string }
+export interface OutreachRef { outreachId: string; messageId: string; sentAt?: Date }
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The IMAP search is bounded with a SINCE date so Gmail only scans recent mail
+// (a reply can only post-date its pitch) instead of all-time over All Mail —
+// this is what keeps the scan under Heroku's 30s request limit. Use the earliest
+// pitch date minus a 1-day buffer, or 90 days back if no dates are known.
+export function earliestSince(refs: OutreachRef[]): Date {
+  const times = refs.map((r) => r.sentAt).filter(Boolean).map((d) => new Date(d as Date).getTime());
+  if (times.length === 0) return new Date(Date.now() - 90 * DAY_MS);
+  return new Date(Math.min(...times) - DAY_MS);
+}
 export interface ReplyMatch {
   outreachId: string;
   fromAddress: string;
@@ -60,14 +72,23 @@ export function imapEnabled(): boolean {
     && !!process.env.GMAIL_IMAP_APP_PASSWORD;
 }
 
+// Hard ceiling for the whole IMAP scan, comfortably under Heroku's 30s router
+// limit. If Gmail is slow, we return whatever matched so far rather than let the
+// request time out (H12) — the next tick re-scans the rest.
+const SCAN_DEADLINE_MS = 25000;
+
 // Connect to Gmail over IMAP and return one ReplyMatch per outreach record that
-// has a genuine reply. Returns [] (never throws to the caller) when disabled or
-// on a connection failure, so a bad credential degrades the cron tick to a no-op
-// rather than crashing it. The connection/fetch I/O is excluded from coverage;
-// the matching + snippet logic above is unit-tested.
+// has a genuine reply. Each search is bounded by SINCE (earliestSince) so Gmail
+// scans only recent mail, and the whole scan is raced against SCAN_DEADLINE_MS.
+// Returns [] / partial (never throws to the caller) when disabled, on a
+// connection failure, or on the deadline — so a bad credential or a slow mailbox
+// degrades the cron tick to a no-op rather than crashing or timing out the
+// request. The connection/fetch I/O is excluded from coverage; the pure
+// matching/snippet/since helpers above are unit-tested.
 /* istanbul ignore next */
 export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
   if (!imapEnabled() || refs.length === 0) return [];
+  const since = earliestSince(refs);
   const client = new ImapFlow({
     host: IMAP_HOST,
     port: 993,
@@ -76,14 +97,15 @@ export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
     logger: false,
   });
   const matches: ReplyMatch[] = [];
-  try {
+
+  const scan = async (): Promise<void> => {
     await client.connect();
     const lock = await client.getMailboxLock(MAILBOX);
     try {
       for (const ref of refs) {
         if (!ref.messageId) continue;
         // eslint-disable-next-line no-await-in-loop
-        const uids = await client.search(buildReplySearch(ref.messageId), { uid: true });
+        const uids = await client.search({ since, ...buildReplySearch(ref.messageId) }, { uid: true });
         if (!uids || uids.length === 0) continue;
         // eslint-disable-next-line no-await-in-loop
         const msg = await client.fetchOne(String(uids[uids.length - 1]), { envelope: true, source: true }, { uid: true });
@@ -102,8 +124,19 @@ export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
       lock.release();
     }
     await client.logout();
+  };
+
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<void>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`imap scan exceeded ${SCAN_DEADLINE_MS}ms`)), SCAN_DEADLINE_MS);
+  });
+  try {
+    await Promise.race([scan(), deadline]);
   } catch (e) {
-    debug('imap reply check failed: %s', (e as Error).message);
+    debug('imap reply check stopped: %s', (e as Error).message);
+    try { await client.close(); } catch { /* already closing */ }
+  } finally {
+    if (timer) clearTimeout(timer);
   }
   return matches;
 }

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -671,7 +671,9 @@ class OutreachController extends Controller {
     try {
       active = await this.model.find({ status: 'sent', messageId: { $nin: [null, ''] } }) as unknown as OutreachDoc[];
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
-    const refs = active.map((o) => ({ outreachId: String(o._id), messageId: (o as { messageId?: string }).messageId || '' }));
+    const refs = active.map((o) => ({
+      outreachId: String(o._id), messageId: (o as { messageId?: string }).messageId || '', sentAt: o.sentAt,
+    }));
     const matches = await findReplies(refs);
     const result = { checked: refs.length, matched: 0, classified: 0 };
     for (const m of matches) {

--- a/test/unit/lib/imap-replies.spec.ts
+++ b/test/unit/lib/imap-replies.spec.ts
@@ -1,5 +1,5 @@
 import {
-  bareMessageId, buildReplySearch, snippetFromBody, imapEnabled, findReplies,
+  bareMessageId, buildReplySearch, snippetFromBody, imapEnabled, findReplies, earliestSince,
 } from '#src/lib/imap-replies.js';
 
 describe('imap-replies', () => {
@@ -36,6 +36,21 @@ describe('imap-replies', () => {
     });
     it('returns empty for empty input', () => {
       expect(snippetFromBody('')).toBe('');
+    });
+  });
+
+  describe('earliestSince', () => {
+    it('returns the earliest pitch date minus a 1-day buffer', () => {
+      const refs = [
+        { outreachId: 'a', messageId: '<a>', sentAt: new Date('2026-06-10T00:00:00Z') },
+        { outreachId: 'b', messageId: '<b>', sentAt: new Date('2026-06-20T00:00:00Z') },
+      ];
+      expect(earliestSince(refs).toISOString()).toBe('2026-06-09T00:00:00.000Z');
+    });
+    it('falls back to ~90 days ago when no dates are known', () => {
+      const since = earliestSince([{ outreachId: 'a', messageId: '<a>' }]).getTime();
+      const ninetyDaysAgo = Date.now() - 90 * 24 * 60 * 60 * 1000;
+      expect(Math.abs(since - ninetyDaysAgo)).toBeLessThan(5000);
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes the prod H12 timeout found when enabling #825, and documents the setup.
- **Bound the IMAP scan**: `findReplies` now adds `SINCE` (earliest active-pitch date − 1 day) to every Gmail search so it scans only recent mail instead of all-time over All Mail, and races the whole scan against a **25s internal deadline** — returning whatever matched so far rather than tripping Heroku's 30s router limit (`H12`). Root cause: 7 unbounded HEADER searches over All Mail + full-message fetches blew past 30s.
- `checkReplies` passes each record's `sentAt` so the search can be bounded.
- **New `docs/gig-outreach-reply-detection.md`**: one-time setup (Gmail IMAP / app password / Anthropic key), the three `heroku config:set` vars, the endpoints, the 30s constraint, and how to trigger a scan manually (cron wiring still pending in web-jam-tools).

Part of #825

## How to test locally
Run:
```sh
npm test
npm run typecheck
```
Expect: lint + jscpd clean, all tests pass, coverage over the 90/90/80/80 gate, typecheck green.

## Test evidence
```
Test Files  27 passed (27)
     Tests  364 passed (364)
Coverage: 91.58 stmts / 84.71 branch / 84.33 funcs / 92.13 lines  → over gate
imap-replies.ts 100/87.5/100/100
npm run typecheck → exit 0
```

🤖 Work by Claude Code — Opus 4.8