### PR TITLE
feat(integration): Google Calendar call-tasks (DONE) + Gmail reply-detection (IMAP + AI-suggested venue update)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.41",
+      "version": "2.0.42",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/imap-replies.ts
+++ b/src/lib/imap-replies.ts
@@ -24,6 +24,20 @@ export interface ReplyMatch {
   gmailThreadId?: string;
 }
 
+// Minimal interface covering the ImapFlow methods findReplies actually uses.
+// Allows injection of a fake client in tests without pulling in the real network.
+export interface ImapClientLike {
+  connect(): Promise<unknown>;
+  getMailboxLock(mailbox: string): Promise<{ release: () => void }>;
+  search(query: unknown, opts: { uid: boolean }): Promise<number[] | false>;
+  fetchOne(uid: string, query: unknown, opts: { uid: boolean }): Promise<{
+    envelope?: { messageId?: string; from?: { address?: string }[]; date?: Date };
+    source?: Buffer | string; threadId?: string | number;
+  } | false>;
+  logout(): Promise<unknown>;
+  close(): void | Promise<unknown>;
+}
+
 // IMAP HEADER search does a substring match, so strip the angle brackets the
 // Message-ID is stored/sent with (`<abc@mail>` → `abc@mail`) for a clean match.
 export function bareMessageId(messageId: string): string {
@@ -98,6 +112,19 @@ export function isSelfOrPitch(
   return false;
 }
 
+// True if a message is an automated bounce / auto-reply rather than a human venue
+// reply — these legitimately reference our pitch but must NOT count as replies.
+export function isAutoOrBounce(fromAddress: string, rawSource: string): boolean {
+  const from = (fromAddress || '').toLowerCase();
+  if (from.includes('mailer-daemon@') || from.includes('postmaster@')) return true;
+  const localPart = from.split('@')[0];
+  if (localPart.startsWith('no-reply') || localPart.startsWith('noreply')) return true;
+  const autoSubmitted = extractHeader(rawSource, 'auto-submitted').toLowerCase();
+  if (autoSubmitted && autoSubmitted !== 'no') return true;
+  if (extractHeader(rawSource, 'content-type').toLowerCase().includes('multipart/report')) return true;
+  return false;
+}
+
 // The message body = everything after the first blank line (drop the RFC822
 // header block, which would otherwise be classified as the "reply" text).
 export function bodyFromSource(rawSource: string): string {
@@ -137,27 +164,28 @@ const SCAN_DEADLINE_MS = 25000;
 // Connect to Gmail over IMAP and return one ReplyMatch per outreach record that
 // has a GENUINE venue reply. One bounded batched search finds candidate replies
 // to any pitch; each candidate is then verified — not our own pitch/CC copy
-// (isSelfOrPitch), and actually referencing one of our pitches (referencedPitchId)
-// — before its body snippet is taken. The whole scan is raced against a 25s
-// deadline. Returns [] / partial (never throws) when disabled, on a connection
-// failure, or on the deadline. The connection/fetch I/O is excluded from
-// coverage; the pure parse/match/guard helpers above are unit-tested.
-/* istanbul ignore next */
-export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
-  if (!imapEnabled() || refs.length === 0) return [];
+// (isSelfOrPitch), not a bounce/auto-reply (isAutoOrBounce), and actually
+// referencing one of our pitches (referencedPitchId) — before its body snippet
+// is taken. The whole scan is raced against a 25s deadline. Returns [] / partial
+// (never throws) when disabled, on a connection failure, or on the deadline.
+// An optional makeClient factory injects a fake IMAP client in tests; when
+// present the imapEnabled() env gate is skipped so tests never hit Gmail.
+export async function findReplies(refs: OutreachRef[], makeClient?: () => ImapClientLike): Promise<ReplyMatch[]> {
+  const injected = makeClient !== undefined;
+  if ((!injected && !imapEnabled()) || refs.length === 0) return [];
   const idToOutreach = new Map<string, string>();
   for (const r of refs) { const b = bareMessageId(r.messageId); if (b) idToOutreach.set(b, r.outreachId); }
   const bareIds = [...idToOutreach.keys()];
   const search = buildBatchSearch(bareIds, earliestSince(refs));
   if (!search) return [];
   const selfAddress = (process.env.GMAIL_IMAP_USER || '').toLowerCase();
-  const client = new ImapFlow({
+  const client = makeClient ? makeClient() : (new ImapFlow({
     host: IMAP_HOST,
     port: 993,
     secure: true,
     auth: { user: process.env.GMAIL_IMAP_USER || '', pass: process.env.GMAIL_IMAP_APP_PASSWORD || '' },
     logger: false,
-  });
+  }) as unknown as ImapClientLike);
   // Keyed by outreachId so a venue that replied more than once collapses to its
   // latest reply (UIDs ascend, so a later one overwrites).
   const byOutreach = new Map<string, ReplyMatch>();
@@ -174,6 +202,7 @@ export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
         const raw = msg.source.toString();
         const from = msg.envelope?.from?.[0]?.address || '';
         if (isSelfOrPitch(msg.envelope?.messageId, from, selfAddress, bareIds)) continue;
+        if (isAutoOrBounce(from, raw)) continue;
         const pitchId = referencedPitchId(raw, bareIds);
         const outreachId = pitchId ? idToOutreach.get(pitchId) : undefined;
         if (!outreachId) continue;
@@ -208,5 +237,5 @@ export async function findReplies(refs: OutreachRef[]): Promise<ReplyMatch[]> {
 
 export default {
   bareMessageId, earliestSince, buildBatchSearch, extractHeader, referencedPitchId,
-  isSelfOrPitch, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
+  isSelfOrPitch, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
 };

--- a/test/unit/lib/imap-replies.spec.ts
+++ b/test/unit/lib/imap-replies.spec.ts
@@ -1,6 +1,7 @@
 import {
   bareMessageId, earliestSince, buildBatchSearch, extractHeader, referencedPitchId,
-  isSelfOrPitch, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
+  isSelfOrPitch, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
+  type ImapClientLike,
 } from '#src/lib/imap-replies.js';
 
 const RAW = [
@@ -14,6 +15,104 @@ const RAW = [
   '> On Mon, Josh wrote:',
   '> the original pitch',
 ].join('\r\n');
+
+// ---------------------------------------------------------------------------
+// Fixture messages for FakeImapClient
+// ---------------------------------------------------------------------------
+
+// Fixture 1 — genuine venue reply: should match outreach o1.
+const FIXTURE_REPLY_SOURCE = [
+  'From: booking@thevenue.com',
+  'Message-ID: <reply-1@thevenue.com>',
+  'In-Reply-To: <pitch-1@gmail.com>',
+  'References: <pitch-1@gmail.com>',
+  'Subject: Re: gig inquiry',
+  '',
+  "Yes we'd love to host you!",
+].join('\r\n');
+
+// Fixture 2 — bounce: mailer-daemon + multipart/report. Must NOT match.
+const FIXTURE_BOUNCE_SOURCE = [
+  'From: mailer-daemon@googlemail.com',
+  'Message-ID: <6a3afcb1.fcfc1c8a.266c68.5881.GMR@mx.google.com>',
+  'Subject: Delivery Status Notification (Failure)',
+  'In-Reply-To: <pitch-1@gmail.com>',
+  'Content-Type: multipart/report; report-type=delivery-status',
+  '',
+  'Delivery failure notice.',
+].join('\r\n');
+
+// Fixture 3 — self/pitch copy: Message-ID equals the pitch id. Must NOT match.
+const FIXTURE_SELF_SOURCE = [
+  'From: joshua.v.sherman@gmail.com',
+  'Message-ID: <pitch-1@gmail.com>',
+  'Subject: gig inquiry',
+  '',
+  'Original pitch text.',
+].join('\r\n');
+
+type FakeMsg = {
+  uid: number;
+  envelope: { messageId?: string; from?: { address?: string }[]; date?: Date };
+  source: string;
+  threadId?: string | number;
+};
+
+class FakeImapClient implements ImapClientLike {
+  constructor(private readonly msgs: FakeMsg[]) {}
+  async connect() { return undefined; }
+  async getMailboxLock(_mailbox: string) { return { release() {} }; }
+  async search(_query: unknown, _opts: { uid: boolean }) {
+    return this.msgs.map((m) => m.uid);
+  }
+  async fetchOne(uid: string, _query: unknown, _opts: { uid: boolean }) {
+    const msg = this.msgs.find((m) => m.uid === Number(uid));
+    return msg ?? false;
+  }
+  async logout() { return undefined; }
+  close() { return undefined; }
+}
+
+function makeFake(msgs: FakeMsg[]): FakeImapClient {
+  return new FakeImapClient(msgs);
+}
+
+const FAKE_MSGS: FakeMsg[] = [
+  {
+    uid: 1,
+    envelope: {
+      messageId: '<reply-1@thevenue.com>',
+      from: [{ address: 'booking@thevenue.com' }],
+      date: new Date('2026-06-21T10:00:00Z'),
+    },
+    source: FIXTURE_REPLY_SOURCE,
+    threadId: 'thread-abc',
+  },
+  {
+    uid: 2,
+    envelope: {
+      messageId: '<6a3afcb1.fcfc1c8a.266c68.5881.GMR@mx.google.com>',
+      from: [{ address: 'mailer-daemon@googlemail.com' }],
+      date: new Date('2026-06-21T11:00:00Z'),
+    },
+    source: FIXTURE_BOUNCE_SOURCE,
+  },
+  {
+    uid: 3,
+    envelope: {
+      messageId: '<pitch-1@gmail.com>',
+      from: [{ address: 'joshua.v.sherman@gmail.com' }],
+      date: new Date('2026-06-20T09:00:00Z'),
+    },
+    source: FIXTURE_SELF_SOURCE,
+  },
+];
+
+const PITCH_REFS = [{ outreachId: 'o1', messageId: '<pitch-1@gmail.com>', sentAt: new Date('2026-06-20') }];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe('imap-replies', () => {
   describe('bareMessageId', () => {
@@ -87,6 +186,41 @@ describe('imap-replies', () => {
     });
   });
 
+  describe('isAutoOrBounce', () => {
+    it('detects mailer-daemon sender', () => {
+      expect(isAutoOrBounce('mailer-daemon@googlemail.com', '')).toBe(true);
+    });
+    it('detects postmaster sender', () => {
+      expect(isAutoOrBounce('postmaster@example.com', '')).toBe(true);
+    });
+    it('detects no-reply local-part', () => {
+      expect(isAutoOrBounce('no-reply@domain.com', '')).toBe(true);
+    });
+    it('detects noreply local-part', () => {
+      expect(isAutoOrBounce('noreply@domain.com', '')).toBe(true);
+    });
+    it('detects Auto-Submitted: auto-generated header', () => {
+      const raw = 'Auto-Submitted: auto-generated\r\n\r\nbody';
+      expect(isAutoOrBounce('system@domain.com', raw)).toBe(true);
+    });
+    it('detects Auto-Submitted: auto-replied header', () => {
+      const raw = 'Auto-Submitted: auto-replied\r\n\r\nbody';
+      expect(isAutoOrBounce('system@domain.com', raw)).toBe(true);
+    });
+    it('does not flag Auto-Submitted: no', () => {
+      const raw = 'Auto-Submitted: no\r\n\r\nbody';
+      expect(isAutoOrBounce('booking@venue.com', raw)).toBe(false);
+    });
+    it('detects multipart/report content-type (delivery-status report)', () => {
+      const raw = 'Content-Type: multipart/report; report-type=delivery-status\r\n\r\nbody';
+      expect(isAutoOrBounce('system@domain.com', raw)).toBe(true);
+    });
+    it('returns false for a normal human reply', () => {
+      const raw = 'Content-Type: text/plain\r\n\r\nHey, we would love to book you!';
+      expect(isAutoOrBounce('booking@venue.com', raw)).toBe(false);
+    });
+  });
+
   describe('bodyFromSource', () => {
     it('drops the header block, keeping the body after the first blank line', () => {
       expect(bodyFromSource(RAW).startsWith('Yes we would love to host you!')).toBe(true);
@@ -107,10 +241,74 @@ describe('imap-replies', () => {
     });
   });
 
-  describe('imapEnabled / findReplies', () => {
+  describe('imapEnabled / findReplies (no client)', () => {
     it('is disabled under test and findReplies is a no-op', async () => {
       expect(imapEnabled()).toBe(false);
       await expect(findReplies([{ outreachId: 'o1', messageId: '<m1@x>' }])).resolves.toEqual([]);
+    });
+  });
+
+  describe('findReplies (via FakeImapClient)', () => {
+    it('returns only the genuine reply, filtering out bounce and self-copy', async () => {
+      const fake = makeFake(FAKE_MSGS);
+      const result = await findReplies(PITCH_REFS, () => fake);
+      expect(result).toHaveLength(1);
+      expect(result[0].outreachId).toBe('o1');
+      expect(result[0].fromAddress).toBe('booking@thevenue.com');
+      expect(result[0].snippet).toContain("Yes we'd love to host you");
+      expect(result[0].gmailThreadId).toBe('thread-abc');
+    });
+
+    it('returns [] when refs is empty (even with injected client)', async () => {
+      await expect(findReplies([], () => makeFake([]))).resolves.toEqual([]);
+    });
+
+    it('returns [] when all pitch messageIds are empty (no searchable ids)', async () => {
+      const refs = [{ outreachId: 'o1', messageId: '' }];
+      await expect(findReplies(refs, () => makeFake([]))).resolves.toEqual([]);
+    });
+
+    it('skips messages that have no source', async () => {
+      const noSource: FakeMsg = {
+        uid: 10,
+        envelope: {
+          messageId: '<no-source@x>',
+          from: [{ address: 'booking@thevenue.com' }],
+        },
+        source: '',
+      };
+      const result = await findReplies(PITCH_REFS, () => makeFake([noSource]));
+      expect(result).toEqual([]);
+    });
+
+    it('collapses multiple replies from same outreach to the latest (highest uid)', async () => {
+      const first: FakeMsg = {
+        uid: 1,
+        envelope: {
+          messageId: '<first-reply@thevenue.com>',
+          from: [{ address: 'booking@thevenue.com' }],
+          date: new Date('2026-06-21T10:00:00Z'),
+        },
+        source: FIXTURE_REPLY_SOURCE,
+      };
+      const second: FakeMsg = {
+        uid: 2,
+        envelope: {
+          messageId: '<second-reply@thevenue.com>',
+          from: [{ address: 'booking@thevenue.com' }],
+          date: new Date('2026-06-22T10:00:00Z'),
+        },
+        source: [
+          'From: booking@thevenue.com',
+          'Message-ID: <second-reply@thevenue.com>',
+          'In-Reply-To: <pitch-1@gmail.com>',
+          '',
+          'Following up — still interested!',
+        ].join('\r\n'),
+      };
+      const result = await findReplies(PITCH_REFS, () => makeFake([first, second]));
+      expect(result).toHaveLength(1);
+      expect(result[0].snippet).toContain('Following up');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Bounce/auto-reply exclusion via new isAutoOrBounce() helper (mailer-daemon/postmaster senders, no-reply local-parts, Auto-Submitted headers, multipart/report Content-Type)
- Injectable ImapClientLike interface added; findReplies() accepts optional makeClient factory so tests can inject a fake client; istanbul-ignore removed from findReplies()
- Fixture-driven tests with FakeImapClient covering genuine reply (matches), bounce (excluded), and self-copy (excluded). Direct unit tests for isAutoOrBounce() covering all four detection paths.
- Part of #825.

Part of #825

## How to test locally
- npm test (eslint + jscpd + vitest with coverage gate 90/90/80/80)
- npm run typecheck (tsc --noEmit over src and tests)

## Test evidence
27 test files, 386 tests — all passed.
Coverage: Statements 91.78% / Branches 84.22% / Functions 84.61% / Lines 92.41% — all above gates.
imap-replies.ts specifically: Stmts 95.72% / Branch 81.13% / Funcs 94.11% / Lines 97.77%.
npm run typecheck exited 0.

🤖 Work by Claude Code — Sonnet 4.6