### PR TITLE
Outreach endpoints accept optional custom pitch body (tracked send)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -49,6 +49,10 @@ interface SendBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
+  // #900 — optional one-off wording (e.g. "we stopped in Wednesday, submitted
+  // your form, left a card") woven into the rendered pitch ahead of the
+  // template copy, while still going through the tracked send pipeline.
+  customBody?: string;
 }
 
 // #844 — batch target-list approval. The approval gate is the TARGET SELECTION
@@ -62,6 +66,8 @@ interface BatchBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
+  // #900 — same customBody as SendBody, applied to every venue in the batch.
+  customBody?: string;
 }
 
 interface ConfigBody { autoApprove?: boolean; actor?: string }
@@ -136,14 +142,45 @@ function footerHtml(): string {
     + 'style="width:320px;max-width:100%;height:auto;border-radius:8px;display:block;margin:0 auto;"></td></tr></table>';
 }
 
+// customBody is free text (may come from a form, a phone paste, or an AI draft
+// upstream — #899) and is never trusted as HTML, unlike the vetted template
+// copy. Escape the five HTML-significant characters before it ever reaches
+// buildPitchEmail's output.
+function escapeHtml(text: string): string {
+  return text
+    .split('&').join('&amp;')
+    .split('<').join('&lt;')
+    .split('>').join('&gt;')
+    .split('"').join('&quot;')
+    .split("'").join('&#39;');
+}
+
+// Render a one-off customBody as its own HTML paragraph(s): escape first, then
+// turn blank-line breaks into paragraph breaks and single newlines into <br>,
+// so a multi-line note reads the way it was typed.
+function renderCustomBodyHtml(customBody: string): string {
+  const escaped = escapeHtml(customBody.trim());
+  const paragraphs = escaped.split(/\n{2,}/).map((para) => para.split('\n').join('<br>'));
+  return paragraphs.map((para) => `<p>${para}</p>`).join('\n');
+}
+
 // Render a template into a ready-to-send email: token-filled subject + body,
 // with the footer photo appended as an inline-CID attachment when the template
 // names one (and the asset is on disk).
+//
+// #900 — an optional customBody is woven in as an INTRO paragraph ahead of the
+// template's own copy (not a replacement): the template still supplies the
+// standard closing/signature/CTA, so a one-off note (e.g. "we stopped in
+// Wednesday, submitted your form, left a card") reads as a personal lead-in to
+// the familiar pitch rather than orphaning the send from its usual framing.
 function buildPitchEmail(venue: VenueDoc, template: TemplateDoc, body: SendBody): {
   subject: string; html: string; attachments: { filename: string; path: string; cid: string }[];
 } {
   const subject = personalize(template.subject || 'Performance Inquiry: Josh and Maria', venue, body);
   let html = personalize(template.bodyHtml || '', venue, body);
+  if (body.customBody && body.customBody.trim()) {
+    html = `${renderCustomBodyHtml(body.customBody)}\n${html}`;
+  }
   const attachments = [];
   const assetPath = template.footerPhotoRef ? resolveFooterAsset(template.footerPhotoRef) : null;
   /* istanbul ignore else */
@@ -466,7 +503,9 @@ class OutreachController extends Controller {
     };
     for (const venueId of body.venueIds) {
       if (!mongoose.Types.ObjectId.isValid(venueId)) { result.skipped.push({ venueId, reason: 'invalid id' }); continue; }
-      const sendBody = { targetDates: body.targetDates, bookingPeriod: body.bookingPeriod, cc: body.cc };
+      const sendBody = {
+        targetDates: body.targetDates, bookingPeriod: body.bookingPeriod, cc: body.cc, customBody: body.customBody,
+      };
       // eslint-disable-next-line no-await-in-loop
       const ctx = await this.resolvePitch({ venueId, templateType: body.templateType, ...sendBody });
       if (ctx.error) { result.skipped.push({ venueId, reason: ctx.error.message }); continue; }
@@ -521,6 +560,7 @@ class OutreachController extends Controller {
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     const q = (req.query || {}) as {
       venueId?: string; venueIds?: string; templateType?: string; targetDates?: string; bookingPeriod?: string;
+      customBody?: string;
     };
 
     // BATCH form: venueIds (plural, comma-separated) → array of preview objects.
@@ -536,7 +576,8 @@ class OutreachController extends Controller {
         if (ctx.error) continue; // skip unresolvable venues
         const { venue, template } = ctx as Required<PitchContext>;
         const { subject, html } = buildPitchEmail(
-          venue, template, { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod } as SendBody,
+          venue, template,
+          { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customBody: q.customBody } as SendBody,
         );
         results.push({ venueId, venueName: venue.name || '', subject, body: html });
       }
@@ -551,7 +592,9 @@ class OutreachController extends Controller {
     );
     if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
     const { venue, template } = ctx as Required<PitchContext>;
-    const { subject, html } = buildPitchEmail(venue, template, { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod } as SendBody);
+    const { subject, html } = buildPitchEmail(
+      venue, template, { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customBody: q.customBody } as SendBody,
+    );
     return res.status(200).json({ to: venue.email, cc: PITCH_CC, subject, html });
   }
 

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -14,13 +14,17 @@ const router = express.Router();
 // parsed as an id.
 
 // POST /outreach/send — send ONE pitch immediately to a vetted venue (#844).
+// Body accepts an optional `customBody` (#900) — one-off wording woven into
+// the rendered pitch ahead of the template copy; still goes through the full
+// tracked pipeline (record, PITCH_CC, cadence).
 router.route('/send')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'sendPitch', controller, authUtils);
     void action();
   });
 
-// POST /outreach/batch — send the approved target list (#844).
+// POST /outreach/batch — send the approved target list (#844). Body accepts
+// an optional `customBody` (#900), applied to every venue in the batch.
 router.route('/batch')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'sendBatch', controller, authUtils);
@@ -35,6 +39,8 @@ router.route('/candidates')
   });
 
 // GET /outreach/preview — render a venue's pitch email without sending (#844).
+// Accepts an optional `customBody` query param (#900) so the woven-in wording
+// can be reviewed before send.
 router.route('/preview')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'previewByVenue', controller, authUtils);

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -503,6 +503,110 @@ describe('Outreach Controller (#844 batch model)', () => {
     });
   });
 
+  describe('customBody (#900)', () => {
+    const body = () => ({ venueId: oid(), targetDates: 'Aug 14-16', bookingPeriod: 'August' });
+
+    it('sendPitch: absent customBody leaves the rendered html byte-for-byte unchanged', async () => {
+      asApprover();
+      await c.sendPitch({ user: 'josh', body: body() }, resStub);
+      expect(status).toBe(201);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html).toBe(
+        '<p>Hi Pat, we are booking our August run and want Aug 14-16 at The Spot on Kirk.</p>'
+          + '\n<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin-top:16px;">'
+          + '<tr><td style="text-align:center;">'
+          + '<img src="cid:footerphoto" width="320" alt="Josh and Maria performing" '
+          + 'style="width:320px;max-width:100%;height:auto;border-radius:8px;display:block;margin:0 auto;"></td></tr></table>',
+      );
+    });
+
+    it('sendPitch: a present customBody is prepended ahead of the template body', async () => {
+      asApprover();
+      await c.sendPitch({ user: 'josh', body: { ...body(), customBody: 'We stopped in Wednesday and left a card.' } }, resStub);
+      expect(status).toBe(201);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.indexOf('<p>We stopped in Wednesday and left a card.</p>')).toBe(0);
+      expect(html).toContain('Hi Pat, we are booking our August run');
+      // cc / tracking / cadence stay intact regardless of customBody.
+      expect((sendMail as any).mock.calls[0][0].cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
+      const rec = (c.model.create as any).mock.calls[0][0];
+      expect(rec.status).toBe('sent');
+      expect(rec.nextTouchDue).toBeInstanceOf(Date);
+    });
+
+    it('sendPitch: a blank/whitespace-only customBody is treated as absent', async () => {
+      asApprover();
+      await c.sendPitch({ user: 'josh', body: { ...body(), customBody: '   ' } }, resStub);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.startsWith('<p>Hi Pat')).toBe(true);
+    });
+
+    it('sendPitch: customBody is HTML-escaped', async () => {
+      asApprover();
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customBody: 'Q&A: is "5pm" ok? <script>bad()</script>' } },
+        resStub,
+      );
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html).toContain('Q&amp;A: is &quot;5pm&quot; ok? &lt;script&gt;bad()&lt;/script&gt;');
+      expect(html).not.toContain('<script>');
+    });
+
+    it('sendPitch: a multi-line customBody renders as multiple paragraphs with <br> for single breaks', async () => {
+      asApprover();
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customBody: 'Line one\nLine two\n\nSecond paragraph' } },
+        resStub,
+      );
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html).toContain('<p>Line one<br>Line two</p>\n<p>Second paragraph</p>');
+    });
+
+    it('sendBatch: threads customBody to every venue in the batch', async () => {
+      asApprover();
+      await c.sendBatch(
+        { user: 'josh', body: { venueIds: [oid(), oid()], targetDates: 'Aug 14-16', customBody: 'Loved your open mic last week!' } },
+        resStub,
+      );
+      expect(status).toBe(200);
+      expect(payload.sent).toBe(2);
+      expect((sendMail as any).mock.calls[0][0].html).toContain('<p>Loved your open mic last week!</p>');
+      expect((sendMail as any).mock.calls[1][0].html).toContain('<p>Loved your open mic last week!</p>');
+    });
+
+    it('sendBatch: absent customBody leaves batch sends unchanged', async () => {
+      asApprover();
+      await c.sendBatch({ user: 'josh', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
+      expect((sendMail as any).mock.calls[0][0].html.startsWith('<p>Hi Pat')).toBe(true);
+    });
+
+    it('previewByVenue (single form): reflects customBody without sending', async () => {
+      await c.previewByVenue(
+        { user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16', customBody: 'We met at the farmers market.' } },
+        resStub,
+      );
+      expect(status).toBe(200);
+      expect(sendMail).not.toHaveBeenCalled();
+      expect(payload.html).toContain('<p>We met at the farmers market.</p>');
+      expect(payload.html).toContain('Hi Pat,');
+    });
+
+    it('previewByVenue (batch form): reflects customBody per venue', async () => {
+      const id1 = oid();
+      await c.previewByVenue(
+        { user: 'a', query: { venueIds: id1, targetDates: 'Sept 25-27', customBody: 'Card left at the bar.' } },
+        resStub,
+      );
+      expect(status).toBe(200);
+      expect(payload[0].body).toContain('<p>Card left at the bar.</p>');
+    });
+
+    it('previewByVenue: absent customBody leaves preview unchanged', async () => {
+      await c.previewByVenue({ user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
+      expect(payload.html.startsWith('<p>Hi Pat')).toBe(true);
+    });
+  });
+
   describe('config — auto-approve (#844)', () => {
     it('reads the default (OFF) when no doc exists', async () => {
       await c.getOutreachConfig({ user: 'a', query: {} }, resStub);


### PR DESCRIPTION
## Summary
- Add optional `customBody` to `/outreach/send`, `/outreach/batch`, and `/outreach/preview` — free-text one-off wording (e.g. a visit + form + card note) woven into the rendered pitch as escaped intro paragraph(s) ahead of the template copy.
- Keep the full tracked pipeline intact when `customBody` is set: outreach record, `PITCH_CC` (Josh + Maria), and cadence follow-ups are unchanged.
- `customBody` is HTML-escaped (never trusted as markup); blank lines become paragraph breaks, single newlines become `<br>`.
- Absent or whitespace-only `customBody` = byte-for-byte unchanged behavior (plain 4-token template merge).
- Unblocks the parked Big Lick Brewing follow-up (visit + form + card, target Fri 9/25–Sun 9/27).

Closes #900

## How to test locally
Run the suite + typecheck:
```sh
npx vitest run test/unit/outreach/outreach-controller.spec.ts
npm run typecheck
```
Expect: outreach spec green (133 tests), typecheck exit 0.

Exercise the change (preview, no send) — substitute a real venue id + bearer token:
```sh
curl -s 'https://webjamsalem.herokuapp.com/outreach/preview?venueId=VENUE_ID&targetDates=Sept%2025-27&customBody=We%20stopped%20in%20Wednesday%2C%20left%20a%20card.' -H 'Authorization: Bearer TOKEN'
```
Expect: HTTP 200 JSON whose `html` opens with an escaped `p` paragraph containing the customBody text, followed by the usual template body; omitting `customBody` returns the unchanged pitch.

## Test evidence
```
 Test Files  1 passed (1)
      Tests  133 passed (133)

> web-jam-back@2.0.47 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
TYPECHECK EXIT: 0
```
(Full `npm test` also runs eslint + jscpd, both green; the only failing test is the unrelated `admin-user` `mintToken` case, which requires `HashString` in the local env — set in CI, untouched by this change.)

🤖 Work by Claude Code — Sonnet 5