### PR TITLE
feat(outreach): auto-flag venue + halt cadence on bounce (Part of #825)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.45",
+      "version": "2.0.46",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/imap-replies.ts
+++ b/src/lib/imap-replies.ts
@@ -22,6 +22,11 @@ export interface ReplyMatch {
   repliedAt: Date;
   snippet: string;
   gmailThreadId?: string;
+  // #825 bounce auto-flag. True when this "match" is actually a delivery-failure
+  // bounce (isBounce below), not a genuine venue reply. The caller (checkReplies)
+  // branches on this: a bounce auto-flags the venue + halts the outreach
+  // deterministically, rather than going through the AI-suggestion review queue.
+  isBounce?: boolean;
 }
 
 // Minimal interface covering the ImapFlow methods findReplies actually uses.
@@ -112,16 +117,27 @@ export function isSelfOrPitch(
   return false;
 }
 
+// True if a message is a genuine delivery-failure BOUNCE — sent by the mail
+// system itself (mailer-daemon/postmaster), or a DSN report (multipart/report).
+// Narrower than isAutoOrBounce below: an out-of-office or other auto-reply is
+// NOT a bounce (the address is alive, a human just isn't at their desk), so it
+// must not trigger the #825 auto-flag. A bounce means the address is dead.
+export function isBounce(fromAddress: string, rawSource: string): boolean {
+  const from = (fromAddress || '').toLowerCase();
+  if (from.includes('mailer-daemon@') || from.includes('postmaster@')) return true;
+  if (extractHeader(rawSource, 'content-type').toLowerCase().includes('multipart/report')) return true;
+  return false;
+}
+
 // True if a message is an automated bounce / auto-reply rather than a human venue
 // reply — these legitimately reference our pitch but must NOT count as replies.
 export function isAutoOrBounce(fromAddress: string, rawSource: string): boolean {
+  if (isBounce(fromAddress, rawSource)) return true;
   const from = (fromAddress || '').toLowerCase();
-  if (from.includes('mailer-daemon@') || from.includes('postmaster@')) return true;
   const localPart = from.split('@')[0];
   if (localPart.startsWith('no-reply') || localPart.startsWith('noreply')) return true;
   const autoSubmitted = extractHeader(rawSource, 'auto-submitted').toLowerCase();
   if (autoSubmitted && autoSubmitted !== 'no') return true;
-  if (extractHeader(rawSource, 'content-type').toLowerCase().includes('multipart/report')) return true;
   return false;
 }
 
@@ -161,13 +177,50 @@ export function imapEnabled(): boolean {
 // request time out (H12) — the next tick re-scans the rest.
 const SCAN_DEADLINE_MS = 25000;
 
+// Minimal shape of a fetched candidate message, as returned by fetchOne.
+type CandidateMsg = {
+  envelope?: { messageId?: string; from?: { address?: string }[]; date?: Date };
+  source?: Buffer | string; threadId?: string | number;
+};
+
+// Classify one candidate message into a ReplyMatch to record, or null to skip
+// it: our own pitch/CC copy (isSelfOrPitch), a non-bounce auto-reply
+// (out-of-office etc. — isAutoOrBounce but not isBounce), or a message that
+// references none of our pitches. A genuine bounce is kept and flagged
+// (isBounce: true, #825 auto-flag) even though isAutoOrBounce is also true for
+// it. Extracted out of the scan loop to keep that loop's branching simple.
+function classifyCandidate(
+  msg: CandidateMsg, bareIds: string[], idToOutreach: Map<string, string>, selfAddress: string,
+): ReplyMatch | null {
+  const raw = (msg.source || '').toString();
+  const from = msg.envelope?.from?.[0]?.address || '';
+  if (isSelfOrPitch(msg.envelope?.messageId, from, selfAddress, bareIds)) return null;
+  const bounce = isBounce(from, raw);
+  if (!bounce && isAutoOrBounce(from, raw)) return null;
+  const pitchId = referencedPitchId(raw, bareIds);
+  const outreachId = pitchId ? idToOutreach.get(pitchId) : undefined;
+  if (!outreachId) return null;
+  const match: ReplyMatch = {
+    outreachId,
+    fromAddress: from,
+    repliedAt: msg.envelope?.date || new Date(),
+    snippet: snippetFromBody(bodyFromSource(raw)),
+    gmailThreadId: msg.threadId ? String(msg.threadId) : undefined,
+  };
+  if (bounce) match.isBounce = true;
+  return match;
+}
+
 // Connect to Gmail over IMAP and return one ReplyMatch per outreach record that
-// has a GENUINE venue reply. One bounded batched search finds candidate replies
-// to any pitch; each candidate is then verified — not our own pitch/CC copy
-// (isSelfOrPitch), not a bounce/auto-reply (isAutoOrBounce), and actually
-// referencing one of our pitches (referencedPitchId) — before its body snippet
-// is taken. The whole scan is raced against a 25s deadline. Returns [] / partial
-// (never throws) when disabled, on a connection failure, or on the deadline.
+// has a GENUINE venue reply OR a genuine bounce (#825 auto-flag; isBounce: true
+// on the match). One bounded batched search finds candidates referencing any
+// pitch; each candidate is then verified — not our own pitch/CC copy
+// (isSelfOrPitch); a true bounce (isBounce) is kept and flagged; any other
+// auto-reply (isAutoOrBounce, e.g. an out-of-office) is skipped entirely; the
+// rest must actually reference one of our pitches (referencedPitchId) before its
+// body snippet is taken. The whole scan is raced against a 25s deadline. Returns
+// [] / partial (never throws) when disabled, on a connection failure, or on the
+// deadline.
 // An optional makeClient factory injects a fake IMAP client in tests; when
 // present the imapEnabled() env gate is skipped so tests never hit Gmail.
 export async function findReplies(refs: OutreachRef[], makeClient?: () => ImapClientLike): Promise<ReplyMatch[]> {
@@ -199,20 +252,8 @@ export async function findReplies(refs: OutreachRef[], makeClient?: () => ImapCl
         // eslint-disable-next-line no-await-in-loop
         const msg = await client.fetchOne(String(uid), { envelope: true, source: true }, { uid: true });
         if (!msg || !msg.source) continue;
-        const raw = msg.source.toString();
-        const from = msg.envelope?.from?.[0]?.address || '';
-        if (isSelfOrPitch(msg.envelope?.messageId, from, selfAddress, bareIds)) continue;
-        if (isAutoOrBounce(from, raw)) continue;
-        const pitchId = referencedPitchId(raw, bareIds);
-        const outreachId = pitchId ? idToOutreach.get(pitchId) : undefined;
-        if (!outreachId) continue;
-        byOutreach.set(outreachId, {
-          outreachId,
-          fromAddress: from,
-          repliedAt: msg.envelope?.date || new Date(),
-          snippet: snippetFromBody(bodyFromSource(raw)),
-          gmailThreadId: msg.threadId ? String(msg.threadId) : undefined,
-        });
+        const match = classifyCandidate(msg, bareIds, idToOutreach, selfAddress);
+        if (match) byOutreach.set(match.outreachId, match);
       }
     } finally {
       lock.release();
@@ -237,5 +278,5 @@ export async function findReplies(refs: OutreachRef[], makeClient?: () => ImapCl
 
 export default {
   bareMessageId, earliestSince, buildBatchSearch, extractHeader, referencedPitchId,
-  isSelfOrPitch, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
+  isSelfOrPitch, isBounce, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
 };

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -69,7 +69,7 @@ interface UpdateBody { status?: string; gmailThreadId?: string; actor?: string }
 
 interface VenueDoc {
   _id?: unknown; name?: string; email?: string; contactName?: string; phone?: string;
-  venueType?: string; status?: string; outreachEligible?: boolean;
+  venueType?: string; status?: string; outreachEligible?: boolean; contactVerified?: boolean;
   bookingStatus?: string; relationshipStage?: string; templateOverride?: string;
 }
 interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
@@ -753,12 +753,26 @@ class OutreachController extends Controller {
     return res.status(200).json(result);
   }
 
+  // Is a bounce item still pending? (#825 option B, decision 2026-07-02 — bounce
+  // items AUTO-CLEAR from venue state; there is no dismiss button.) A bounce
+  // stays in the queue only while its venue still needs attention: it drops out
+  // once the venue is archived, re-verified (contactVerified true — Josh fixed
+  // the address), or deleted. A venue-lookup failure keeps the item pending —
+  // never hide an unresolved bounce because of a transient read error.
+  async isBounceStillPending(venueId: string): Promise<boolean> { // eslint-disable-line class-methods-use-this
+    let venue: VenueDoc | null;
+    try { venue = await venueModel.findById(venueId) as unknown as VenueDoc | null; } catch { return true; }
+    if (!venue || venue.status === 'archived') return false;
+    return !venue.contactVerified;
+  }
+
   // GET /outreach/replies/pending — the AdminVenues "replies to review" queue:
-  // replied records that carry an unreviewed AI suggestion, PLUS any bounce
-  // records (#825 auto-flag; replyKind: 'bounce') — the JaMmusic UI (#1162)
-  // renders those as "bounced — needs new email". A bounce item carries no
-  // suggestion and needs no apply-suggestion step; it's surfaced here purely so
-  // Josh can see it and go fix the venue's address.
+  // replied records that carry an unreviewed AI suggestion, PLUS bounce records
+  // (#825 auto-flag; replyKind: 'bounce') whose venue still needs attention —
+  // the JaMmusic UI (#1162) renders those as "bounced — needs new email". A
+  // bounce item carries no suggestion and needs no apply-suggestion step; it's
+  // surfaced here purely so Josh can see it and go fix the venue's address, and
+  // it auto-clears once he does (isBounceStillPending above).
   async listPendingReplies(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -771,7 +785,13 @@ class OutreachController extends Controller {
         ],
       });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
-    return res.status(200).json(records);
+    const pending: Record<string, unknown>[] = [];
+    for (const r of records) {
+      if (r.replyKind !== 'bounce') { pending.push(r); continue; }
+      // eslint-disable-next-line no-await-in-loop
+      if (await this.isBounceStillPending(String(r.venueId))) pending.push(r);
+    }
+    return res.status(200).json(pending);
   }
 
   // Write a reply suggestion's values (Josh's edited body values win, else the

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -690,12 +690,39 @@ class OutreachController extends Controller {
     return !!suggestion;
   }
 
+  // Action one matched BOUNCE (#825 auto-flag): the venue's address is dead, so
+  // auto-flag the venue (contactVerified: false, outreachEligible: false — it can
+  // never be selected for a future batch) and halt this outreach record
+  // (no-response, nextTouchDue: null — cadence never follows up on a dead
+  // address). Entirely deterministic (the caller only reaches here off
+  // isAutoOrBounce/isBounce, no AI judgment): unlike recordReply, this NEVER
+  // attaches a suggestion, and the flagging takes effect immediately — there is
+  // no apply-suggestion review step for a bounce. The venue write is best-effort
+  // (swallowed) so a venue-write hiccup can't stop the more critical cadence
+  // halt below.
+  async recordBounce(o: OutreachDoc, match: { repliedAt: Date; snippet: string; gmailThreadId?: string }): Promise<void> {
+    try {
+      await venueModel.findByIdAndUpdate(String(o.venueId), {
+        contactVerified: false, outreachEligible: false, lastModifiedBy: 'reply-detection',
+      });
+    } catch { /* best-effort: the outreach halt below is the critical write */ }
+    const update: Record<string, unknown> = {
+      status: 'no-response', nextTouchDue: null, replyKind: 'bounce',
+      repliedAt: match.repliedAt, replySnippet: match.snippet, lastModifiedBy: 'reply-detection',
+    };
+    if (match.gmailThreadId) update.gmailThreadId = match.gmailThreadId;
+    await this.model.findByIdAndUpdate(String(o._id), update);
+  }
+
   // POST /outreach/check-replies — reply-detection tick (#825 Half B). Scans Gmail
   // over IMAP for replies to still-active (`sent`) pitches, matched precisely by
-  // the stored Message-ID; each match halts the cadence + gets an AI suggestion
-  // for review. Separate from /advance (no send IO) so the cron can run it more
-  // often. Dormant until GMAIL_IMAP_* (and ANTHROPIC_API_KEY for suggestions) are
-  // set — findReplies returns [] otherwise, so this is a safe no-op.
+  // the stored Message-ID. A genuine reply halts the cadence + gets an AI
+  // suggestion for review (recordReply); a genuine bounce instead auto-flags the
+  // venue + halts the cadence deterministically, with no AI suggestion
+  // (recordBounce, #825 auto-flag). Separate from /advance (no send IO) so the
+  // cron can run it more often. Dormant until GMAIL_IMAP_* (and ANTHROPIC_API_KEY
+  // for suggestions) are set — findReplies returns [] otherwise, so this is a
+  // safe no-op.
   async checkReplies(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, ['outreach:edit']);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -707,27 +734,42 @@ class OutreachController extends Controller {
       outreachId: String(o._id), messageId: (o as { messageId?: string }).messageId || '', sentAt: o.sentAt,
     }));
     const matches = await findReplies(refs);
-    const result = { checked: refs.length, matched: 0, classified: 0 };
+    const result = { checked: refs.length, matched: 0, classified: 0, bounced: 0 };
     for (const m of matches) {
       const o = active.find((a) => String(a._id) === m.outreachId);
       if (!o) continue;
       try {
-        const classified = await this.recordReply(o, m); // eslint-disable-line no-await-in-loop
-        result.matched += 1;
-        if (classified) result.classified += 1;
+        if (m.isBounce) {
+          await this.recordBounce(o, m); // eslint-disable-line no-await-in-loop
+          result.matched += 1;
+          result.bounced += 1;
+        } else {
+          const classified = await this.recordReply(o, m); // eslint-disable-line no-await-in-loop
+          result.matched += 1;
+          if (classified) result.classified += 1;
+        }
       } catch { /* one bad record shouldn't abort the whole scan */ }
     }
     return res.status(200).json(result);
   }
 
   // GET /outreach/replies/pending — the AdminVenues "replies to review" queue:
-  // replied records that carry an unreviewed AI suggestion.
+  // replied records that carry an unreviewed AI suggestion, PLUS any bounce
+  // records (#825 auto-flag; replyKind: 'bounce') — the JaMmusic UI (#1162)
+  // renders those as "bounced — needs new email". A bounce item carries no
+  // suggestion and needs no apply-suggestion step; it's surfaced here purely so
+  // Josh can see it and go fix the venue's address.
   async listPendingReplies(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     let records: Record<string, unknown>[];
     try {
-      records = await this.model.find({ status: 'replied', suggestion: { $ne: null }, 'suggestion.reviewed': { $ne: true } });
+      records = await this.model.find({
+        $or: [
+          { status: 'replied', suggestion: { $ne: null }, 'suggestion.reviewed': { $ne: true } },
+          { replyKind: 'bounce' },
+        ],
+      });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
     return res.status(200).json(records);
   }

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -72,6 +72,13 @@ const outreachSchema = new Schema({
   repliedAt: { type: Date, required: false, default: null },
   replySnippet: { type: String, required: false, trim: true },
   suggestion: { type: suggestionSchema, required: false, default: null },
+  // #825 bounce auto-flag. Set to 'bounce' when the "reply" the IMAP job matched
+  // was actually a delivery-failure bounce (mailer-daemon/DSN), not a genuine
+  // venue reply. Distinguishes a bounced record (status already halted to
+  // `no-response`, deterministic, no AI suggestion) from a real replied record
+  // in the /outreach/replies-pending queue, so the JaMmusic UI (#1162) can render
+  // it as "bounced — needs new email".
+  replyKind: { type: String, required: false, enum: ['bounce'], default: null },
   // Which AI agent or human sent this pitch (#818 `actor` field).
   sentBy: { type: String, required: false, trim: true },
   followUps: { type: [followUpSchema], required: false, default: [] },

--- a/test/unit/lib/imap-replies.spec.ts
+++ b/test/unit/lib/imap-replies.spec.ts
@@ -1,6 +1,6 @@
 import {
   bareMessageId, earliestSince, buildBatchSearch, extractHeader, referencedPitchId,
-  isSelfOrPitch, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
+  isSelfOrPitch, isBounce, isAutoOrBounce, bodyFromSource, snippetFromBody, imapEnabled, findReplies,
   type ImapClientLike,
 } from '#src/lib/imap-replies.js';
 
@@ -186,6 +186,30 @@ describe('imap-replies', () => {
     });
   });
 
+  describe('isBounce', () => {
+    it('detects mailer-daemon sender', () => {
+      expect(isBounce('mailer-daemon@googlemail.com', '')).toBe(true);
+    });
+    it('detects postmaster sender', () => {
+      expect(isBounce('postmaster@example.com', '')).toBe(true);
+    });
+    it('detects multipart/report content-type (delivery-status report)', () => {
+      const raw = 'Content-Type: multipart/report; report-type=delivery-status\r\n\r\nbody';
+      expect(isBounce('system@domain.com', raw)).toBe(true);
+    });
+    it('does NOT flag a no-reply sender (auto-reply, not a bounce)', () => {
+      expect(isBounce('no-reply@domain.com', '')).toBe(false);
+    });
+    it('does NOT flag an Auto-Submitted header (auto-reply, not a bounce)', () => {
+      const raw = 'Auto-Submitted: auto-replied\r\n\r\nbody';
+      expect(isBounce('system@domain.com', raw)).toBe(false);
+    });
+    it('returns false for a normal human reply', () => {
+      const raw = 'Content-Type: text/plain\r\n\r\nHey, we would love to book you!';
+      expect(isBounce('booking@venue.com', raw)).toBe(false);
+    });
+  });
+
   describe('isAutoOrBounce', () => {
     it('detects mailer-daemon sender', () => {
       expect(isAutoOrBounce('mailer-daemon@googlemail.com', '')).toBe(true);
@@ -249,14 +273,59 @@ describe('imap-replies', () => {
   });
 
   describe('findReplies (via FakeImapClient)', () => {
-    it('returns only the genuine reply, filtering out bounce and self-copy', async () => {
+    it('returns the genuine reply AND the bounce (flagged isBounce), filtering out only the self-copy', async () => {
       const fake = makeFake(FAKE_MSGS);
       const result = await findReplies(PITCH_REFS, () => fake);
       expect(result).toHaveLength(1);
+      // Same outreachId (o1) for both fixtures — the bounce (later uid) collapses
+      // the map entry, same as two replies would. Confirms it carries isBounce.
       expect(result[0].outreachId).toBe('o1');
+      expect(result[0].isBounce).toBe(true);
+      expect(result[0].fromAddress).toBe('mailer-daemon@googlemail.com');
+    });
+
+    it('returns a genuine reply untouched (isBounce undefined) when no bounce follows it', async () => {
+      const fake = makeFake([FAKE_MSGS[0], FAKE_MSGS[2]]); // reply + self-copy only, no bounce
+      const result = await findReplies(PITCH_REFS, () => fake);
+      expect(result).toHaveLength(1);
+      expect(result[0].outreachId).toBe('o1');
+      expect(result[0].isBounce).toBeUndefined();
       expect(result[0].fromAddress).toBe('booking@thevenue.com');
       expect(result[0].snippet).toContain("Yes we'd love to host you");
       expect(result[0].gmailThreadId).toBe('thread-abc');
+    });
+
+    it('flags a bounce with no prior reply (isBounce: true, referencing the pitch)', async () => {
+      const fake = makeFake([FAKE_MSGS[1]]); // bounce only
+      const result = await findReplies(PITCH_REFS, () => fake);
+      expect(result).toEqual([{
+        outreachId: 'o1',
+        fromAddress: 'mailer-daemon@googlemail.com',
+        repliedAt: new Date('2026-06-21T11:00:00Z'),
+        snippet: 'Delivery failure notice.',
+        gmailThreadId: undefined,
+        isBounce: true,
+      }]);
+    });
+
+    it('drops a bounce that references none of our pitches (no outreachId to flag)', async () => {
+      const orphanBounce: FakeMsg = {
+        uid: 5,
+        envelope: {
+          messageId: '<orphan-bounce@mx.google.com>',
+          from: [{ address: 'mailer-daemon@googlemail.com' }],
+          date: new Date('2026-06-21T12:00:00Z'),
+        },
+        source: [
+          'From: mailer-daemon@googlemail.com',
+          'Subject: Delivery Status Notification (Failure)',
+          'Content-Type: multipart/report; report-type=delivery-status',
+          '',
+          'Delivery failure notice.',
+        ].join('\r\n'),
+      };
+      const result = await findReplies(PITCH_REFS, () => makeFake([orphanBounce]));
+      expect(result).toEqual([]);
     });
 
     it('returns [] when refs is empty (even with injected client)', async () => {

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -922,12 +922,58 @@ describe('Outreach Controller (#844 batch model)', () => {
         });
       });
 
-      it('surfaces a bounce record (no suggestion) in the pending queue', async () => {
-        const recs = [{ _id: 'o1', status: 'no-response', replyKind: 'bounce' }];
+      it('surfaces a bounce record while its venue still needs attention (active, not re-verified)', async () => {
+        const recs = [{ _id: 'o1', venueId: 'v1', status: 'no-response', replyKind: 'bounce' }];
         c.model.find = vi.fn(() => Promise.resolve(recs));
+        (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ contactVerified: false })));
         await c.listPendingReplies({ user: 'a' }, resStub);
         expect(status).toBe(200);
         expect(payload).toEqual(recs);
+      });
+
+      // #825 option B (decision 2026-07-02): bounce items auto-clear from venue
+      // state — no dismiss button. Three clear conditions:
+      it('auto-clears a bounce item once its venue is archived', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', replyKind: 'bounce' }]));
+        (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ status: 'archived' })));
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual([]);
+      });
+
+      it('auto-clears a bounce item once its venue is re-verified (contactVerified true)', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', replyKind: 'bounce' }]));
+        (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ contactVerified: true })));
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual([]);
+      });
+
+      it('auto-clears a bounce item whose venue no longer exists', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', replyKind: 'bounce' }]));
+        (venueModel as any).findById = vi.fn(() => Promise.resolve(null));
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual([]);
+      });
+
+      it('keeps a bounce item pending when the venue lookup fails (never hide on a read error)', async () => {
+        const recs = [{ _id: 'o1', venueId: 'v1', replyKind: 'bounce' }];
+        c.model.find = vi.fn(() => Promise.resolve(recs));
+        (venueModel as any).findById = vi.fn(() => Promise.reject(new Error('db read fail')));
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual(recs);
+      });
+
+      it('leaves genuine reply-suggestion items untouched by the bounce auto-clear (no venue lookup)', async () => {
+        const recs = [{ _id: 'o1', status: 'replied', suggestion: { sentiment: 'positive', reviewed: false } }];
+        c.model.find = vi.fn(() => Promise.resolve(recs));
+        (venueModel as any).findById = vi.fn(() => Promise.resolve(null)); // would clear a bounce; must not touch a reply
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual(recs);
+        expect(venueModel.findById).not.toHaveBeenCalled();
       });
 
       it('500s when the query throws', async () => {

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -818,7 +818,7 @@ describe('Outreach Controller (#844 batch model)', () => {
         c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', messageId: '<m1@x>' }]));
         findReplies.mockResolvedValue([]);
         await c.checkReplies({ user: 'a' }, resStub);
-        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0 });
+        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0, bounced: 0 });
       });
 
       it('marks a matched reply replied, stores the snippet + suggestion, and halts cadence', async () => {
@@ -828,7 +828,7 @@ describe('Outreach Controller (#844 batch model)', () => {
         }]);
         classifyReply.mockResolvedValue({ sentiment: 'positive', proposedBookingStatus: 'booking', model: 'claude-haiku-4-5' });
         await c.checkReplies({ user: 'a' }, resStub);
-        expect(payload).toEqual({ checked: 1, matched: 1, classified: 1 });
+        expect(payload).toEqual({ checked: 1, matched: 1, classified: 1, bounced: 0 });
         expect(c.model.findByIdAndUpdate).toHaveBeenCalledWith('o1', expect.objectContaining({
           status: 'replied', replySnippet: 'We would love to!', gmailThreadId: 't9', nextTouchDue: null,
           suggestion: expect.objectContaining({ sentiment: 'positive' }),
@@ -840,14 +840,14 @@ describe('Outreach Controller (#844 batch model)', () => {
         findReplies.mockResolvedValue([{ outreachId: 'o1', repliedAt: new Date(), snippet: 'hi' }]);
         classifyReply.mockResolvedValue(null);
         await c.checkReplies({ user: 'a' }, resStub);
-        expect(payload).toEqual({ checked: 1, matched: 1, classified: 0 });
+        expect(payload).toEqual({ checked: 1, matched: 1, classified: 0, bounced: 0 });
       });
 
       it('skips a match that does not correspond to a scanned record', async () => {
         c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', messageId: '<m1@x>' }]));
         findReplies.mockResolvedValue([{ outreachId: 'ghost', repliedAt: new Date(), snippet: 'hi' }]);
         await c.checkReplies({ user: 'a' }, resStub);
-        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0 });
+        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0, bounced: 0 });
       });
 
       it('swallows a per-record update failure without aborting the scan', async () => {
@@ -855,7 +855,49 @@ describe('Outreach Controller (#844 batch model)', () => {
         findReplies.mockResolvedValue([{ outreachId: 'o1', repliedAt: new Date(), snippet: 'hi' }]);
         c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('write fail')));
         await c.checkReplies({ user: 'a' }, resStub);
-        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0 });
+        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0, bounced: 0 });
+      });
+
+      // #825 bounce auto-flag: a bounced match auto-flags the venue + halts the
+      // outreach deterministically, with NO AI suggestion involved.
+      it('auto-flags the venue and halts the outreach on a bounce match, without classifying', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', messageId: '<m1@x>' }]));
+        findReplies.mockResolvedValue([{
+          outreachId: 'o1', fromAddress: 'mailer-daemon@x.com', repliedAt: new Date('2026-06-26'),
+          snippet: 'Delivery failure notice.', gmailThreadId: 't9', isBounce: true,
+        }]);
+        await c.checkReplies({ user: 'a' }, resStub);
+        expect(payload).toEqual({ checked: 1, matched: 1, classified: 0, bounced: 1 });
+        expect(classifyReply).not.toHaveBeenCalled();
+        expect(venueModel.findByIdAndUpdate).toHaveBeenCalledWith('v1', expect.objectContaining({
+          contactVerified: false, outreachEligible: false,
+        }));
+        expect(c.model.findByIdAndUpdate).toHaveBeenCalledWith('o1', expect.objectContaining({
+          status: 'no-response', nextTouchDue: null, replyKind: 'bounce',
+          replySnippet: 'Delivery failure notice.', gmailThreadId: 't9',
+        }));
+        expect(c.model.findByIdAndUpdate).not.toHaveBeenCalledWith('o1', expect.objectContaining({ suggestion: expect.anything() }));
+      });
+
+      it('swallows a bounce venue-write failure and still halts the outreach', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', messageId: '<m1@x>' }]));
+        findReplies.mockResolvedValue([{
+          outreachId: 'o1', repliedAt: new Date(), snippet: 'bounce', isBounce: true,
+        }]);
+        (venueModel as any).findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('venue write fail')));
+        await c.checkReplies({ user: 'a' }, resStub);
+        expect(payload).toEqual({ checked: 1, matched: 1, classified: 0, bounced: 1 });
+        expect(c.model.findByIdAndUpdate).toHaveBeenCalledWith('o1', expect.objectContaining({ status: 'no-response' }));
+      });
+
+      it('swallows a bounce outreach-write failure without aborting the scan', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'o1', venueId: 'v1', messageId: '<m1@x>' }]));
+        findReplies.mockResolvedValue([{
+          outreachId: 'o1', repliedAt: new Date(), snippet: 'bounce', isBounce: true,
+        }]);
+        c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('write fail')));
+        await c.checkReplies({ user: 'a' }, resStub);
+        expect(payload).toEqual({ checked: 1, matched: 0, classified: 0, bounced: 0 });
       });
     });
 
@@ -866,13 +908,26 @@ describe('Outreach Controller (#844 batch model)', () => {
         expect(status).toBe(403);
       });
 
-      it('returns replied records with an unreviewed suggestion', async () => {
+      it('returns replied records with an unreviewed suggestion, plus bounce records', async () => {
         const recs = [{ _id: 'o1', suggestion: { sentiment: 'positive', reviewed: false } }];
         c.model.find = vi.fn(() => Promise.resolve(recs));
         await c.listPendingReplies({ user: 'a' }, resStub);
         expect(status).toBe(200);
         expect(payload).toEqual(recs);
-        expect(c.model.find).toHaveBeenCalledWith(expect.objectContaining({ status: 'replied' }));
+        expect(c.model.find).toHaveBeenCalledWith({
+          $or: [
+            { status: 'replied', suggestion: { $ne: null }, 'suggestion.reviewed': { $ne: true } },
+            { replyKind: 'bounce' },
+          ],
+        });
+      });
+
+      it('surfaces a bounce record (no suggestion) in the pending queue', async () => {
+        const recs = [{ _id: 'o1', status: 'no-response', replyKind: 'bounce' }];
+        c.model.find = vi.fn(() => Promise.resolve(recs));
+        await c.listPendingReplies({ user: 'a' }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toEqual(recs);
       });
 
       it('500s when the query throws', async () => {


### PR DESCRIPTION
## Summary

Backend half of the #825 bounce auto-flag design (decision comment 2026-07-02). When `check-replies` encounters a genuine BOUNCE (mailer-daemon/postmaster, or a DSN `multipart/report` — matched deterministically, no AI judgment) for a sent outreach:

1. **Auto-updates the venue**: `contactVerified: false`, `outreachEligible: false` — a dead address can no longer be selected for a future batch.
2. **Halts the outreach record**: `status: 'no-response'`, `nextTouchDue: null` — cadence can never follow up on it.
3. **Records the bounce** (`replyKind: 'bounce'`) so `GET /outreach/replies-pending` surfaces it as a bounced item, distinct from a real reply — the upcoming JaMmusic UI (#1162) will render it as "bounced — needs new email". A bounce item carries no AI suggestion and needs no `apply-suggestion` step; the flag already took effect.
4. **Genuine non-bounce auto-replies** (out-of-office etc.) keep the existing skip behavior — only a true bounce (new `isBounce()`, a narrower subset of the existing `isAutoOrBounce()`) triggers the auto-flag.

Bounce items auto-clear from venue state (decision 2026-07-02, option B — no dismiss flow needed): a `replyKind: 'bounce'` record stays in `replies-pending` only while its venue still needs attention, and drops out automatically once the venue is archived, re-verified (`contactVerified: true`), or deleted. A venue-lookup failure keeps the item pending so a transient read error never hides an unresolved bounce; genuine reply-suggestion items are unaffected.

Part of #825

## Test plan
- [x] `npm test` (eslint + jscpd + vitest coverage) passes: 443 tests, coverage 91.85% stmts / 84.81% branch / 85.26% funcs / 92.47% lines, all above the 90/80/80/90 gate
- [x] `npm run typecheck` passes clean
- [x] Extended the injectable-client fixture tests in `test/unit/lib/imap-replies.spec.ts` (bounce-only match, reply-without-bounce, orphan bounce with no matching pitch) and `test/unit/outreach/outreach-controller.spec.ts` (bounce auto-flag, venue-write failure swallowed, outreach-write failure swallowed, updated `replies-pending` query, auto-clear on archived/re-verified/missing venue, still-pending + lookup-failure cases)
- [x] No prod/Atlas touched, no real email sent — mailer/IMAP stay mocked/injected throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
