### PR TITLE
feat(artist): backend support for timshermanmusic.com (#885)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,8 @@ FB_PAGE_ID=202368653220334
 # display name is used in the dead-token alert email. Add WebJamLLC's page id.
 FB_PAGES={"202368653220334":"CollegeLutheran","365007513885497":"WebJamLLC"}
 AUTH_ROLES={"song":["userType1","userType2"],"book":["userType1","userType2"],"user":["userType1", "userType2"],"facebook":["Developer","clc-admin","JaM-admin"]}
+ArtistAdmins={"tim@example.com":"tim"}
+InquiryRecipients={"tim":"booking@example.com"}
+TimGoogleClientId=
+TimGoogleClientSecret=
 APP_NAME=Example

--- a/README.md
+++ b/README.md
@@ -181,6 +181,19 @@ These live in the **Web Jam LLC** Meta app (developers.facebook.com), not in cod
 - **Who can use "Reconnect Facebook":** because the app is in Development mode, only users with a **role on the app** (Admin / Developer / Tester) can complete `FB.login`. To let someone reconnect their own page (e.g. the CLC admin), add them under **App Roles → Roles → Testers**; they must also be an admin of that Facebook page.
 - **Consent dialog reuse:** `FB.login` is called with `auth_type: 'rerequest'` so the page picker shows every time. Without it Facebook offers *"continue with previous settings"* and silently reuses the last grant — which is how reconnecting one page can leave the other ungranted and 400 the next exchange (`page not found in /me/accounts`). Still **keep both pages checked** each time (see "Reconnecting a feed" above).
 
+### Artist-scoping env vars (#885)
+
+Powers timshermanmusic.com login and booking integrations. All four must be set on Heroku (webjamsalem) before timshermanmusic.com login and booking inquiry routing goes live.
+
+| Env var | Purpose | Example |
+|---------|---------|---------|
+| `ArtistAdmins` | JSON map of lower-cased login email → artist slug. A matching email is provisioned at login as an artist-scoped admin (`userType: artist-admin`). Unmatched emails are untouched. | `{"tim@example.com":"tim"}` |
+| `InquiryRecipients` | JSON map of artist slug → booking email. Routes contact/booking inquiries for that artist; unmapped artists fall back to the default JaMmusic recipients. | `{"tim":"booking@example.com"}` |
+| `TimGoogleClientId` | Google OAuth client ID for timshermanmusic.com login (its own GCP project). | (obtain from GCP Console) |
+| `TimGoogleClientSecret` | Google OAuth client secret for timshermanmusic.com login. **Secret — server-side only.** | (obtain from GCP Console) |
+
+Set these the same way as the Facebook vars above (Heroku dashboard Config Vars or `heroku config:set ... -a webjamsalem`).
+
 ## Test
 
 **`npm test`** runs the tests and generates a coverage report.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.43",
+      "version": "2.0.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -10,6 +10,9 @@ const debug = Debug('web-jam-back:authUtils');
 export interface AuthRequest extends Request {
   user?: string;
   userType?: string;
+  // Artist slug an artist-scoped admin owns (web-jam-back#885). Undefined for
+  // super-admins and ordinary users.
+  userArtist?: string;
 }
 
 export interface EmailCheckRequest {
@@ -20,6 +23,7 @@ export interface EmailCheckRequest {
 
 interface UserDoc {
   userType?: string;
+  artist?: string;
 }
 
 interface JwtPayload {
@@ -37,6 +41,7 @@ const findUserById = async (req: AuthRequest): Promise<void> => {
     throw new Error(`token does not match any existing user, ${e.message}`);
   }
   req.userType = myUser ? myUser.userType : 'none';
+  req.userArtist = myUser ? myUser.artist : undefined;
   debug(req.userType);
   debug(req.baseUrl);
   const route = req.baseUrl.split('/')[1] || '';

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -14,6 +14,15 @@ export interface GoogleAuthenticateResponse {
   names: { displayName: string }[];
 }
 
+// Pick the OAuth client secret that pairs with the client the login came from
+// (#885). timshermanmusic.com uses its own GCP OAuth client, so its code-for-
+// token exchange needs a DIFFERENT secret than JaMmusic's. Any client id other
+// than Tim's falls back to the original secret — JaMmusic behaviour unchanged.
+function clientSecretFor(clientId: string | undefined): string {
+  if (clientId && clientId === process.env.TimGoogleClientId) return process.env.TimGoogleClientSecret || '';
+  return process.env.GoogleClientSecret || '';
+}
+
 async function authenticate(req: { body: { redirectUri: string; code: string; clientId: string; }; }): Promise<GoogleAuthenticateResponse> {
   const reUri = req.body.redirectUri;
   let tokenBody: GoogleTokenResponse;
@@ -21,7 +30,7 @@ async function authenticate(req: { body: { redirectUri: string; code: string; cl
   const params = new URLSearchParams({
     code: req.body.code,
     client_id: req.body.clientId,
-    client_secret: process.env.GoogleClientSecret || '',
+    client_secret: clientSecretFor(req.body.clientId),
     redirect_uri: reUri,
     grant_type: 'authorization_code',
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import morgan from 'morgan';
 import cors from 'cors';
 import enforce from 'express-sslify';
 import utils from './lib/utils.js';
+import { makeCorsOptions } from './lib/cors.js';
 import ReadCSV from './ReadCSV/index.js';
 import routes from './routes.js';
 import songData from './model/song/reset-song.js';
@@ -29,11 +30,9 @@ process.on('unhandledRejection', (reason) => {
   console.error('[unhandledRejection]', reason); // eslint-disable-line no-console
 });
 const readCsv = new ReadCSV();
-const corsOptions = {
-  origin: JSON.parse(process.env.AllowUrl || /* istanbul ignore next */'{}').urls,
-  credentials: true,
-  optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
-};
+// Allow-list built in lib/cors.ts: the AllowUrl env origins (JaMmusic +
+// CollegeLutheran) plus timshermanmusic.com and its *.pages.dev previews (#885).
+const corsOptions = makeCorsOptions();
 const app = express();
 
 /* istanbul ignore next */

--- a/src/lib/artist-controller.ts
+++ b/src/lib/artist-controller.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from 'express';
+import Controller from './controller.js';
+import type { AuthRequest } from '../auth/authUtils.js';
+import { DEFAULT_ARTIST, normalizeArtist, artistListFilter } from './artist.js';
+
+// Base controller for collections shared across artists/tenants (#885): gigs and
+// the `book` collection (JaMmusic slideshow photos + per-artist bio/page-content).
+// It layers artist scoping onto the generic CRUD controller:
+//   - reads are filtered by the `?artist=` query (legacy field-less records read
+//     as the default artist), so nothing an existing front-end sees changes;
+//   - writes stamp the record's artist and stop an artist-SCOPED admin from
+//     touching another artist's records.
+//
+// Who is "scoped": any user whose account carries an `artist` slug (set at login
+// from the ArtistAdmins config, e.g. Tim). Josh and every legacy account have no
+// artist slug, so they are UNSCOPED — their pre-#885 write behaviour is
+// unchanged. Coarse route access is still governed by the existing AUTH_ROLES
+// guard; this only adds per-record ownership on top.
+type AnyDoc = Record<string, unknown>;
+
+class ArtistController extends Controller {
+  // The single artist the caller is scoped to, or null (unscoped: Josh / ordinary
+  // accounts). Public GETs run without auth, so this is null there too.
+  scopedArtist(req: Request): string | null { // eslint-disable-line class-methods-use-this
+    const artist = (req as AuthRequest).userArtist;
+    return typeof artist === 'string' && artist ? artist : null;
+  }
+
+  // 403 (returns false) when a scoped admin targets a record outside their
+  // artist, or tries to move a record to another artist. Otherwise true.
+  // eslint-disable-next-line class-methods-use-this
+  private guardScopedArtist(req: Request, res: Response, scope: string, recordArtist: unknown): boolean {
+    const owns = normalizeArtist(recordArtist) === scope;
+    const bodyArtist = (req.body as AnyDoc)?.artist;
+    const keepsArtist = bodyArtist === undefined || normalizeArtist(bodyArtist) === scope;
+    if (owns && keepsArtist) return true;
+    res.status(403).json({ message: 'not authorized for this artist' });
+    return false;
+  }
+
+  // Public list, scoped by ?artist=.
+  async find(req: Request, res: Response): Promise<unknown> {
+    let collection;
+    try { collection = await this.model.find(artistListFilter(req.query as AnyDoc)); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    return res.status(200).json(collection);
+  }
+
+  // Public single fetch (e.g. GET /book/one for a bio doc), scoped by ?artist=.
+  async findOne(req: Request, res: Response): Promise<unknown> {
+    let doc;
+    try { doc = await this.model.findOne(artistListFilter(req.query as AnyDoc)); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!doc || doc._id === null || doc._id === undefined) return res.status(400).json({ message: 'invalid request' });
+    return res.status(200).json(doc);
+  }
+
+  // Stamp the record's artist: forced to a scoped admin's artist, otherwise the
+  // (unscoped) caller may pass one, defaulting to the original artist.
+  async create(req: Request, res: Response): Promise<unknown> {
+    const scope = this.scopedArtist(req);
+    (req.body as AnyDoc).artist = scope || normalizeArtist((req.body as AnyDoc).artist);
+    return super.create(req, res);
+  }
+
+  async findByIdAndUpdate(req: Request<{ id: string }>, res: Response): Promise<unknown> {
+    const scope = this.scopedArtist(req);
+    if (scope) {
+      const existing = await this.model.findById(req.params.id).catch(() => null);
+      if (!this.guardScopedArtist(req, res, scope, existing?.artist)) return undefined;
+    }
+    return super.findByIdAndUpdate(req, res);
+  }
+
+  async findByIdAndDelete(req: Request<{ id: string }>, res: Response): Promise<unknown> {
+    const scope = this.scopedArtist(req);
+    if (scope) {
+      const existing = await this.model.findById(req.params.id).catch(() => null);
+      if (!this.guardScopedArtist(req, res, scope, existing?.artist)) return undefined;
+    }
+    return super.findByIdAndDelete(req, res);
+  }
+
+  // Update-by-query (e.g. PUT /book/one). Scope the match to the caller's artist
+  // and stamp it on the write so a scoped admin can only edit their own doc.
+  async findOneAndUpdate(req: Request, res: Response): Promise<unknown> {
+    const scope = this.scopedArtist(req);
+    const query = scope
+      ? { ...(req.query as AnyDoc), artist: scope }
+      : artistListFilter(req.query as AnyDoc);
+    if (scope) (req.body as AnyDoc).artist = scope;
+    else if ((req.body as AnyDoc).artist !== undefined) (req.body as AnyDoc).artist = normalizeArtist((req.body as AnyDoc).artist);
+    let updated;
+    try { updated = await this.model.findOneAndUpdate(query, req.body); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (updated === null || updated === undefined) return res.status(400).json({ message: 'invalid request' });
+    return res.status(200).json(updated);
+  }
+}
+
+export { DEFAULT_ARTIST };
+export default ArtistController;

--- a/src/lib/artist.ts
+++ b/src/lib/artist.ts
@@ -1,0 +1,50 @@
+// Multi-artist (multi-tenant) scoping shared by the collections that more than
+// one front-end reads from the same Mongo database (web-jam-back#885).
+//
+// Background: this backend originally served only the JaMmusic front-end. A new
+// front-end (timshermanmusic.com) now reuses it. To keep both artists' data in
+// the same collections without leaking across sites, records carry an `artist`
+// slug. EVERY record that predates #885 has NO `artist` field, so those are
+// treated as the original JaMmusic artist — existing behaviour is unchanged.
+
+// The slug the pre-#885 (field-less) records belong to.
+export const DEFAULT_ARTIST = 'jammusic';
+
+// Coerce a possibly-missing/blank artist value to a concrete slug.
+export function normalizeArtist(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : DEFAULT_ARTIST;
+}
+
+// Build the Mongo filter for a PUBLIC list/find, given the request query.
+// - `?artist=tim` (any non-default slug) -> exactly that artist's records.
+// - no `artist` param, or `?artist=jammusic` -> the original artist, i.e. every
+//   record whose `artist` is absent/null OR explicitly `jammusic`. This is what
+//   makes the change backward compatible: legacy records still show up.
+// Any other query params (e.g. ?type=paperback) are preserved.
+export function artistListFilter(query: Record<string, unknown>): Record<string, unknown> {
+  const { artist, ...rest } = query || {};
+  const requested = typeof artist === 'string' && artist.trim() ? artist.trim() : DEFAULT_ARTIST;
+  if (requested !== DEFAULT_ARTIST) return { ...rest, artist: requested };
+  return {
+    ...rest,
+    $or: [{ artist: { $exists: false } }, { artist: null }, { artist: DEFAULT_ARTIST }],
+  };
+}
+
+// Login-time role grant driven by the `ArtistAdmins` env var — a JSON map of
+// lower-cased email -> artist slug, e.g. {"tim@example.com":"tim"}. A matched
+// email is provisioned as an artist-scoped admin (userType `artist-admin`,
+// `artist` = the slug). Josh sets Tim's real email here; unmatched emails (incl.
+// Josh's own Developer account) get no grant and are left untouched.
+export function artistGrantForEmail(email: string): { userType: string; artist: string } | null {
+  let map: Record<string, string>;
+  try { map = JSON.parse(process.env.ArtistAdmins || '{}') as Record<string, string>; } catch { return null; }
+  const key = (email || '').toLowerCase();
+  // eslint-disable-next-line security/detect-object-injection
+  const slug = map[key];
+  return typeof slug === 'string' && slug ? { userType: 'artist-admin', artist: slug } : null;
+}
+
+export default {
+  DEFAULT_ARTIST, normalizeArtist, artistListFilter, artistGrantForEmail,
+};

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -1,0 +1,46 @@
+// CORS allow-list (web-jam-back#885).
+//
+// Historically the allow-list was a static array parsed from the `AllowUrl` env
+// var (`{"urls":[...]}`). That still holds the JaMmusic + CollegeLutheran
+// origins. To onboard timshermanmusic.com (hosted on Cloudflare Pages) we also
+// allow its production origins and, because a static array can't express a
+// wildcard, its `*.pages.dev` preview deployments — hence an origin FUNCTION
+// rather than a bare array.
+
+import type { CorsOptions } from 'cors';
+
+// timshermanmusic.com production origins (Cloudflare Pages custom domain).
+export const TIM_ORIGINS = [
+  'https://timshermanmusic.com',
+  'https://www.timshermanmusic.com',
+];
+
+// Cloudflare Pages preview deployments: https://<hash>.<project>.pages.dev
+const PAGES_DEV = /^https:\/\/([a-z0-9-]+\.)*pages\.dev$/i;
+
+export function readStaticOrigins(): string[] {
+  try {
+    const parsed = JSON.parse(process.env.AllowUrl || '{}') as { urls?: string[] };
+    return Array.isArray(parsed.urls) ? parsed.urls : [];
+  } catch { return []; }
+}
+
+// True when the given request Origin is permitted.
+export function isAllowedOrigin(origin: string | undefined, staticOrigins: string[]): boolean {
+  // No Origin header (server-to-server, curl, same-origin navigations) — allow.
+  if (!origin) return true;
+  if (staticOrigins.includes(origin)) return true;
+  if (TIM_ORIGINS.includes(origin)) return true;
+  return PAGES_DEV.test(origin);
+}
+
+export function makeCorsOptions(): CorsOptions {
+  const staticOrigins = readStaticOrigins();
+  return {
+    origin: (origin, callback) => callback(null, isAllowedOrigin(origin || undefined, staticOrigins)),
+    credentials: true,
+    optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+  };
+}
+
+export default { TIM_ORIGINS, readStaticOrigins, isAllowedOrigin, makeCorsOptions };

--- a/src/model/book/book-controller.ts
+++ b/src/model/book/book-controller.ts
@@ -1,9 +1,13 @@
 import { Request, Response } from 'express';
 import { Icontroller } from '#src/lib/routeUtils.js';
-import Controller from '#src/lib/controller.js';
+import ArtistController from '#src/lib/artist-controller.js';
 import bookModel from './book-facade.js';
 
-class BookController extends Controller {
+// The `book` collection is shared across artists/tenants (#885): JaMmusic
+// slideshow photos, per-artist bio/page-content docs, and CollegeLutheran's
+// library. Artist scoping is backward compatible — legacy field-less records
+// (all of CollegeLutheran's) read as the default artist.
+class BookController extends ArtistController {
   findCheckedOut(req: Request, res: Response) {
     return this.model.find({ checkedOutBy: req.params.id })
       .then((collection) => res.status(200).json(collection));

--- a/src/model/book/book-schema.ts
+++ b/src/model/book/book-schema.ts
@@ -24,6 +24,10 @@ const bookSchema = new Schema({
   // page-content docs (e.g. type:'stewardshipPageContent') use this as an
   // admin on/off visibility toggle; absent/false = hidden (CollegeLutheran#707)
   enabled: { type: Boolean, required: false },
+  // Artist/tenant slug (#885). Absent on all pre-#885 records (incl. every
+  // CollegeLutheran doc), which read as the default (JaMmusic) artist. Slideshow
+  // photos and per-artist bio/page-content docs (e.g. type:'bio') carry a slug.
+  artist: { type: String, required: false },
 }, options);
 
 export default mongoose.models.Book || mongoose.model('Book', bookSchema);

--- a/src/model/gig/gig-controller.ts
+++ b/src/model/gig/gig-controller.ts
@@ -1,8 +1,10 @@
-import Controller from '../../lib/controller.js';
+import ArtistController from '../../lib/artist-controller.js';
 import gigModel from './gig-facade.js';
 import { Icontroller } from '../../lib/routeUtils.js';
 
-class GigController extends Controller {
+// Gigs are shared across artists (#885): reads scope by ?artist=, writes stamp
+// the artist and respect artist-scoped admins.
+class GigController extends ArtistController {
 
 }
 

--- a/src/model/gig/gig-schema.ts
+++ b/src/model/gig/gig-schema.ts
@@ -21,6 +21,9 @@ const gigSchema = new Schema({
   duration: { type: Number, required: false, default: 0 },
   promoImageUrl: { type: String, required: false },
   more: { type: String, required: false },
+  // Artist/tenant slug (#885). Absent on all pre-#885 records, which read as the
+  // default (JaMmusic) artist. Kept in sync with WebJamSocketCluster's mirror.
+  artist: { type: String, required: false },
 }, options);
 
 // Gigs live in WebJamSocketCluster's Mongo, a DIFFERENT database than

--- a/src/model/inquiry/InquiryController.ts
+++ b/src/model/inquiry/InquiryController.ts
@@ -1,6 +1,7 @@
 import nodemailer, { Transporter } from 'nodemailer';
 import { Request, Response } from 'express';
 import Debug from 'debug';
+import { DEFAULT_ARTIST, normalizeArtist } from '#src/lib/artist.js';
 
 const debug = Debug('web-jam-back:InquiryController');
 
@@ -8,6 +9,21 @@ const RECIPIENT_EMAIL = 'joshua.v.sherman@gmail.com';
 // CC Maria on every inquiry so she sees booking requests in real time
 // (Josh's preference 2026-05-18). Comma-separated string per nodemailer spec.
 const INQUIRY_CC = 'chemmariasherman@gmail.com';
+
+// Contact/booking submissions are artist-scoped (#885): a submission carries an
+// `artist` slug and is emailed to that artist's booking contact. The default
+// (JaMmusic) artist keeps the original Josh + Maria-CC behaviour. Other artists'
+// recipients come from the InquiryRecipients env map ({"tim":"tim@example.com"});
+// an unmapped artist falls back to the default so no inquiry is ever dropped.
+export function recipientForArtist(artist: unknown): { to: string; cc?: string } {
+  const slug = normalizeArtist(artist);
+  if (slug === DEFAULT_ARTIST) return { to: RECIPIENT_EMAIL, cc: INQUIRY_CC };
+  let map: Record<string, string>;
+  try { map = JSON.parse(process.env.InquiryRecipients || '{}') as Record<string, string>; } catch { map = {}; }
+  // eslint-disable-next-line security/detect-object-injection
+  const to = map[slug];
+  return typeof to === 'string' && to ? { to } : { to: RECIPIENT_EMAIL, cc: INQUIRY_CC };
+}
 
 class InquiryController {
   private transporter: Transporter | null = null;
@@ -50,7 +66,8 @@ class InquiryController {
 
   handleInquiry(req: Request, res: Response) {
     debug(req.body);
-    return this.sendEmail(JSON.stringify(req.body), RECIPIENT_EMAIL, 'inquiry', res, INQUIRY_CC);
+    const { to, cc } = recipientForArtist((req.body as { artist?: unknown })?.artist);
+    return this.sendEmail(JSON.stringify(req.body), to, 'inquiry', res, cc);
   }
 }
 export default InquiryController;

--- a/src/model/user/user-controller.ts
+++ b/src/model/user/user-controller.ts
@@ -4,6 +4,7 @@ import Debug from 'debug';
 import authGoogle from '#src/auth/google.js';
 import Controller from '#src/lib/controller.js';
 import { Icontroller } from '#src/lib/routeUtils.js';
+import { artistGrantForEmail } from '#src/lib/artist.js';
 import userModel from './user-facade.js';
 
 const debug = Debug('web-jam-back:user-controller');
@@ -12,6 +13,14 @@ interface UserHandler extends Record<string, unknown> {
   arg1: string;
   arg2: string;
   verified: boolean;
+}
+
+// Login-time role/artist grant for a configured artist-scoped admin (#885), e.g.
+// Tim. Spread onto the created/updated user doc so the account gets `userType`
+// and `artist` set. Empty for everyone else, leaving Josh's Developer role and
+// all ordinary users untouched.
+function grantFor(email: string): { userType: string; artist: string } | Record<string, never> {
+  return artistGrantForEmail(email) || {};
 }
 
 class UserController extends Controller {
@@ -35,7 +44,8 @@ class UserController extends Controller {
   }
 
   async handleNewUser(name:string, email:string, req: Request, res: Response) {
-    const user: UserHandler = { arg1: name, arg2: email, verified: true };
+    // Persist the real schema fields (name/email) plus any artist-admin grant.
+    const user = { name, email, verifiedEmail: true, ...grantFor(email) };
     const newUser = await this.model.create(user);
     newUser.password = '';
     return res.status(201).json({ email: newUser.email, token: this.authUtils.createJWT(newUser as unknown as { _id: string }) });
@@ -47,8 +57,11 @@ class UserController extends Controller {
       const { names, emailAddresses } = await authGoogle.authenticate(req);
       const name = names[0].displayName;
       const email = emailAddresses[0].value;
-      // Step 3. Create a new user account or return an existing one.
-      const update: UserHandler = { arg1: '', arg2: name, verified: true };
+      // Step 3. Create a new user account or return an existing one. A returning
+      // artist-admin has their grant (userType/artist) refreshed from config.
+      const update: UserHandler = {
+        arg1: '', arg2: name, verified: true, ...grantFor(email),
+      };
       const existingUser = await this.model.findOneAndUpdate({ email }, update);
       if (existingUser) {
         return res.status(200).json({ email: existingUser.email, token: this.authUtils.createJWT(existingUser as unknown as { _id: string }) });

--- a/src/model/user/user-schema.ts
+++ b/src/model/user/user-schema.ts
@@ -10,6 +10,9 @@ const userSchema = new Schema({
   userPhone: { type: Number, required: false },
   userStatus: { type: String, required: false },
   userType: { type: String, required: false },
+  // Artist slug an artist-scoped admin owns (#885). Absent for super-admins
+  // (Josh) and ordinary users. Set at login from the ArtistAdmins env config.
+  artist: { type: String, required: false },
   userStreetAddress: { type: String, required: false },
   userCity: { type: String, required: false },
   userState: { type: String, required: false },

--- a/test/unit/artist-scoping.spec.ts
+++ b/test/unit/artist-scoping.spec.ts
@@ -1,0 +1,140 @@
+import app from '#src/index.js';
+import GigModel from '#src/model/gig/gig-facade.js';
+import BookModel from '#src/model/book/book-facade.js';
+import userModel from '#src/model/user/user-facade.js';
+import authUtils from '#src/auth/authUtils.js';
+import request, { type ApiResponse } from '../helpers/api.js';
+
+// Artist scoping (web-jam-back#885): reads filter by ?artist=, writes stamp the
+// artist, and an artist-scoped admin can only touch their own artist's records.
+describe('Artist scoping', () => {
+  let r: ApiResponse;
+  let superUser: { _id: string };
+  let timAdmin: { _id: string };
+  const allowedUrl = JSON.parse(process.env.AllowUrl || '{}').urls[0];
+  const auth = (id: string) => `Bearer ${authUtils.createJWT({ _id: id })}`;
+
+  // A role allowed through the existing AUTH_ROLES route guard for /book etc.
+  // Scoping is driven by the `artist` field, not the role: superUser has no
+  // artist slug (unscoped -> pre-#885 behaviour); timAdmin carries artist='tim'.
+  const allowedRole = JSON.parse(process.env.AUTH_ROLES || '{}').user[0];
+  beforeAll(async () => {
+    await GigModel.deleteMany({});
+    await BookModel.deleteMany({});
+    await userModel.deleteMany({});
+    const su = await userModel.create({ name: 'josh', email: 'super@example.com', userType: allowedRole }) as unknown as { _id: { toString(): string } };
+    const tim = await userModel.create({
+      name: 'tim', email: 'tim@example.com', userType: allowedRole, artist: 'tim',
+    }) as unknown as { _id: { toString(): string } };
+    superUser = { _id: su._id.toString() };
+    timAdmin = { _id: tim._id.toString() };
+  });
+  beforeEach(async () => {
+    await GigModel.deleteMany({});
+    await BookModel.deleteMany({});
+  });
+
+  it('GET /gig?artist=tim returns only that artist', async () => {
+    await GigModel.create({ venue: 'Legacy Hall' }); // no artist -> jammusic
+    await GigModel.create({ venue: 'Tim Stage', artist: 'tim' });
+    r = await request(app).get('/gig').query({ artist: 'tim' }).set({ origin: allowedUrl });
+    expect(r.status).toBe(200);
+    expect(r.body).toHaveLength(1);
+    expect(r.body[0].venue).toBe('Tim Stage');
+  });
+
+  it('GET /gig with no artist returns legacy/jammusic only (excludes tim)', async () => {
+    await GigModel.create({ venue: 'Legacy Hall' });
+    await GigModel.create({ venue: 'JaM Hall', artist: 'jammusic' });
+    await GigModel.create({ venue: 'Tim Stage', artist: 'tim' });
+    r = await request(app).get('/gig').set({ origin: allowedUrl });
+    expect(r.status).toBe(200);
+    const venues = (r.body as { venue: string }[]).map((g) => g.venue).sort();
+    expect(venues).toEqual(['JaM Hall', 'Legacy Hall']);
+  });
+
+  it('scoped admin create is force-stamped to their artist', async () => {
+    r = await request(app).post('/gig').set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id))
+      .send({ venue: 'Coffee House', artist: 'somebodyelse' });
+    expect(r.status).toBe(201);
+    expect(r.body.artist).toBe('tim');
+  });
+
+  it('super create can set any artist', async () => {
+    r = await request(app).post('/gig').set({ origin: allowedUrl }).set('Authorization', auth(superUser._id))
+      .send({ venue: 'Big Venue', artist: 'tim' });
+    expect(r.status).toBe(201);
+    expect(r.body.artist).toBe('tim');
+  });
+
+  it('super create with no artist defaults to jammusic', async () => {
+    r = await request(app).post('/gig').set({ origin: allowedUrl }).set('Authorization', auth(superUser._id))
+      .send({ venue: 'Default Venue' });
+    expect(r.status).toBe(201);
+    expect(r.body.artist).toBe('jammusic');
+  });
+
+  it('scoped admin can update their own record', async () => {
+    const g = await GigModel.create({ venue: 'Old', artist: 'tim' });
+    r = await request(app).put(`/gig/${g._id}`).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id))
+      .send({ venue: 'New' });
+    expect(r.status).toBe(200);
+    expect(r.body.venue).toBe('New');
+  });
+
+  it('scoped admin cannot update another artist record (403)', async () => {
+    const g = await GigModel.create({ venue: 'JaM Only' }); // jammusic
+    r = await request(app).put(`/gig/${g._id}`).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id))
+      .send({ venue: 'Hijacked' });
+    expect(r.status).toBe(403);
+  });
+
+  it('scoped admin cannot move their record to another artist (403)', async () => {
+    const g = await GigModel.create({ venue: 'Mine', artist: 'tim' });
+    r = await request(app).put(`/gig/${g._id}`).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id))
+      .send({ artist: 'jammusic' });
+    expect(r.status).toBe(403);
+  });
+
+  it('scoped admin cannot delete another artist record (403)', async () => {
+    const g = await GigModel.create({ venue: 'JaM Only' });
+    r = await request(app).delete(`/gig/${g._id}`).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id));
+    expect(r.status).toBe(403);
+  });
+
+  it('scoped admin can delete their own record', async () => {
+    const g = await GigModel.create({ venue: 'Mine', artist: 'tim' });
+    r = await request(app).delete(`/gig/${g._id}`).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id));
+    expect(r.status).toBe(200);
+  });
+
+  it('serves a public per-artist bio via GET /book/one', async () => {
+    await BookModel.create({ title: 'Bio', type: 'bio', artist: 'tim', comments: 'Tim plays guitar' });
+    r = await request(app).get('/book/one').query({ type: 'bio', artist: 'tim' }).set({ origin: allowedUrl });
+    expect(r.status).toBe(200);
+    expect(r.body.comments).toBe('Tim plays guitar');
+  });
+
+  it('scoped admin bio update is stamped and scoped to their artist', async () => {
+    await BookModel.create({ title: 'Bio', type: 'bio', artist: 'tim', comments: 'old' });
+    r = await request(app).put('/book/one').query({ type: 'bio' }).set({ origin: allowedUrl }).set('Authorization', auth(timAdmin._id))
+      .send({ comments: 'new bio' });
+    expect(r.status).toBe(200);
+    expect(r.body.comments).toBe('new bio');
+    expect(r.body.artist).toBe('tim');
+  });
+
+  it('super findOneAndUpdate normalizes a provided artist on the body', async () => {
+    await BookModel.create({ title: 'Bio', type: 'bio', comments: 'jam bio' }); // jammusic (legacy)
+    r = await request(app).put('/book/one').query({ type: 'bio' }).set({ origin: allowedUrl }).set('Authorization', auth(superUser._id))
+      .send({ comments: 'edited', artist: '' });
+    expect(r.status).toBe(200);
+    expect(r.body.artist).toBe('jammusic');
+  });
+
+  it('should wait unit tests finish before exiting', async () => { // eslint-disable-line vitest/expect-expect
+    // eslint-disable-next-line no-promise-executor-return
+    const delay = (ms: number) => new Promise((resolve) => setTimeout(() => resolve(true), ms));
+    await delay(3000);
+  });
+});

--- a/test/unit/google.spec.ts
+++ b/test/unit/google.spec.ts
@@ -30,4 +30,21 @@ describe('google.ts', () => {
     const res = await google.authenticate(req);
     expect(res.emailAddresses[0].value).toBe('me@me.com');
   });
+  it("accepts Tim's OAuth client id (#885) and pairs it with Tim's secret", async () => {
+    const prevId = process.env.TimGoogleClientId;
+    const prevSecret = process.env.TimGoogleClientSecret;
+    process.env.TimGoogleClientId = 'tim-client-id';
+    process.env.TimGoogleClientSecret = 'tim-secret';
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'booya' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ emailAddresses: [{ value: 'tim@me.com' }], names: [] }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const req = { body: { code: 'whatever', clientId: 'tim-client-id', redirectUri: 'https://timshermanmusic.com' } };
+    const res = await google.authenticate(req);
+    expect(res.emailAddresses[0].value).toBe('tim@me.com');
+    // the token-exchange POST body carries Tim's secret, not JaMmusic's
+    expect((fetchMock.mock.calls[0][1] as { body: URLSearchParams }).body.get('client_secret')).toBe('tim-secret');
+    process.env.TimGoogleClientId = prevId;
+    process.env.TimGoogleClientSecret = prevSecret;
+  });
 });

--- a/test/unit/inquiry/recipient.spec.ts
+++ b/test/unit/inquiry/recipient.spec.ts
@@ -1,0 +1,26 @@
+import { recipientForArtist } from '#src/model/inquiry/InquiryController.js';
+
+describe('inquiry recipientForArtist', () => {
+  const orig = process.env.InquiryRecipients;
+  afterEach(() => { process.env.InquiryRecipients = orig; });
+
+  it('routes the default (JaMmusic) artist to Josh + Maria CC', () => {
+    expect(recipientForArtist(undefined)).toEqual({
+      to: 'joshua.v.sherman@gmail.com',
+      cc: 'chemmariasherman@gmail.com',
+    });
+    expect(recipientForArtist('jammusic').cc).toBe('chemmariasherman@gmail.com');
+  });
+
+  it('routes a mapped artist to its own contact (no CC)', () => {
+    process.env.InquiryRecipients = JSON.stringify({ tim: 'tim@example.com' });
+    expect(recipientForArtist('tim')).toEqual({ to: 'tim@example.com' });
+  });
+
+  it('falls back to the default when the artist is unmapped or config is bad', () => {
+    process.env.InquiryRecipients = JSON.stringify({ tim: 'tim@example.com' });
+    expect(recipientForArtist('nobody').to).toBe('joshua.v.sherman@gmail.com');
+    process.env.InquiryRecipients = 'not-json';
+    expect(recipientForArtist('tim').to).toBe('joshua.v.sherman@gmail.com');
+  });
+});

--- a/test/unit/lib/artist.spec.ts
+++ b/test/unit/lib/artist.spec.ts
@@ -1,0 +1,51 @@
+import {
+  DEFAULT_ARTIST, normalizeArtist, artistListFilter, artistGrantForEmail,
+} from '#src/lib/artist.js';
+
+describe('lib/artist', () => {
+  const orig = process.env.ArtistAdmins;
+  afterEach(() => { process.env.ArtistAdmins = orig; });
+
+  it('exposes the default artist', () => {
+    expect(DEFAULT_ARTIST).toBe('jammusic');
+  });
+
+  it('normalizeArtist falls back to the default for blank/non-string', () => {
+    expect(normalizeArtist('tim')).toBe('tim');
+    expect(normalizeArtist('  spaced  ')).toBe('spaced');
+    expect(normalizeArtist('')).toBe('jammusic');
+    expect(normalizeArtist(undefined)).toBe('jammusic');
+    expect(normalizeArtist(42)).toBe('jammusic');
+  });
+
+  it('artistListFilter scopes to a specific artist', () => {
+    expect(artistListFilter({ artist: 'tim', city: 'Salem' })).toEqual({ artist: 'tim', city: 'Salem' });
+  });
+
+  it('artistListFilter defaults to legacy + jammusic records', () => {
+    const f = artistListFilter({ type: 'paperback' });
+    expect(f.type).toBe('paperback');
+    expect(f.$or).toEqual([{ artist: { $exists: false } }, { artist: null }, { artist: 'jammusic' }]);
+  });
+
+  it('artistListFilter treats an explicit jammusic like the default', () => {
+    expect(artistListFilter({ artist: 'jammusic' }).$or).toBeDefined();
+  });
+
+  it('artistGrantForEmail returns a grant for a configured email (case-insensitive)', () => {
+    process.env.ArtistAdmins = JSON.stringify({ 'tim@example.com': 'tim' });
+    expect(artistGrantForEmail('Tim@Example.com')).toEqual({ userType: 'artist-admin', artist: 'tim' });
+  });
+
+  it('artistGrantForEmail returns null for an unlisted email', () => {
+    process.env.ArtistAdmins = JSON.stringify({ 'tim@example.com': 'tim' });
+    expect(artistGrantForEmail('someone@else.com')).toBeNull();
+  });
+
+  it('artistGrantForEmail returns null on missing/invalid config', () => {
+    delete process.env.ArtistAdmins;
+    expect(artistGrantForEmail('tim@example.com')).toBeNull();
+    process.env.ArtistAdmins = 'not-json';
+    expect(artistGrantForEmail('tim@example.com')).toBeNull();
+  });
+});

--- a/test/unit/lib/cors.spec.ts
+++ b/test/unit/lib/cors.spec.ts
@@ -1,0 +1,53 @@
+import {
+  TIM_ORIGINS, readStaticOrigins, isAllowedOrigin, makeCorsOptions,
+} from '#src/lib/cors.js';
+
+describe('lib/cors', () => {
+  const orig = process.env.AllowUrl;
+  afterEach(() => { process.env.AllowUrl = orig; });
+
+  it('readStaticOrigins parses the AllowUrl env', () => {
+    process.env.AllowUrl = JSON.stringify({ urls: ['https://a.com', 'https://b.com'] });
+    expect(readStaticOrigins()).toEqual(['https://a.com', 'https://b.com']);
+  });
+
+  it('readStaticOrigins returns [] on missing/invalid config', () => {
+    delete process.env.AllowUrl;
+    expect(readStaticOrigins()).toEqual([]);
+    process.env.AllowUrl = 'not-json';
+    expect(readStaticOrigins()).toEqual([]);
+  });
+
+  it('allows requests with no Origin header', () => {
+    expect(isAllowedOrigin(undefined, [])).toBe(true);
+  });
+
+  it('allows configured static origins', () => {
+    expect(isAllowedOrigin('https://jammusic.com', ['https://jammusic.com'])).toBe(true);
+  });
+
+  it('allows the timshermanmusic production origins', () => {
+    for (const o of TIM_ORIGINS) expect(isAllowedOrigin(o, [])).toBe(true);
+  });
+
+  it('allows Cloudflare Pages preview origins', () => {
+    expect(isAllowedOrigin('https://abc123.timshermanmusic.pages.dev', [])).toBe(true);
+    expect(isAllowedOrigin('https://timshermanmusic.pages.dev', [])).toBe(true);
+  });
+
+  it('rejects an unknown origin', () => {
+    expect(isAllowedOrigin('https://evil.com', [])).toBe(false);
+    expect(isAllowedOrigin('https://evil.pages.dev.attacker.com', [])).toBe(false);
+  });
+
+  it('makeCorsOptions wires an origin callback that reflects the allow-list', () => {
+    process.env.AllowUrl = JSON.stringify({ urls: ['https://ok.com'] });
+    const opts = makeCorsOptions();
+    const originFn = opts.origin as (o: string | undefined, cb: (e: Error | null, ok?: boolean) => void) => void;
+    let allowed: boolean | undefined;
+    originFn('https://ok.com', (_e, ok) => { allowed = ok; });
+    expect(allowed).toBe(true);
+    originFn('https://nope.com', (_e, ok) => { allowed = ok; });
+    expect(allowed).toBe(false);
+  });
+});

--- a/test/unit/user/user-controller.spec.ts
+++ b/test/unit/user/user-controller.spec.ts
@@ -37,5 +37,17 @@ describe('User Controller', () => {
     authGoogle.authenticate = authMock;
     await controller.google({ body: {} } as any, resStub);
     expect(status).toBe(201);
-  }); 
+  });
+  it('stamps the artist-admin grant for a configured email on login (#885)', async () => {
+    const prev = process.env.ArtistAdmins;
+    process.env.ArtistAdmins = JSON.stringify({ 'tim@sherman.com': 'tim' });
+    const update = vi.fn(() => Promise.resolve({ email: 'tim@sherman.com' }));
+    (controller as unknown as LibController).model.findOneAndUpdate = update as any;
+    const authMock:any = vi.fn(() => Promise.resolve({ names: [{ displayName: 'Tim' }], emailAddresses: [{ value: 'tim@sherman.com' }] }));
+    authGoogle.authenticate = authMock;
+    await controller.google({ body: {} } as any, resStub);
+    expect((update.mock.calls[0] as unknown[])[1]).toMatchObject({ userType: 'artist-admin', artist: 'tim' });
+    process.env.ArtistAdmins = prev;
+    testObj = {};
+  });
 });


### PR DESCRIPTION
Closes #885 (backend half; front-end consumers TimShermanMusic #3/#4/#5 + bio).

Reuses this backend for a second front-end (timshermanmusic.com, Cloudflare
Pages) alongside JaMmusic. **Backward compatible:** every pre-existing record has
no `artist` field and is treated as the original `jammusic` artist, so JaMmusic
and CollegeLutheran behaviour is unchanged.

## What changed
- **Artist scoping** (`src/lib/artist.ts`, `src/lib/artist-controller.ts`): added
  an `artist` slug to the `gig`, `book`, and `user` schemas. `ArtistController`
  (extended by gig + book controllers) filters public reads by `?artist=`, stamps
  the artist on writes, and enforces per-record ownership — a user whose account
  carries an `artist` slug (Tim) can only touch that artist's records; unscoped
  accounts (Josh, legacy) keep pre-#885 behaviour. `book` also backs slideshow
  photos (`allBooks`) and CollegeLutheran's library — legacy field-less docs still
  read as the default artist.
- **Bio** (item 5): reuses the existing book page-content pattern — a
  `{ type:'bio', artist:<slug> }` book doc. Public `GET /book/one?type=bio&artist=`,
  admin update via `PUT /book/one`.
- **Contact/booking**: `/inquiry` now routes the email to the submission's artist
  (`InquiryRecipients` env map). Default artist keeps Josh + Maria-CC.
- **OAuth** (`src/auth/google.ts`): accepts Tim's own GCP OAuth client — the
  code-for-token exchange pairs `TimGoogleClientId` with `TimGoogleClientSecret`;
  any other client id keeps JaMmusic's `GoogleClientSecret`.
- **Roles** (`ArtistAdmins` env): at Google login a configured email is
  provisioned as an artist-scoped admin (`userType: 'artist-admin'`, `artist`
  slug). Unlisted accounts (incl. Josh's Developer) are untouched. Also fixed the
  google new-user path to persist real `name`/`email` fields.
- **CORS** (`src/lib/cors.ts`): allow `https://timshermanmusic.com`,
  `https://www.timshermanmusic.com`, and `*.pages.dev` preview origins in addition
  to the existing `AllowUrl` list.

## Tests
`npm test` green: 31 files / 425 tests, coverage 91.7% stmts / 84.42% branch /
85.05% funcs / 92.34% lines (gate 90/80/80/90). Typecheck + eslint + jscpd clean.

## Env / follow-ups for Josh
See PR discussion — new env vars (TimGoogleClientId/Secret, ArtistAdmins,
InquiryRecipients) and the AUTH_ROLES note for `artist-admin` route access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
