### PR TITLE
Outreach custom pitch: custom-intro (replaces intro) + custom-body (inserts at [Custom Body] marker) — supersedes #900 prepend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.46",
+  "version": "2.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.0.46",
+      "version": "2.0.48",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/scripts/seed-outreach.mjs
+++ b/scripts/seed-outreach.mjs
@@ -40,10 +40,14 @@ if (!isLocal && !isDevOrTest) {
 const { Schema } = mongoose;
 
 // mirror: src/model/template/template-schema.ts — unique index on (type, stage)
+// introHtml + the bodyHtml [Custom Body] marker are the #903 template migration
+// (see the templates array below): intro split out so a per-send customIntro
+// can replace it; marker dropped into bodyHtml as the customBody insertion point.
 const templateSchema = new Schema({
   type: { type: String, required: true, enum: ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar', 'OnlineForm'] },
   stage: { type: String, enum: ['cold', 'returning'], default: 'cold' },
   subject: String,
+  introHtml: String,
   bodyHtml: String,
   footerPhotoRef: String,
   active: { type: Boolean, default: true },
@@ -97,15 +101,29 @@ const Outreach = mongoose.models.Outreach || mongoose.model('Outreach', outreach
 const OutreachConfig = mongoose.models.OutreachConfig || mongoose.model('OutreachConfig', configSchema);
 
 // ── Seed data: 6 Templates (3 venueTypes × 2 stages) ────────────────────────
+//
+// #903 template migration: each template's intro (greeting + opening line)
+// is split out into `introHtml`, and `bodyHtml` now opens with a
+// `[Custom Body]` marker at the insertion point for a per-send customBody.
+// The intro/body split boundary is consistent across all 6: introHtml is the
+// first two <p> blocks (greeting, then the opening line introducing who we
+// are / the context); bodyHtml is the marker followed by everything else
+// (the ask, any closing line, and the signature). Concatenating
+// introHtml + bodyHtml-with-marker-removed reproduces the pre-#903 bodyHtml
+// byte-for-byte (verified: neither slot adds or removes any surrounding
+// whitespace beyond the marker token itself).
 
 const templates = [
   {
     type: 'Originals', stage: 'cold',
     subject: 'Performance Inquiry: Josh & Maria at [Venue Name]',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>My name is Josh Sherman and I perform alongside my wife Maria as an acoustic duo',
       ' based in Salem, VA. We specialize in original music and love venues that value songwriting.</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>We\'d love to be considered for a slot at [Venue Name] around [Target Dates].',
       ' Our [Booking Period] calendar is filling up and [Venue Name] would be a great fit.</p>',
       '<p>Happy to send samples or answer any questions.</p>',
@@ -117,10 +135,13 @@ const templates = [
   {
     type: 'Originals', stage: 'returning',
     subject: 'Would love to return to [Venue Name] — Josh & Maria',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>We loved playing at [Venue Name] and would be thrilled to come back',
       ' for another show around [Target Dates] during [Booking Period].</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>We have some new songs since our last visit and would love to share them with your crowd again.</p>',
       '<p>Best,<br>Josh &amp; Maria<br>540-494-8035<br>',
       '<a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>',
@@ -130,10 +151,13 @@ const templates = [
   {
     type: 'PubFestivalBrewery', stage: 'cold',
     subject: 'Live Music Inquiry — Josh & Maria for [Venue Name]',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>I\'m Josh Sherman — my wife Maria and I perform as an acoustic duo out of Salem, VA.',
       ' We play a crowd-pleasing mix of covers and originals, perfect for a pub or brewery atmosphere.</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>We\'d love to play [Venue Name] around [Target Dates].',
       ' We\'re booking our [Booking Period] dates and think [Venue Name] would be a great fit.</p>',
       '<p>Happy to share samples!</p>',
@@ -145,10 +169,13 @@ const templates = [
   {
     type: 'PubFestivalBrewery', stage: 'returning',
     subject: 'We\'d love to return to [Venue Name] — Josh & Maria',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>Thank you again for having us at [Venue Name] — the crowd was fantastic.',
       ' We\'d love to come back around [Target Dates] if there\'s a spot available during [Booking Period].</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>Same acoustic duo, same good energy.</p>',
       '<p>Best,<br>Josh &amp; Maria<br>540-494-8035<br>',
       '<a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>',
@@ -158,10 +185,13 @@ const templates = [
   {
     type: 'MidRangeCafeBar', stage: 'cold',
     subject: 'Acoustic Live Music for [Venue Name] — Josh & Maria',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>I\'m Josh Sherman — my wife Maria and I are an acoustic duo in Salem, VA.',
       ' We play original songs and acoustic covers, ideal for a relaxed café or bar setting.</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>We\'d love to bring live music to [Venue Name] around [Target Dates]',
       ' — looks like a great spot for [Booking Period] entertainment.</p>',
       '<p>Thanks for your consideration!</p>',
@@ -173,10 +203,13 @@ const templates = [
   {
     type: 'MidRangeCafeBar', stage: 'returning',
     subject: 'Hope to play [Venue Name] again — Josh & Maria',
-    bodyHtml: [
+    introHtml: [
       '<p>Hi [Contact Name],</p>',
       '<p>It was great playing at [Venue Name] — we\'d love to come back',
       ' around [Target Dates] for [Booking Period] if you have availability.</p>',
+    ].join(''),
+    bodyHtml: [
+      '[Custom Body]',
       '<p>Same acoustic duo, a few new songs, same good vibes.</p>',
       '<p>Best,<br>Josh &amp; Maria<br>540-494-8035<br>',
       '<a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>',

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -49,9 +49,13 @@ interface SendBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
-  // #900 — optional one-off wording (e.g. "we stopped in Wednesday, submitted
-  // your form, left a card") woven into the rendered pitch ahead of the
-  // template copy, while still going through the tracked send pipeline.
+  // #903 — two optional, independent one-off slots (supersedes #900's single
+  // prepended customBody, which caused a double-greeting):
+  //   customIntro — REPLACES the template's own intro (greeting + opening
+  //     line) when present; the default intro is not emitted alongside it.
+  //   customBody  — INSERTED at the template's [Custom Body] marker; the rest
+  //     of the body is unchanged. Absent => the marker renders to nothing.
+  customIntro?: string;
   customBody?: string;
 }
 
@@ -66,7 +70,8 @@ interface BatchBody {
   bookingPeriod?: string;
   actor?: string;
   cc?: string | string[];
-  // #900 — same customBody as SendBody, applied to every venue in the batch.
+  // #903 — same customIntro/customBody as SendBody, applied to every venue in the batch.
+  customIntro?: string;
   customBody?: string;
 }
 
@@ -78,7 +83,11 @@ interface VenueDoc {
   venueType?: string; status?: string; outreachEligible?: boolean; contactVerified?: boolean;
   bookingStatus?: string; relationshipStage?: string; templateOverride?: string;
 }
-interface TemplateDoc { type?: string; subject?: string; bodyHtml?: string; footerPhotoRef?: string }
+// introHtml (#903) is the template's addressable intro (greeting + opening
+// line), split out from bodyHtml so customIntro can replace it independently.
+// A template authored before the #903 migration simply has no introHtml (it
+// defaults to '' at render time) — its whole copy lives in bodyHtml, unchanged.
+interface TemplateDoc { type?: string; subject?: string; introHtml?: string; bodyHtml?: string; footerPhotoRef?: string }
 interface FollowUp { sentAt?: Date; type?: string; messageId?: string; eventId?: string; step?: number }
 interface OutreachDoc {
   _id?: unknown; venueId?: unknown; sentAt?: Date; step?: number; targetDates?: string; followUps?: FollowUp[];
@@ -142,10 +151,10 @@ function footerHtml(): string {
     + 'style="width:320px;max-width:100%;height:auto;border-radius:8px;display:block;margin:0 auto;"></td></tr></table>';
 }
 
-// customBody is free text (may come from a form, a phone paste, or an AI draft
-// upstream — #899) and is never trusted as HTML, unlike the vetted template
-// copy. Escape the five HTML-significant characters before it ever reaches
-// buildPitchEmail's output.
+// customIntro / customBody are free text (may come from a form, a phone paste,
+// or an AI draft upstream — #899) and are never trusted as HTML, unlike the
+// vetted template copy. Escape the five HTML-significant characters before
+// either ever reaches buildPitchEmail's output.
 function escapeHtml(text: string): string {
   return text
     .split('&').join('&amp;')
@@ -155,32 +164,55 @@ function escapeHtml(text: string): string {
     .split("'").join('&#39;');
 }
 
-// Render a one-off customBody as its own HTML paragraph(s): escape first, then
-// turn blank-line breaks into paragraph breaks and single newlines into <br>,
-// so a multi-line note reads the way it was typed.
-function renderCustomBodyHtml(customBody: string): string {
-  const escaped = escapeHtml(customBody.trim());
+// Render one-off custom text (either slot) as its own HTML paragraph(s):
+// escape first, then turn blank-line breaks into paragraph breaks and single
+// newlines into <br>, so a multi-line note reads the way it was typed.
+function renderCustomHtml(customText: string): string {
+  const escaped = escapeHtml(customText.trim());
   const paragraphs = escaped.split(/\n{2,}/).map((para) => para.split('\n').join('<br>'));
   return paragraphs.map((para) => `<p>${para}</p>`).join('\n');
 }
 
-// Render a template into a ready-to-send email: token-filled subject + body,
-// with the footer photo appended as an inline-CID attachment when the template
-// names one (and the asset is on disk).
+// #903 — the token a body template carries at the exact spot a customBody
+// should land. Kept out of the schema (it's copy authored into bodyHtml, not
+// a separate field) so an editor can move it per template.
+const CUSTOM_BODY_MARKER = '[Custom Body]';
+
+// #903 — customIntro (when present) REPLACES the template's own intro
+// (greeting + opening line) rather than being woven in alongside it — this is
+// what kills the double-greeting #900's prepend caused. Absent => the
+// template's own introHtml renders exactly as authored (personalized).
+function resolveIntroHtml(template: TemplateDoc, venue: VenueDoc, body: SendBody): string {
+  if (body.customIntro && body.customIntro.trim()) return renderCustomHtml(body.customIntro);
+  return personalize(template.introHtml || '', venue, body);
+}
+
+// #903 — customBody (when present) is INSERTED at the body's [Custom Body]
+// marker; the rest of the body is untouched (an insert, not a replace).
+// Absent => the marker renders to nothing. A body that predates the #903
+// template migration carries no marker at all — rather than silently
+// dropping a supplied customBody in that case, append it after the body so
+// the note is never lost, just less precisely placed.
+function fillCustomBodyMarker(bodyHtml: string, customBody?: string): string {
+  const custom = customBody && customBody.trim() ? renderCustomHtml(customBody) : '';
+  if (bodyHtml.indexOf(CUSTOM_BODY_MARKER) !== -1) return bodyHtml.split(CUSTOM_BODY_MARKER).join(custom);
+  return custom ? `${bodyHtml}\n${custom}` : bodyHtml;
+}
+
+// Render a template into a ready-to-send email: token-filled subject + intro +
+// body, with the footer photo appended as an inline-CID attachment when the
+// template names one (and the asset is on disk).
 //
-// #900 — an optional customBody is woven in as an INTRO paragraph ahead of the
-// template's own copy (not a replacement): the template still supplies the
-// standard closing/signature/CTA, so a one-off note (e.g. "we stopped in
-// Wednesday, submitted your form, left a card") reads as a personal lead-in to
-// the familiar pitch rather than orphaning the send from its usual framing.
+// #903 — customIntro/customBody are two independent optional slots (see the
+// resolveIntroHtml / fillCustomBodyMarker docs above); when both are absent,
+// this renders byte-for-byte identically to the pre-#903 template render.
 function buildPitchEmail(venue: VenueDoc, template: TemplateDoc, body: SendBody): {
   subject: string; html: string; attachments: { filename: string; path: string; cid: string }[];
 } {
   const subject = personalize(template.subject || 'Performance Inquiry: Josh and Maria', venue, body);
-  let html = personalize(template.bodyHtml || '', venue, body);
-  if (body.customBody && body.customBody.trim()) {
-    html = `${renderCustomBodyHtml(body.customBody)}\n${html}`;
-  }
+  const introHtml = resolveIntroHtml(template, venue, body);
+  const bodyHtml = fillCustomBodyMarker(personalize(template.bodyHtml || '', venue, body), body.customBody);
+  let html = introHtml + bodyHtml;
   const attachments = [];
   const assetPath = template.footerPhotoRef ? resolveFooterAsset(template.footerPhotoRef) : null;
   /* istanbul ignore else */
@@ -504,7 +536,8 @@ class OutreachController extends Controller {
     for (const venueId of body.venueIds) {
       if (!mongoose.Types.ObjectId.isValid(venueId)) { result.skipped.push({ venueId, reason: 'invalid id' }); continue; }
       const sendBody = {
-        targetDates: body.targetDates, bookingPeriod: body.bookingPeriod, cc: body.cc, customBody: body.customBody,
+        targetDates: body.targetDates, bookingPeriod: body.bookingPeriod, cc: body.cc,
+        customIntro: body.customIntro, customBody: body.customBody,
       };
       // eslint-disable-next-line no-await-in-loop
       const ctx = await this.resolvePitch({ venueId, templateType: body.templateType, ...sendBody });
@@ -560,7 +593,7 @@ class OutreachController extends Controller {
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     const q = (req.query || {}) as {
       venueId?: string; venueIds?: string; templateType?: string; targetDates?: string; bookingPeriod?: string;
-      customBody?: string;
+      customIntro?: string; customBody?: string;
     };
 
     // BATCH form: venueIds (plural, comma-separated) → array of preview objects.
@@ -577,7 +610,9 @@ class OutreachController extends Controller {
         const { venue, template } = ctx as Required<PitchContext>;
         const { subject, html } = buildPitchEmail(
           venue, template,
-          { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customBody: q.customBody } as SendBody,
+          {
+            targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customIntro: q.customIntro, customBody: q.customBody,
+          } as SendBody,
         );
         results.push({ venueId, venueName: venue.name || '', subject, body: html });
       }
@@ -593,7 +628,10 @@ class OutreachController extends Controller {
     if (ctx.error) return res.status(ctx.error.status).json({ message: ctx.error.message });
     const { venue, template } = ctx as Required<PitchContext>;
     const { subject, html } = buildPitchEmail(
-      venue, template, { targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customBody: q.customBody } as SendBody,
+      venue, template,
+      {
+        targetDates: q.targetDates, bookingPeriod: q.bookingPeriod, customIntro: q.customIntro, customBody: q.customBody,
+      } as SendBody,
     );
     return res.status(200).json({ to: venue.email, cc: PITCH_CC, subject, html });
   }

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -14,9 +14,10 @@ const router = express.Router();
 // parsed as an id.
 
 // POST /outreach/send — send ONE pitch immediately to a vetted venue (#844).
-// Body accepts an optional `customBody` (#900) — one-off wording woven into
-// the rendered pitch ahead of the template copy; still goes through the full
-// tracked pipeline (record, PITCH_CC, cadence).
+// Body accepts two optional, independent slots (#903, supersedes #900's
+// prepend): `customIntro` REPLACES the template's own intro; `customBody` is
+// INSERTED at the template's [Custom Body] marker. Still goes through the
+// full tracked pipeline (record, PITCH_CC, cadence).
 router.route('/send')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'sendPitch', controller, authUtils);
@@ -24,7 +25,8 @@ router.route('/send')
   });
 
 // POST /outreach/batch — send the approved target list (#844). Body accepts
-// an optional `customBody` (#900), applied to every venue in the batch.
+// the same optional `customIntro` + `customBody` (#903), applied to every
+// venue in the batch.
 router.route('/batch')
   .post((req, res) => {
     const action = routeUtils.makeAction(req, res, 'sendBatch', controller, authUtils);
@@ -39,8 +41,8 @@ router.route('/candidates')
   });
 
 // GET /outreach/preview — render a venue's pitch email without sending (#844).
-// Accepts an optional `customBody` query param (#900) so the woven-in wording
-// can be reviewed before send.
+// Accepts optional `customIntro` + `customBody` query params (#903) so either
+// slot can be reviewed before send.
 router.route('/preview')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'previewByVenue', controller, authUtils);

--- a/src/model/template/template-controller.ts
+++ b/src/model/template/template-controller.ts
@@ -28,6 +28,9 @@ interface TemplateBody {
   type?: string;
   stage?: string;
   subject?: string;
+  // introHtml (#903) — the addressable intro (greeting + opening line),
+  // split out from bodyHtml so a per-send customIntro can replace it.
+  introHtml?: string;
   bodyHtml?: string;
   footerPhotoRef?: string;
   active?: boolean;

--- a/src/model/template/template-schema.ts
+++ b/src/model/template/template-schema.ts
@@ -13,6 +13,14 @@ const options = {
 // [Target Dates], filled in at send time (#823). `footerPhotoRef` is a KEY into
 // the repo-bundled email assets (resolved to an inline-CID image at send), not a
 // URL. `type` is unique — one template per type.
+//
+// `introHtml` (#903) is the template's addressable intro (greeting + opening
+// line), split out from `bodyHtml` so a per-send `customIntro` can REPLACE it
+// without also emitting the default greeting (the #900 double-greeting bug).
+// `bodyHtml` carries a `[Custom Body]` marker at the spot a per-send
+// `customBody` should be INSERTED; a template with no marker just has no
+// insertion point. Both introHtml and the marker are optional — a template
+// authored before #903 has neither and renders exactly as before.
 const templateSchema = new Schema({
   type: {
     type: String,
@@ -30,6 +38,7 @@ const templateSchema = new Schema({
     default: 'cold',
   },
   subject: { type: String, required: false, trim: true },
+  introHtml: { type: String, required: false },
   bodyHtml: { type: String, required: false },
   footerPhotoRef: { type: String, required: false, trim: true },
   active: { type: Boolean, required: false, default: true },

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -69,6 +69,17 @@ describe('Outreach Controller (#844 batch model)', () => {
     ...over,
   });
 
+  // #903 — a migrated template: introHtml split out (greeting), bodyHtml
+  // carries the [Custom Body] marker right where the ask begins.
+  const templateWithSlots = (over = {}) => ({
+    type: 'Originals',
+    subject: 'Performance Inquiry for [Venue Name]',
+    introHtml: '<p>Hi [Contact Name],</p>',
+    bodyHtml: '[Custom Body]<p>we are booking our [Booking Period] run and want [Target Dates] at [Venue Name].</p>',
+    footerPhotoRef: 'footer-josh-maria',
+    ...over,
+  });
+
   beforeEach(() => {
     status = 0;
     payload = undefined;
@@ -503,10 +514,10 @@ describe('Outreach Controller (#844 batch model)', () => {
     });
   });
 
-  describe('customBody (#900)', () => {
+  describe('customIntro + customBody (#903, supersedes #900)', () => {
     const body = () => ({ venueId: oid(), targetDates: 'Aug 14-16', bookingPeriod: 'August' });
 
-    it('sendPitch: absent customBody leaves the rendered html byte-for-byte unchanged', async () => {
+    it('sendPitch: both absent leaves the rendered html byte-for-byte unchanged (un-migrated template, no marker)', async () => {
       asApprover();
       await c.sendPitch({ user: 'josh', body: body() }, resStub);
       expect(status).toBe(201);
@@ -520,29 +531,99 @@ describe('Outreach Controller (#844 batch model)', () => {
       );
     });
 
-    it('sendPitch: a present customBody is prepended ahead of the template body', async () => {
+    it('sendPitch: both absent on a migrated (marker-carrying) template is also byte-for-byte unchanged', async () => {
       asApprover();
-      await c.sendPitch({ user: 'josh', body: { ...body(), customBody: 'We stopped in Wednesday and left a card.' } }, resStub);
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch({ user: 'josh', body: body() }, resStub);
+      expect(status).toBe(201);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      // introHtml ("Hi Pat,") + bodyHtml with the marker stripped to '' reproduces
+      // exactly the same copy the pre-#903 single-bodyHtml template would render.
+      expect(html.startsWith('<p>Hi Pat,</p><p>we are booking our August run and want Aug 14-16 at The Spot on Kirk.</p>')).toBe(true);
+      expect(html).not.toContain('[Custom Body]');
+    });
+
+    it('sendPitch: customIntro REPLACES the template intro — default intro is not also emitted (kills the #900 double-greeting)', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customIntro: 'We stopped in Wednesday and left a card.' } },
+        resStub,
+      );
       expect(status).toBe(201);
       const html = (sendMail as any).mock.calls[0][0].html;
       expect(html.indexOf('<p>We stopped in Wednesday and left a card.</p>')).toBe(0);
-      expect(html).toContain('Hi Pat, we are booking our August run');
-      // cc / tracking / cadence stay intact regardless of customBody.
+      expect(html).not.toContain('Hi Pat,'); // default intro NOT emitted alongside customIntro
+      expect(html).toContain('we are booking our August run');
+    });
+
+    it('sendPitch: customBody is INSERTED at the [Custom Body] marker, template intro stays intact', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customBody: 'Loved your open mic last week!' } },
+        resStub,
+      );
+      expect(status).toBe(201);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.startsWith('<p>Hi Pat,</p><p>Loved your open mic last week!</p><p>we are booking our August run')).toBe(true);
+    });
+
+    it('sendPitch: customIntro and customBody together — replace + insert, no double-greeting', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch(
+        {
+          user: 'josh',
+          body: { ...body(), customIntro: 'Hey Pat, following up!', customBody: 'We met at the farmers market.' },
+        },
+        resStub,
+      );
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.indexOf('<p>Hey Pat, following up!</p>')).toBe(0);
+      expect(html).not.toContain('Hi Pat,');
+      expect(html).toContain('<p>We met at the farmers market.</p><p>we are booking our August run');
+      // cc / tracking / cadence stay intact regardless of the custom slots.
       expect((sendMail as any).mock.calls[0][0].cc).toEqual(['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com']);
       const rec = (c.model.create as any).mock.calls[0][0];
       expect(rec.status).toBe('sent');
       expect(rec.nextTouchDue).toBeInstanceOf(Date);
     });
 
-    it('sendPitch: a blank/whitespace-only customBody is treated as absent', async () => {
+    it('sendPitch: a customBody supplied against an un-migrated (marker-less) template is appended, never dropped', async () => {
       asApprover();
-      await c.sendPitch({ user: 'josh', body: { ...body(), customBody: '   ' } }, resStub);
+      await c.sendPitch({ user: 'josh', body: { ...body(), customBody: 'We stopped in Wednesday and left a card.' } }, resStub);
+      expect(status).toBe(201);
       const html = (sendMail as any).mock.calls[0][0].html;
-      expect(html.startsWith('<p>Hi Pat')).toBe(true);
+      expect(html).toContain('Hi Pat, we are booking our August run');
+      expect(html).toContain('<p>We stopped in Wednesday and left a card.</p>');
+      // appended after the body, not prepended (the #900 behavior this supersedes).
+      expect(html.indexOf('<p>We stopped in Wednesday and left a card.</p>')).toBeGreaterThan(html.indexOf('Hi Pat'));
+    });
+
+    it('sendPitch: blank/whitespace-only customIntro and customBody are treated as absent', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch({ user: 'josh', body: { ...body(), customIntro: '   ', customBody: '  ' } }, resStub);
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.startsWith('<p>Hi Pat,</p><p>we are booking our August run')).toBe(true);
+    });
+
+    it('sendPitch: customIntro is HTML-escaped', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customIntro: 'Q&A: is "5pm" ok? <script>bad()</script>' } },
+        resStub,
+      );
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html).toContain('Q&amp;A: is &quot;5pm&quot; ok? &lt;script&gt;bad()&lt;/script&gt;');
+      expect(html).not.toContain('<script>');
     });
 
     it('sendPitch: customBody is HTML-escaped', async () => {
       asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
       await c.sendPitch(
         { user: 'josh', body: { ...body(), customBody: 'Q&A: is "5pm" ok? <script>bad()</script>' } },
         resStub,
@@ -554,6 +635,7 @@ describe('Outreach Controller (#844 batch model)', () => {
 
     it('sendPitch: a multi-line customBody renders as multiple paragraphs with <br> for single breaks', async () => {
       asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
       await c.sendPitch(
         { user: 'josh', body: { ...body(), customBody: 'Line one\nLine two\n\nSecond paragraph' } },
         resStub,
@@ -562,46 +644,79 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(html).toContain('<p>Line one<br>Line two</p>\n<p>Second paragraph</p>');
     });
 
-    it('sendBatch: threads customBody to every venue in the batch', async () => {
+    it('sendPitch: a multi-line customIntro renders as multiple paragraphs with <br> for single breaks', async () => {
       asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
+      await c.sendPitch(
+        { user: 'josh', body: { ...body(), customIntro: 'Line one\nLine two\n\nSecond paragraph' } },
+        resStub,
+      );
+      const html = (sendMail as any).mock.calls[0][0].html;
+      expect(html.indexOf('<p>Line one<br>Line two</p>\n<p>Second paragraph</p>')).toBe(0);
+    });
+
+    it('sendBatch: threads customIntro + customBody to every venue in the batch', async () => {
+      asApprover();
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
       await c.sendBatch(
-        { user: 'josh', body: { venueIds: [oid(), oid()], targetDates: 'Aug 14-16', customBody: 'Loved your open mic last week!' } },
+        {
+          user: 'josh',
+          body: {
+            venueIds: [oid(), oid()], targetDates: 'Aug 14-16',
+            customIntro: 'Hey again!', customBody: 'Loved your open mic last week!',
+          },
+        },
         resStub,
       );
       expect(status).toBe(200);
       expect(payload.sent).toBe(2);
+      expect((sendMail as any).mock.calls[0][0].html.indexOf('<p>Hey again!</p>')).toBe(0);
       expect((sendMail as any).mock.calls[0][0].html).toContain('<p>Loved your open mic last week!</p>');
       expect((sendMail as any).mock.calls[1][0].html).toContain('<p>Loved your open mic last week!</p>');
     });
 
-    it('sendBatch: absent customBody leaves batch sends unchanged', async () => {
+    it('sendBatch: both absent leaves batch sends unchanged', async () => {
       asApprover();
       await c.sendBatch({ user: 'josh', body: { venueIds: [oid()], targetDates: 'Aug 14-16' } }, resStub);
       expect((sendMail as any).mock.calls[0][0].html.startsWith('<p>Hi Pat')).toBe(true);
     });
 
-    it('previewByVenue (single form): reflects customBody without sending', async () => {
+    it('previewByVenue (single form): reflects customIntro + customBody without sending', async () => {
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
       await c.previewByVenue(
-        { user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16', customBody: 'We met at the farmers market.' } },
+        {
+          user: 'a',
+          query: {
+            venueId: oid(), targetDates: 'Aug 14-16', customIntro: 'Hi there again,', customBody: 'We met at the farmers market.',
+          },
+        },
         resStub,
       );
       expect(status).toBe(200);
       expect(sendMail).not.toHaveBeenCalled();
+      expect(payload.html.indexOf('<p>Hi there again,</p>')).toBe(0);
       expect(payload.html).toContain('<p>We met at the farmers market.</p>');
-      expect(payload.html).toContain('Hi Pat,');
+      expect(payload.html).not.toContain('Hi Pat,');
     });
 
-    it('previewByVenue (batch form): reflects customBody per venue', async () => {
+    it('previewByVenue (batch form): reflects customIntro + customBody per venue', async () => {
+      (templateModel as any).findOne = vi.fn(() => Promise.resolve(templateWithSlots()));
       const id1 = oid();
       await c.previewByVenue(
-        { user: 'a', query: { venueIds: id1, targetDates: 'Sept 25-27', customBody: 'Card left at the bar.' } },
+        {
+          user: 'a',
+          query: {
+            venueIds: id1, targetDates: 'Sept 25-27', customIntro: 'Following up,', customBody: 'Card left at the bar.',
+          },
+        },
         resStub,
       );
       expect(status).toBe(200);
+      expect(payload[0].body.indexOf('<p>Following up,</p>')).toBe(0);
       expect(payload[0].body).toContain('<p>Card left at the bar.</p>');
     });
 
-    it('previewByVenue: absent customBody leaves preview unchanged', async () => {
+    it('previewByVenue: both absent leaves preview unchanged', async () => {
       await c.previewByVenue({ user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16' } }, resStub);
       expect(payload.html.startsWith('<p>Hi Pat')).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Reworks the #900 single-`customBody`-prepend (live in prod, caused a double greeting) into two optional, independent slots on `/outreach/send`, `/outreach/batch`, `/outreach/preview`:
  - `customIntro` — **REPLACES** the template's own intro when present; the default intro is not also emitted (this is what kills the double-greeting).
  - `customBody` — **INSERTED** at a `[Custom Body]` marker inside the body template (an insert, not a replace); absent renders to nothing.
- Both slots share the existing escape + paragraph-render pipeline (renamed `renderCustomBodyHtml` to `renderCustomHtml` since it now serves both slots) — custom text is never trusted as HTML for either slot.
- **Intro/body split boundary:** each template now carries a separate `introHtml` field (new on the `Template` schema) alongside `bodyHtml`. `introHtml` is the greeting paragraph plus the immediately-following opening-line paragraph; `bodyHtml` is everything else (the ask, any closing line, signature), prefixed with the `[Custom Body]` marker token.
- **Marker mechanism:** a literal string-replace of the `[Custom Body]` token inside `bodyHtml`. If a template has no marker at all (not yet migrated), a supplied `customBody` is appended after the body rather than silently dropped — but it is never *prepended* (that was the #900 bug).
- **Template migration (the 6 prod templates):** migrated at the code/seed source of truth, `scripts/seed-outreach.mjs` — the only place the 6 prod templates (3 venueTypes x cold/returning) are authored (`seed.cjs` is unrelated legacy venue-only seed data). Each of the 6 had its `bodyHtml` split into `introHtml` (first two paragraph blocks) + `bodyHtml` (marker + remaining blocks); verified programmatically that `introHtml` concatenated with `bodyHtml` (marker stripped) reproduces the pre-migration `bodyHtml` byte-for-byte for every template. **This PR does not touch prod Mongo** — Josh re-running `npm run seed:outreach` against the target DB (guarded to local/DEV/TEST only, never `release`) applies the migration; a separate, explicit prod data step is still needed to update the live 6 templates.
- `Template` schema (`src/model/template/template-schema.ts`) gains the optional `introHtml` field; `TemplateController`'s body interface documents it (no new validation needed — extra fields already pass straight through to Mongoose).
- Router/controller comments across `outreach-router.ts` / `outreach-controller.ts` updated from #900 to #903 framing.

Closes #903

## How to test locally
Run the outreach unit spec directly (both new-slot tests and the byte-for-byte-unchanged regression cases) plus a clean typecheck:
```sh
cd ~/WebJamApps/web-jam-back/.worktrees/903-custom-intro-body
npx vitest run test/unit/outreach/outreach-controller.spec.ts test/unit/template/template-controller.spec.ts
npm run typecheck
```
Expect: both test files green (159 tests), typecheck exits 0.

Manual `/outreach/preview` exercise (customIntro replacing the intro with no double-greeting, customBody landing at the marker):
```sh
curl -s "http://localhost:PORT/outreach/preview?venueId=VENUE_ID&targetDates=Aug+14-16&customIntro=We+stopped+by+Wednesday%2C+left+a+card&customBody=Loved+your+open+mic+last+week" -H "Authorization: Bearer TOKEN"
```
Expected `html` field, rendered against the real migrated Originals/cold seed template (see Test evidence for the exact string) — no default greeting anywhere (customIntro fully replaced it), and the custom body note sits exactly where the marker was, ahead of the standard ask/signature.

`npm test` (full eslint + jscpd + coverage) was NOT run clean end-to-end locally: this worktree has no `.env` (only `.env.example`), so `process.env.HashString` is unset and the pre-existing `admin-user` mintToken test fails, and vitest's bail:1 then stops the whole run at that unrelated file. This is a known local-env gap unrelated to this change, and it passes in CI. `eslint` was instead run directly against every touched `src`/`test` file (clean) since `scripts` is outside `npm test`'s lint scope (`eslint ./src`) — confirmed the pre-existing `no-undef` lint findings in `scripts/seed-outreach.mjs` are identical on origin/dev's unmodified copy of that file (this PR added zero new lint issues there).

## Test evidence
```
$ npx vitest run test/unit/outreach/outreach-controller.spec.ts test/unit/template/template-controller.spec.ts

 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back/.worktrees/903-custom-intro-body

 Test Files  2 passed (2)
      Tests  159 passed (159)
   Start at  13:18:57
   Duration  912ms (transform 211ms, setup 0ms, import 571ms, tests 110ms, environment 0ms)

$ npm run typecheck
> web-jam-back@2.0.48 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
(exit 0, no output)

$ npx eslint src/model/outreach/outreach-controller.ts src/model/outreach/outreach-router.ts src/model/template/template-schema.ts src/model/template/template-controller.ts test/unit/outreach/outreach-controller.spec.ts
(exit 0, no output)
```

Standalone rendering harness (mirrors resolveIntroHtml/fillCustomBodyMarker exactly) against the migrated Originals/cold seed template, venue name "Big Lick Brewing" / contact "Maria" -- each rendered html string below is a single line wrapped in backticks:

Both absent (must equal old single-bodyHtml render):
`<p>Hi Maria,</p><p>My name is Josh Sherman and I perform alongside my wife Maria as an acoustic duo based in Salem, VA. We specialize in original music and love venues that value songwriting.</p><p>We'd love to be considered for a slot at Big Lick Brewing around flexible dates. Our upcoming calendar is filling up and Big Lick Brewing would be a great fit.</p><p>Happy to send samples or answer any questions.</p><p>Best,<br>Josh &amp; Maria<br>540-494-8035<br><a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>`

customIntro only (replaces intro, no double-greeting):
`<p>We stopped by Wednesday, submitted your form, and left a card!</p><p>We'd love to be considered for a slot at Big Lick Brewing around flexible dates. Our upcoming calendar is filling up and Big Lick Brewing would be a great fit.</p><p>Happy to send samples or answer any questions.</p><p>Best,<br>Josh &amp; Maria<br>540-494-8035<br><a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>`

customBody only (inserted at marker, intro stays):
`<p>Hi Maria,</p><p>My name is Josh Sherman and I perform alongside my wife Maria as an acoustic duo based in Salem, VA. We specialize in original music and love venues that value songwriting.</p><p>Loved your open mic last week!</p><p>We'd love to be considered for a slot at Big Lick Brewing around flexible dates. Our upcoming calendar is filling up and Big Lick Brewing would be a great fit.</p><p>Happy to send samples or answer any questions.</p><p>Best,<br>Josh &amp; Maria<br>540-494-8035<br><a href="https://www.joshandmariamusic.com">joshandmariamusic.com</a></p>`

Full-suite attempt with the local env gap worked around (HashString set locally only, just to see the rest of the suite):
```
$ HashString=local-test-secret npm run test:unit
 Test Files  5 failed | 13 passed (31)
      Tests  1 failed | 347 passed (348)
```
The 5 failed files are pre-existing, unrelated local-env gaps: artist-scoping/book-router/gig-router/facebook (missing AllowUrl env var) and authUtils (unrelated userType assertion) -- none touch outreach/template code.

🤖 Work by Claude Code — Sonnet 5