### PR TITLE
Track + land the parked backup/restore tooling (local claude/backup-endpoint branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ src/experiments
 
 .yarn
 .yarnrc
+
+# git worktrees used for parallel agent sessions (never repo content)
+.worktrees/

--- a/docs/mongo-backup.md
+++ b/docs/mongo-backup.md
@@ -1,0 +1,153 @@
+# Weekly Mongo backup (Dropbox)
+
+Reference: [web-jam-tools#116](https://github.com/WebJamApps/web-jam-tools/issues/116).
+
+## TL;DR
+
+`POST /admin/backup` exports every collection of **both** prod databases as EJSON
+and uploads them to Dropbox, keeping the newest 8 weekly runs. Free M0 Atlas has
+no snapshots/PITR, so this self-export is the only safety net. Triggered weekly
+by the Deno cron app (`web-jam-tools`, same pattern as `/outreach/advance`) — that
+half is a separate PR in that repo.
+
+- Both DBs exported: **webjamsalem** (this app's own `MONGO_DB_URI`) and
+  **webjamsocket** (WebJamSocketCluster's Mongo, via `GIGS_MONGO_DB_URI` — the
+  var `src/model/gig/gig-schema.ts` already uses to read the `gigs` collection
+  from that same cluster; no *new* env var was needed for the second DB).
+- Responds **202 immediately**; the export + upload run async so the request
+  never rides Heroku's 30s router timeout (H12).
+- Exports collection-by-collection (one collection's documents in memory at a
+  time, never both DBs at once).
+- EJSON preserves data + types (ObjectId/Date/etc.) but **not** indexes or
+  collection options — Mongoose re-creates indexes on the app's next boot.
+
+## One-time manual setup
+
+### 1. Create the Dropbox app (Josh)
+
+1. <https://www.dropbox.com/developers/apps> → **Create app** → Scoped access →
+   **App folder** access type (simplest — the app only ever writes under its own
+   `/webjam-backups` folder) → name it e.g. `webjam-backup`.
+2. **Permissions** tab → enable `files.content.write` and `files.content.read` →
+   **Submit**.
+3. **Settings** tab → note the **App key** and **App secret**. Save both in
+   KeePass.
+4. Generate a refresh token (one-time, from a machine with a browser):
+   - Visit (replace `<APP_KEY>`):
+     `https://www.dropbox.com/oauth2/authorize?client_id=<APP_KEY>&token_access_type=offline&response_type=code`
+   - Approve access; copy the **authorization code** shown.
+   - Exchange it for a refresh token:
+     ```sh
+     curl https://api.dropboxapi.com/oauth2/token \
+       -d code=<AUTH_CODE> \
+       -d grant_type=authorization_code \
+       -d client_id=<APP_KEY> \
+       -d client_secret=<APP_SECRET>
+     ```
+   - The response's `refresh_token` **does not expire** (until revoked) — that's
+     why this flow is used instead of a deprecated long-lived token. Save it in
+     KeePass.
+
+### 2. Set the config vars on `webjamsalem`
+
+```sh
+heroku config:set DROPBOX_APP_KEY="<app key>" -a webjamsalem
+heroku config:set DROPBOX_APP_SECRET="<app secret>" -a webjamsalem
+heroku config:set DROPBOX_REFRESH_TOKEN="<refresh token>" -a webjamsalem
+```
+
+`GIGS_MONGO_DB_URI` should already be set (it powers the existing `gigs` read
+path) — confirm with `heroku config:get GIGS_MONGO_DB_URI -a webjamsalem`. If it
+somehow isn't set, the backup still runs but the `webjamsocket` half is skipped
+(logged, reflected as `ok: false` in that run's `manifest.json`).
+
+### Environment variables
+
+| Var | Purpose | Without it |
+| --- | --- | --- |
+| `DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET` / `DROPBOX_REFRESH_TOKEN` | Dropbox refresh-token flow | Export still runs, upload is skipped (local disk only) |
+| `GIGS_MONGO_DB_URI` | Already-existing var for the WebJamSocketCluster Mongo (webjamsocket DB) | `webjamsocket` half of the export is skipped |
+| `BACKUP_OUTPUT_DIR` | Optional override for the local export scratch dir (default: OS tmpdir) | n/a |
+| `BACKUP_KEEP_LOCAL` | Set to `true` to keep the local export after a successful Dropbox upload (debugging) | Local export is deleted once safely in Dropbox |
+
+## Auth
+
+Guarded exactly like `POST /outreach/advance`: `authUtils.ensureAuthenticated`
+via `routeUtils.makeAction`, mounted at `/admin/backup` so it's gated on
+`AUTH_ROLES.admin` (same key as `/admin/user`, `/admin/subscriber` — no new auth
+mechanism). The Deno cron calls it with a no-expiry **service JWT**
+(`createServiceJWT` — mint one via `POST /admin/user/:id/token` for an admin
+user, same as any other cron caller).
+
+## Retention
+
+After a successful upload, the job lists `/webjam-backups`' subfolders and
+deletes every one beyond the newest 8 (`src/lib/dropbox.ts`'s `foldersToPrune`).
+Dropbox's own version history covers recovering something pruned by mistake.
+
+## Restoring
+
+`scripts/restore-backup.mjs` restores one dated export folder's `<db>/*.ndjson`
+files back into a target Mongo database — **dropping** each target collection
+first (a restore is a replace, not a merge) and reinserting every exported
+document, then printing per-collection counts.
+
+```sh
+node scripts/restore-backup.mjs --folder <path/to/run-folder> --db webjamsalem
+```
+
+- `--uri` defaults to `MONGO_DB_URI` from `.env` — **the DEV Atlas cluster**
+  locally (never prod; see the local-dev-uses-dev-atlas convention). Dev is
+  disposable by design, so restoring into it is the normal, safe drill target.
+- The script refuses to run against anything that doesn't look like
+  local/dev/test unless `--force` is passed (mirrors `scripts/seed-outreach.mjs`'s
+  guard) — a real disaster-recovery restore into prod is a deliberate act, never
+  an accidental default.
+- **Mongoose re-creates indexes on the app's next boot** — after restoring, run
+  `npm run dev` (or `npm start`) against that database to confirm indexes come
+  back and the app actually serves real data.
+
+### Parameterization (reused by web-jam-tools#897)
+
+This same script is designed to be reusable, unchanged, as the import half of
+the wj-prod → web-jam-data migration (web-jam-tools#897) — not just this
+issue's local/dev backup drill:
+
+- **Target database is already parameterized**, never hardcoded: `--uri`
+  points the restore at any Mongo connection string, and `--db` selects which
+  exported subfolder to restore. #897 passes its own `--uri`/`--db` rather than
+  needing a fork of this script.
+- **`--transform <path-to-module>`** is an optional per-record hook: the
+  module's default export, `(doc, collectionName) => doc`, runs on every
+  document immediately after `EJSON.parse` and before `insertMany`. It
+  defaults to an identity passthrough, so a plain #116 restore is unaffected.
+  #897 will point this at a small transform module that adds the `artist`
+  field expected by web-jam-data — that logic is intentionally **not**
+  implemented here, only the seam it plugs into.
+
+### End-to-end restore drill
+
+1. Trigger a real backup (or run the export directly for a local drill —
+   `DROPBOX_*` unset skips the upload and leaves the export on local disk at
+   `BACKUP_OUTPUT_DIR`, default the OS tmpdir).
+2. `node scripts/restore-backup.mjs --folder <run-folder> --db webjamsalem`
+   — confirm the printed per-collection counts match that run's `manifest.json`.
+3. `npm run dev` (or `npm start`) against that same `MONGO_DB_URI` and hit a real
+   route (e.g. `curl http://localhost:7000/song`) — confirms the restored data
+   actually serves, not just that the counts matched.
+
+The **real** drill (restoring an actual prod export) happens post-deploy, before
+[web-jam-tools#116](https://github.com/WebJamApps/web-jam-tools/issues/116) is
+closed by the companion cron PR in that repo.
+
+## Triggering
+
+Not yet wired to a schedule from this repo's side — the Deno cron app
+(`web-jam-tools`, PR follows this one) pings `POST /admin/backup` weekly, the
+same way it already pings `/outreach/advance` daily. Until then, trigger it
+manually with a service token:
+
+```sh
+curl -X POST https://webjamsalem.herokuapp.com/admin/backup \
+  -H "Authorization: Bearer <service JWT>"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.0.46",
+  "version": "2.1.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -20,6 +20,7 @@
     "dev": "rimraf build && tsc && npm run copy:assets && concurrently --raw \"npm:ts-start\" \"npm:ts-watch\"",
     "copy:assets": "node scripts/copy-assets.mjs",
     "seed:outreach": "node scripts/seed-outreach.mjs",
+    "restore:backup": "node scripts/restore-backup.mjs",
     "ts-watch": "tsc -w",
     "ts-start": "DEBUG=web-jam-back:* node --watch --trace-deprecation build/src/index.js",
     "installglobals": "npm install -g npm@latest && npm install -g snyk",

--- a/scripts/restore-backup.mjs
+++ b/scripts/restore-backup.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// scripts/restore-backup.mjs — restore an EJSON export (written by
+// `POST /admin/backup`, web-jam-tools#116) back into a target Mongo database.
+//
+// Usage:
+//   node scripts/restore-backup.mjs --folder <path/to/run-folder> [--db webjamsalem|webjamsocket] [--uri <mongo-uri>] [--transform <path-to-module>] [--force]
+//
+// <run-folder> is one dated export folder (e.g. what the backup route or a
+// local drill wrote): it contains `webjamsalem/` and/or `webjamsocket/`
+// subfolders of `<collection>.ndjson` files (one EJSON document per line) and a
+// manifest.json.
+//
+// Defaults: --db webjamsalem, --uri from MONGO_DB_URI (locally, the DEV Atlas
+// cluster from .env — see the local-dev-uses-dev-atlas convention: this laptop
+// never points at prod). Both --uri and --db are already fully parameterized
+// (not hardcoded to one database), so this same script is what web-jam-tools#897
+// will point at web-jam-data when migrating wj-prod's collections there.
+//
+// SAFETY GUARD (mirrors scripts/seed-outreach.mjs): refuses to run against
+// anything that doesn't look like local/dev/test unless --force is passed —
+// writing into a live database should be a deliberate, explicit act, never an
+// accidental default.
+//
+// For each collection found in the export: DROPS the target collection (a
+// restore is a REPLACE, not a merge — safe because dev is disposable by
+// design) then reinserts every exported document. Prints per-collection
+// document counts so they can be checked against the export's manifest.json.
+// NOTE: Mongoose re-creates indexes on the app's next boot; this script does
+// not attempt to recreate them itself.
+//
+// TRANSFORM SEAM (for web-jam-tools#897): --transform <path> dynamically
+// imports a module whose default export is `(doc, collectionName) => doc`,
+// run on every document immediately after EJSON.parse and before insertMany.
+// Defaults to an identity passthrough, so plain #116 restores are unaffected.
+// #897 will use this (not implemented here) to add an `artist` field to
+// migrated documents on the way into web-jam-data — see docs/mongo-backup.md.
+
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import fs from 'fs';
+import path from 'path';
+
+config(); // load .env if present
+
+const { EJSON } = mongoose.mongo.BSON;
+
+function parseArgs(argv) {
+  const out = { db: 'webjamsalem' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--folder') { out.folder = argv[i + 1]; i += 1; } else if (a === '--db') { out.db = argv[i + 1]; i += 1; } else if (a === '--uri') { out.uri = argv[i + 1]; i += 1; } else if (a === '--transform') { out.transform = argv[i + 1]; i += 1; } else if (a === '--force') { out.force = true; }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.folder) {
+  console.error('Usage: node scripts/restore-backup.mjs --folder <run-folder> [--db webjamsalem|webjamsocket] [--uri <mongo-uri>] [--transform <path-to-module>] [--force]');
+  process.exit(1);
+}
+
+// Transform seam (web-jam-tools#897): loads a module's default export as a
+// `(doc, collectionName) => doc` hook, or a no-op passthrough if --transform
+// wasn't passed. See the file-header comment and docs/mongo-backup.md.
+async function loadTransform(modulePath) {
+  if (!modulePath) return (doc) => doc;
+  const mod = await import(path.resolve(modulePath));
+  return mod.default;
+}
+
+const uri = args.uri || process.env.MONGO_DB_URI || 'mongodb://localhost:27017/web-jam-dev';
+const dbDir = path.join(args.folder, args.db);
+if (!fs.existsSync(dbDir)) {
+  console.error(`ERROR: no export found for db "${args.db}" at ${dbDir}`);
+  process.exit(1);
+}
+
+// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
+const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@');
+const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+if (!isLocal && !isDevOrTest && !args.force) {
+  console.error('ERROR: restore-backup only runs against a local, DEV, or TEST database by default — never release/production.');
+  console.error(`Target MONGO URI: ${maskedUri}`);
+  console.error(`Parsed database name: ${dbName || '(none)'}`);
+  console.error('Pass --force to restore into a different database anyway (e.g. a real disaster-recovery restore).');
+  process.exit(1);
+}
+
+async function restoreCollection(db, name, filePath, transform) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+  const docs = lines.map((line) => transform(EJSON.parse(line), name));
+  try { await db.dropCollection(name); } catch { /* collection didn't exist yet — fine */ }
+  if (docs.length === 0) return 0;
+  const result = await db.collection(name).insertMany(docs, { ordered: false });
+  return result.insertedCount;
+}
+
+async function main() {
+  console.log(`Restoring "${args.db}" export from ${dbDir}`);
+  console.log(`  into ${maskedUri} (database: ${dbName || '(default)'})`);
+  const transform = await loadTransform(args.transform);
+  const conn = await mongoose.createConnection(uri).asPromise();
+  const { db } = conn;
+  const files = fs.readdirSync(dbDir).filter((f) => f.endsWith('.ndjson')).sort();
+  const counts = {};
+  for (const file of files) {
+    const name = file.replace(/\.ndjson$/, '');
+    // eslint-disable-next-line no-await-in-loop
+    counts[name] = await restoreCollection(db, name, path.join(dbDir, file), transform);
+  }
+  await conn.close();
+
+  console.log('\nRestore complete. Per-collection document counts:');
+  for (const [name, count] of Object.entries(counts)) {
+    console.log(`  ${name}: ${count}`);
+  }
+  console.log('\nNOTE: Mongoose re-creates indexes on the app\'s next boot — run `npm run dev` (or `npm start`) against this database next to verify.');
+}
+
+main().catch((e) => {
+  console.error('Restore failed:', e.message);
+  process.exit(1);
+});

--- a/src/lib/backup-export.ts
+++ b/src/lib/backup-export.ts
@@ -1,0 +1,153 @@
+import mongoose from 'mongoose';
+import fs from 'fs';
+import path from 'path';
+import Debug from 'debug';
+
+const debug = Debug('web-jam-back:backup-export');
+
+// mongoose re-exports the driver's BSON module (mongoose.mongo.BSON), so EJSON
+// is available without adding `bson` as a direct dependency (it's already a
+// transitive dep of mongoose) — repo convention is to avoid new dependencies
+// when an existing one already carries what's needed.
+const { EJSON } = mongoose.mongo.BSON;
+
+// Minimal shape of what exportConnection needs from a Mongo `Db`, so tests can
+// inject an in-memory fake instead of a real connection — same injectable-client
+// pattern as ImapClientLike in src/lib/imap-replies.ts.
+export interface CollectionLike {
+  find(query: Record<string, unknown>): AsyncIterable<Record<string, unknown>>;
+}
+export interface DbLike {
+  listCollections(): { toArray(): Promise<{ name: string }[]> };
+  collection(name: string): CollectionLike;
+}
+// What a connected database handle looks like, for the orchestration layer.
+export interface OpenDb {
+  db: DbLike;
+  close(): Promise<void>;
+}
+
+export interface DbExportResult {
+  ok: boolean;
+  reason?: string;
+  collections: Record<string, number>; // collectionName -> document count exported
+}
+
+export interface BackupManifest {
+  generatedAt: string;
+  databases: Record<string, DbExportResult>;
+}
+
+// One EJSON document per line (relaxed:false — the "canonical" mode), so
+// ObjectId/Date/etc. round-trip losslessly through restore. This is the
+// serializer covered by the EJSON round-trip unit test.
+export function serializeDoc(doc: Record<string, unknown>): string {
+  return EJSON.stringify(doc, undefined, undefined, { relaxed: false });
+}
+
+export function deserializeDoc(line: string): Record<string, unknown> {
+  return EJSON.parse(line) as Record<string, unknown>;
+}
+
+async function exportOneCollection(db: DbLike, name: string, outDir: string): Promise<number> {
+  const filePath = path.join(outDir, `${name}.ndjson`);
+  const stream = fs.createWriteStream(filePath, { encoding: 'utf8' });
+  let count = 0;
+  try {
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const doc of db.collection(name).find({})) {
+      stream.write(`${serializeDoc(doc)}\n`);
+      count += 1;
+    }
+  } finally {
+    await new Promise((resolve) => stream.end(resolve));
+  }
+  debug('exported %s: %d docs', name, count);
+  return count;
+}
+
+// Exports EVERY collection of one already-connected database to
+// <outDir>/<collection>.ndjson — one EJSON document per line. Collections are
+// processed one at a time (never more than one collection's documents in
+// memory at once, and never both DBs at once — the caller loops databases the
+// same way), which is the "stream/iterate collection-by-collection" hard rule.
+export async function exportConnection(db: DbLike, outDir: string): Promise<Record<string, number>> {
+  fs.mkdirSync(outDir, { recursive: true });
+  const counts: Record<string, number> = {};
+  const collections = await db.listCollections().toArray();
+  for (const { name } of collections) {
+    // eslint-disable-next-line no-await-in-loop
+    counts[name] = await exportOneCollection(db, name, outDir);
+  }
+  return counts;
+}
+
+// Real connector: opens an ad hoc Mongoose connection to `uri` dedicated to
+// this export (never reuses/blocks the app's own long-lived connection), and
+// exposes just the DbLike surface exportConnection needs. Overridable in tests
+// so the orchestration below never touches a real Mongo.
+export async function defaultConnect(uri: string): Promise<OpenDb> {
+  const conn = mongoose.createConnection(uri);
+  await conn.asPromise();
+  if (!conn.db) throw new Error('connection opened with no db handle');
+  const { db } = conn;
+  return { db: db as unknown as DbLike, close: () => conn.close() };
+}
+
+async function exportLabeledDb(
+  label: string,
+  uri: string | undefined,
+  outDir: string,
+  connect: (uri: string) => Promise<OpenDb>,
+): Promise<DbExportResult> {
+  if (!uri) {
+    const reason = `${label} skipped — no URI configured for this database`;
+    debug(reason);
+    return { ok: false, reason, collections: {} };
+  }
+  let opened: OpenDb | undefined;
+  try {
+    opened = await connect(uri);
+    const collections = await exportConnection(opened.db, outDir);
+    return { ok: true, collections };
+  } catch (e) {
+    const reason = (e as Error).message;
+    debug('%s export failed: %s', label, reason);
+    return { ok: false, reason, collections: {} };
+  } finally {
+    if (opened) await opened.close().catch(/* istanbul ignore next */() => undefined);
+  }
+}
+
+export interface RunBackupOptions {
+  // Defaults: MONGO_DB_URI (webjamsalem, this app's own DB) and
+  // GIGS_MONGO_DB_URI — the WebJamSocketCluster URI ALREADY used by
+  // src/model/gig/gig-schema.ts to read the `gigs` collection from that same
+  // database, so no new Heroku config var is needed for the second DB.
+  primaryUri?: string;
+  secondaryUri?: string;
+  connect?: (uri: string) => Promise<OpenDb>;
+}
+
+// Exports both prod databases (web-jam-tools#116) into outDir/<label>/*.ndjson
+// plus a manifest.json summary. A DB whose URI isn't configured is skipped with
+// a logged warning (reflected in the manifest as ok:false), not a thrown error —
+// locally GIGS_MONGO_DB_URI is normally unset.
+export async function runFullBackup(outDir: string, opts: RunBackupOptions = {}): Promise<BackupManifest> {
+  const connect = opts.connect || defaultConnect;
+  const primaryUri = opts.primaryUri ?? process.env.MONGO_DB_URI;
+  const secondaryUri = opts.secondaryUri ?? process.env.GIGS_MONGO_DB_URI;
+
+  const databases: Record<string, DbExportResult> = {};
+  databases.webjamsalem = await exportLabeledDb('webjamsalem', primaryUri, path.join(outDir, 'webjamsalem'), connect);
+  databases.webjamsocket = await exportLabeledDb('webjamsocket', secondaryUri, path.join(outDir, 'webjamsocket'), connect);
+
+  const manifest: BackupManifest = { generatedAt: new Date().toISOString(), databases };
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  return manifest;
+}
+
+export default {
+  serializeDoc, deserializeDoc, exportConnection, defaultConnect, runFullBackup,
+};

--- a/src/lib/dropbox.ts
+++ b/src/lib/dropbox.ts
@@ -1,0 +1,131 @@
+import fs from 'fs';
+import path from 'path';
+import Debug from 'debug';
+
+// Dropbox upload for the weekly Mongo backup (web-jam-tools#116). Uses the
+// refresh-token flow (long-lived tokens are deprecated) via plain fetch against
+// the Dropbox HTTP API — mirrors src/lib/calendar.ts's style (no SDK dependency
+// needed for a handful of endpoints).
+const debug = Debug('web-jam-back:dropbox');
+
+const TOKEN_URL = 'https://api.dropboxapi.com/oauth2/token';
+const UPLOAD_URL = 'https://content.dropboxapi.com/2/files/upload';
+const LIST_FOLDER_URL = 'https://api.dropboxapi.com/2/files/list_folder';
+const DELETE_URL = 'https://api.dropboxapi.com/2/files/delete_v2';
+
+// All backup runs live under this folder, one subfolder per run (named with the
+// run's timestamp label so string-sorting = chronological order).
+export const BACKUP_ROOT = '/webjam-backups';
+// Retention: keep the newest 8 run-folders (web-jam-tools#116); Dropbox's own
+// version history covers deeper time travel if ever needed.
+export const RETAIN_RUNS = 8;
+
+export function dropboxConfigured(): boolean {
+  return !!(process.env.DROPBOX_APP_KEY && process.env.DROPBOX_APP_SECRET && process.env.DROPBOX_REFRESH_TOKEN);
+}
+
+interface TokenResponse { access_token?: string }
+
+async function getAccessToken(): Promise<string> {
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: process.env.DROPBOX_REFRESH_TOKEN || '',
+    client_id: process.env.DROPBOX_APP_KEY || '',
+    client_secret: process.env.DROPBOX_APP_SECRET || '',
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+  if (!res.ok) throw new Error(`dropbox token exchange failed: ${res.status} ${res.statusText}`);
+  const body = await res.json() as TokenResponse;
+  if (!body || !body.access_token) throw new Error('dropbox token exchange returned no access_token');
+  return body.access_token;
+}
+
+export async function uploadFile(accessToken: string, dropboxPath: string, contents: Buffer): Promise<void> {
+  const res = await fetch(UPLOAD_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/octet-stream',
+      'Dropbox-API-Arg': JSON.stringify({ path: dropboxPath, mode: 'overwrite', mute: true }),
+    },
+    body: contents as unknown as BodyInit,
+  });
+  if (!res.ok) throw new Error(`dropbox upload failed for ${dropboxPath}: ${res.status} ${res.statusText}`);
+}
+
+interface ListFolderEntry { '.tag': string; name: string }
+interface ListFolderResponse { entries?: ListFolderEntry[] }
+
+// Names of the direct subfolders of `folderPath`. Returns [] (not an error) the
+// first time a backup ever runs, before /webjam-backups exists (Dropbox 409s
+// path/not_found in that case).
+export async function listSubfolders(accessToken: string, folderPath: string): Promise<string[]> {
+  const res = await fetch(LIST_FOLDER_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: folderPath }),
+  });
+  if (res.status === 409) return [];
+  if (!res.ok) throw new Error(`dropbox list_folder failed: ${res.status} ${res.statusText}`);
+  const body = await res.json() as ListFolderResponse;
+  return (body.entries || []).filter((e) => e['.tag'] === 'folder').map((e) => e.name);
+}
+
+export async function deletePath(accessToken: string, targetPath: string): Promise<void> {
+  const res = await fetch(DELETE_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: targetPath }),
+  });
+  if (!res.ok) throw new Error(`dropbox delete failed for ${targetPath}: ${res.status} ${res.statusText}`);
+}
+
+// Pure retention logic: which run-folder names (out of ALL of them) are older
+// than the newest `keep`. Run-folder names are lexicographically-sortable
+// timestamps, so a plain string sort orders oldest-first. Pure + injectable —
+// unit-tested directly with plain string arrays, no Dropbox/network involved.
+export function foldersToPrune(names: string[], keep: number = RETAIN_RUNS): string[] {
+  const sorted = [...names].sort();
+  const excess = sorted.length - keep;
+  return excess > 0 ? sorted.slice(0, excess) : [];
+}
+
+function listFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listFilesRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+// Uploads every file under localDir (recursively) to
+// `${BACKUP_ROOT}/${runLabel}/<relative path>`, then prunes run-folders beyond
+// the newest RETAIN_RUNS.
+export async function uploadBackupAndPrune(localDir: string, runLabel: string): Promise<void> {
+  const accessToken = await getAccessToken();
+  const files = listFilesRecursive(localDir);
+  for (const file of files) {
+    const rel = path.relative(localDir, file).split(path.sep).join('/');
+    // eslint-disable-next-line no-await-in-loop
+    await uploadFile(accessToken, `${BACKUP_ROOT}/${runLabel}/${rel}`, fs.readFileSync(file));
+  }
+  debug('uploaded %d file(s) to %s/%s', files.length, BACKUP_ROOT, runLabel);
+
+  const names = await listSubfolders(accessToken, BACKUP_ROOT);
+  const toPrune = foldersToPrune(names);
+  for (const name of toPrune) {
+    // eslint-disable-next-line no-await-in-loop
+    await deletePath(accessToken, `${BACKUP_ROOT}/${name}`);
+    debug('pruned old backup folder %s', name);
+  }
+}
+
+export default {
+  dropboxConfigured, uploadFile, listSubfolders, deletePath, foldersToPrune, uploadBackupAndPrune,
+};

--- a/src/model/backup/backup-controller.ts
+++ b/src/model/backup/backup-controller.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import Debug from 'debug';
+import { runFullBackup, type BackupManifest } from '#src/lib/backup-export.js';
+import dropbox from '#src/lib/dropbox.js';
+import type { Icontroller } from '#src/lib/routeUtils.js';
+
+// POST /admin/backup — weekly Mongo backup (web-jam-tools#116), triggered by the
+// Deno cron app. Exports every collection of BOTH prod DBs as EJSON and uploads
+// them to Dropbox, then prunes old runs. Heroku kills requests at 30s, so the
+// route responds 202 immediately and the export+upload run async — never on the
+// request path.
+const debug = Debug('web-jam-back:backup-controller');
+
+// Filesystem/Dropbox-safe run label: an ISO timestamp with `:`/`.` stripped, so
+// plain string-sort on run labels is chronological (used by dropbox.ts retention).
+export function runLabel(now: Date = new Date()): string {
+  return now.toISOString().replace(/[:.]/g, '-');
+}
+
+export function outputRoot(): string {
+  return process.env.BACKUP_OUTPUT_DIR || path.join(os.tmpdir(), 'webjam-backups');
+}
+
+// The actual export + upload + prune work. Exported (not run inline in
+// runBackup) so it can be invoked directly for the local mechanism drill
+// without going through HTTP/auth.
+export async function performBackup(): Promise<BackupManifest> {
+  const label = runLabel();
+  const outDir = path.join(outputRoot(), label);
+  let manifest: BackupManifest | undefined;
+  let uploaded = false;
+  try {
+    manifest = await runFullBackup(outDir);
+    debug('export complete: %o', manifest.databases);
+    if (dropbox.dropboxConfigured()) {
+      await dropbox.uploadBackupAndPrune(outDir, label);
+      uploaded = true;
+      debug('uploaded backup %s to Dropbox and pruned old runs', label);
+    } else {
+      debug('DROPBOX_* env vars not set — export left on local disk at %s, upload skipped', outDir);
+    }
+  } catch (e) {
+    console.error('[backup] run failed:', (e as Error).message); // eslint-disable-line no-console
+  } finally {
+    // Only clean up the local export once it's safely in Dropbox — otherwise
+    // (Dropbox unconfigured, e.g. local dev) it's the only copy, so it stays
+    // (also lets the local mechanism drill feed it straight to the restore
+    // script). BACKUP_KEEP_LOCAL=true forces keeping it even after a successful
+    // upload, for debugging a prod run.
+    if (uploaded && process.env.BACKUP_KEEP_LOCAL !== 'true') {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  }
+  return manifest || { generatedAt: new Date().toISOString(), databases: {} };
+}
+
+class BackupController {
+  // eslint-disable-next-line class-methods-use-this
+  async runBackup(_req: Request, res: Response): Promise<unknown> {
+    void performBackup();
+    return res.status(202).json({ message: 'backup started' });
+  }
+}
+
+export default new BackupController() as unknown as Icontroller;

--- a/src/model/backup/backup-router.ts
+++ b/src/model/backup/backup-router.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import controller from './backup-controller.js';
+import authUtils from '../../auth/authUtils.js';
+import routeUtils from '../../lib/routeUtils.js';
+
+// ADMIN weekly Mongo backup (web-jam-tools#116). Mounted at /admin/backup, so
+// authUtils gates every route on AUTH_ROLES.admin — same key as /admin/user and
+// /admin/subscriber, no new env var needed — via the exact
+// routeUtils.makeAction + authUtils.ensureAuthenticated path that already
+// guards POST /outreach/advance. Triggered weekly by the Deno cron app (a
+// no-expiry service JWT, createServiceJWT — see admin-user's mintToken route).
+const router = express.Router();
+
+router.route('/')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'runBackup', controller, authUtils);
+    void action();
+  });
+
+export default router;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,6 +13,7 @@ import venue from './model/venue/venue-router.js';
 import template from './model/template/template-router.js';
 import outreach from './model/outreach/outreach-router.js';
 import facebook from './model/facebook/index.js';
+import backup from './model/backup/backup-router.js';
 
 const router = express.Router();
 
@@ -32,4 +33,5 @@ export default function route(app: Express): void {
   router.use('/template', template);
   router.use('/outreach', outreach);
   router.use('/facebook', facebook);
+  router.use('/admin/backup', backup);
 }

--- a/test/unit/backup/backup-router.spec.ts
+++ b/test/unit/backup/backup-router.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Auth-gating test for POST /admin/backup (web-jam-tools#116). Mocks Dropbox +
+// the Mongo export entirely — this file never touches a real database or the
+// network — and drives the route through the real Express app + real
+// authUtils.ensureAuthenticated, the same integration style as
+// test/unit/user/user-router.spec.ts (including that file's convention of
+// swapping authUtils.ensureAuthenticated for a stub to simulate "authenticated").
+
+const runFullBackup = vi.fn(() => Promise.resolve({ generatedAt: new Date().toISOString(), databases: {} }));
+vi.mock('#src/lib/backup-export.js', () => ({
+  runFullBackup,
+  default: { runFullBackup },
+}));
+
+const dropboxConfigured = vi.fn(() => false);
+const uploadBackupAndPrune = vi.fn(() => Promise.resolve());
+vi.mock('#src/lib/dropbox.js', () => ({
+  dropboxConfigured,
+  uploadBackupAndPrune,
+  default: { dropboxConfigured, uploadBackupAndPrune },
+}));
+
+const { default: app } = await import('#src/index.js');
+const { default: authUtils } = await import('#src/auth/authUtils.js');
+const { default: request } = await import('../../helpers/api.js');
+
+const flush = () => new Promise((resolve) => { setImmediate(resolve); });
+
+describe('POST /admin/backup', () => {
+  beforeEach(() => {
+    runFullBackup.mockClear();
+    dropboxConfigured.mockClear();
+    uploadBackupAndPrune.mockClear();
+  });
+
+  it('rejects a request with no Authorization header (401), and never starts an export', async () => {
+    const r = await request(app).post('/admin/backup');
+    expect(r.status).toBe(401);
+    await flush();
+    expect(runFullBackup).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request whose token fails ensureAuthenticated (401), and never starts an export', async () => {
+    (authUtils as any).ensureAuthenticated = vi.fn(() => Promise.reject(new Error('The user does not have the permission')));
+    const r = await request(app).post('/admin/backup').set('Authorization', 'Bearer not-a-real-token');
+    expect(r.status).toBe(401);
+    expect(r.body.message).toContain('permission');
+    await flush();
+    expect(runFullBackup).not.toHaveBeenCalled();
+  });
+
+  it('responds 202 immediately for an authenticated caller and kicks off the export async', async () => {
+    (authUtils as any).ensureAuthenticated = vi.fn(() => Promise.resolve());
+    const r = await request(app).post('/admin/backup').set('Authorization', 'Bearer service-token');
+    expect(r.status).toBe(202);
+    expect(r.body.message).toMatch(/backup started/i);
+
+    // The export runs fire-and-forget (not awaited by the route handler) — flush
+    // the microtask queue to observe it having been kicked off.
+    await flush();
+    await flush();
+    expect(runFullBackup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/lib/backup-export.spec.ts
+++ b/test/unit/lib/backup-export.spec.ts
@@ -1,0 +1,154 @@
+import mongoose from 'mongoose';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  serializeDoc, deserializeDoc, exportConnection, runFullBackup, type DbLike, type OpenDb,
+} from '#src/lib/backup-export.js';
+
+const { ObjectId } = mongoose.mongo.BSON;
+
+// A trivial in-memory DbLike: a Map of collectionName -> array of docs, exposing
+// exactly the two Mongo Db methods exportConnection needs (mirrors the
+// ImapClientLike injectable pattern in src/lib/imap-replies.ts) — no real Mongo
+// connection is ever opened by these tests.
+function fakeDb(data: Record<string, Record<string, unknown>[]>): DbLike {
+  return {
+    listCollections: () => ({
+      toArray: () => Promise.resolve(Object.keys(data).map((name) => ({ name }))),
+    }),
+    collection: (name: string) => ({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      find: (_query: Record<string, unknown>) => ({
+        // eslint-disable-next-line @typescript-eslint/require-await
+        [Symbol.asyncIterator]: async function* asyncIterator() {
+          for (const doc of data[name] || []) yield doc;
+        },
+      }),
+    }),
+  };
+}
+
+describe('backup-export.ts', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-export-spec-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('serializeDoc / deserializeDoc (EJSON round trip)', () => {
+    it('preserves ObjectId and Date through a round trip', () => {
+      const id = new ObjectId();
+      const date = new Date('2026-01-15T12:00:00.000Z');
+      const doc = { _id: id, name: 'The Bridge', bookedAt: date, count: 3, active: true };
+
+      const line = serializeDoc(doc);
+      expect(typeof line).toBe('string');
+      const back = deserializeDoc(line);
+
+      expect((back._id as InstanceType<typeof ObjectId>).toString()).toBe(id.toString());
+      expect(back._id).toBeInstanceOf(ObjectId);
+      expect(back.bookedAt).toBeInstanceOf(Date);
+      expect((back.bookedAt as Date).toISOString()).toBe(date.toISOString());
+      expect(back.name).toBe('The Bridge');
+      expect(back.count).toBe(3);
+      expect(back.active).toBe(true);
+    });
+
+    it('round-trips a doc with no ObjectId/Date fields too', () => {
+      const doc = { key: 'outreach', autoApprove: false };
+      expect(deserializeDoc(serializeDoc(doc))).toEqual(doc);
+    });
+  });
+
+  describe('exportConnection', () => {
+    it('writes one ndjson file per collection and returns per-collection counts', async () => {
+      const venueId = new ObjectId();
+      const db = fakeDb({
+        venue: [{ _id: venueId, name: 'The Spot' }],
+        outreach: [{ venueId, status: 'sent' }, { venueId, status: 'replied' }],
+        emptyCollection: [],
+      });
+
+      const counts = await exportConnection(db, tmpDir);
+
+      expect(counts).toEqual({ venue: 1, outreach: 2, emptyCollection: 0 });
+      const venueLines = fs.readFileSync(path.join(tmpDir, 'venue.ndjson'), 'utf8').trim().split('\n');
+      expect(venueLines).toHaveLength(1);
+      expect(deserializeDoc(venueLines[0]).name).toBe('The Spot');
+
+      const outreachLines = fs.readFileSync(path.join(tmpDir, 'outreach.ndjson'), 'utf8').trim().split('\n');
+      expect(outreachLines).toHaveLength(2);
+
+      // An empty collection still gets its (empty) file, not skipped entirely.
+      expect(fs.existsSync(path.join(tmpDir, 'emptyCollection.ndjson'))).toBe(true);
+      expect(fs.readFileSync(path.join(tmpDir, 'emptyCollection.ndjson'), 'utf8')).toBe('');
+    });
+  });
+
+  describe('runFullBackup', () => {
+    const fakeConnect = (dbs: Record<string, DbLike>) => (uri: string): Promise<OpenDb> => {
+      const db = dbs[uri];
+      if (!db) return Promise.reject(new Error(`no fake db registered for ${uri}`));
+      return Promise.resolve({ db, close: () => Promise.resolve() });
+    };
+
+    it('exports both databases when both URIs are configured, and writes a manifest', async () => {
+      const primaryDb = fakeDb({ user: [{ name: 'josh' }] });
+      const secondaryDb = fakeDb({ gigs: [{ venue: 'The Bridge' }, { venue: 'Pub Fest' }] });
+      const outDir = path.join(tmpDir, 'run-1');
+
+      const manifest = await runFullBackup(outDir, {
+        primaryUri: 'mongodb://primary',
+        secondaryUri: 'mongodb://secondary',
+        connect: fakeConnect({ 'mongodb://primary': primaryDb, 'mongodb://secondary': secondaryDb }),
+      });
+
+      expect(manifest.databases.webjamsalem).toEqual({ ok: true, collections: { user: 1 } });
+      expect(manifest.databases.webjamsocket).toEqual({ ok: true, collections: { gigs: 2 } });
+      expect(fs.existsSync(path.join(outDir, 'webjamsalem', 'user.ndjson'))).toBe(true);
+      expect(fs.existsSync(path.join(outDir, 'webjamsocket', 'gigs.ndjson'))).toBe(true);
+
+      const manifestOnDisk = JSON.parse(fs.readFileSync(path.join(outDir, 'manifest.json'), 'utf8'));
+      expect(manifestOnDisk.databases.webjamsalem.ok).toBe(true);
+      expect(typeof manifestOnDisk.generatedAt).toBe('string');
+    });
+
+    it('skips a database with no URI configured (logged, not thrown) — the local GIGS_MONGO_DB_URI-unset case', async () => {
+      const primaryDb = fakeDb({ user: [] });
+      const outDir = path.join(tmpDir, 'run-2');
+
+      const manifest = await runFullBackup(outDir, {
+        primaryUri: 'mongodb://primary',
+        secondaryUri: undefined,
+        connect: fakeConnect({ 'mongodb://primary': primaryDb }),
+      });
+
+      expect(manifest.databases.webjamsalem.ok).toBe(true);
+      expect(manifest.databases.webjamsocket).toEqual({
+        ok: false,
+        reason: 'webjamsocket skipped — no URI configured for this database',
+        collections: {},
+      });
+      expect(fs.existsSync(path.join(outDir, 'webjamsocket'))).toBe(false);
+    });
+
+    it('records a failed connection as ok:false with the error message, without throwing', async () => {
+      const outDir = path.join(tmpDir, 'run-3');
+      const failingConnect = () => Promise.reject(new Error('bad auth'));
+
+      const manifest = await runFullBackup(outDir, {
+        primaryUri: 'mongodb://primary',
+        secondaryUri: 'mongodb://secondary',
+        connect: failingConnect,
+      });
+
+      expect(manifest.databases.webjamsalem).toEqual({ ok: false, reason: 'bad auth', collections: {} });
+      expect(manifest.databases.webjamsocket).toEqual({ ok: false, reason: 'bad auth', collections: {} });
+    });
+  });
+});

--- a/test/unit/lib/dropbox.spec.ts
+++ b/test/unit/lib/dropbox.spec.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  dropboxConfigured, foldersToPrune, uploadBackupAndPrune, BACKUP_ROOT,
+} from '#src/lib/dropbox.js';
+
+// Exercises the real fetch path (token exchange -> upload -> list -> delete) by
+// stubbing global fetch, the same way test/unit/lib/calendar.spec.ts does for
+// its Google refresh-token flow — no real Dropbox network call is ever made.
+const okJson = (body: unknown) => ({ ok: true, json: () => Promise.resolve(body) });
+
+describe('dropbox.ts', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe('dropboxConfigured', () => {
+    it('is false when any of the three env vars is missing', () => {
+      delete process.env.DROPBOX_APP_KEY;
+      delete process.env.DROPBOX_APP_SECRET;
+      delete process.env.DROPBOX_REFRESH_TOKEN;
+      expect(dropboxConfigured()).toBe(false);
+
+      process.env.DROPBOX_APP_KEY = 'k';
+      process.env.DROPBOX_APP_SECRET = 's';
+      expect(dropboxConfigured()).toBe(false); // refresh token still missing
+    });
+
+    it('is true when all three are set', () => {
+      process.env.DROPBOX_APP_KEY = 'k';
+      process.env.DROPBOX_APP_SECRET = 's';
+      process.env.DROPBOX_REFRESH_TOKEN = 'r';
+      expect(dropboxConfigured()).toBe(true);
+    });
+  });
+
+  describe('foldersToPrune (retention)', () => {
+    it('keeps the newest N, prunes the rest, given more than the retention count', () => {
+      const names = ['2026-01-01T00-00-00-000Z', '2026-01-08T00-00-00-000Z', '2026-01-15T00-00-00-000Z'];
+      expect(foldersToPrune(names, 2)).toEqual(['2026-01-01T00-00-00-000Z']);
+    });
+
+    it('prunes nothing when at or under the retention count', () => {
+      const names = ['a', 'b'];
+      expect(foldersToPrune(names, 8)).toEqual([]);
+      expect(foldersToPrune([], 8)).toEqual([]);
+    });
+
+    it('defaults to keeping 8', () => {
+      const names = Array.from({ length: 10 }, (_, i) => `2026-01-${String(i + 1).padStart(2, '0')}T00-00-00-000Z`);
+      const pruned = foldersToPrune(names);
+      expect(pruned).toHaveLength(2);
+      expect(pruned).toEqual(['2026-01-01T00-00-00-000Z', '2026-01-02T00-00-00-000Z']);
+    });
+
+    it('does not mutate the input array', () => {
+      const names = ['b', 'a', 'c'];
+      foldersToPrune(names, 1);
+      expect(names).toEqual(['b', 'a', 'c']);
+    });
+  });
+
+  describe('uploadBackupAndPrune', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dropbox-spec-'));
+      fs.writeFileSync(path.join(tmpDir, 'venue.ndjson'), '{"name":"x"}\n');
+      fs.mkdirSync(path.join(tmpDir, 'sub'));
+      fs.writeFileSync(path.join(tmpDir, 'sub', 'outreach.ndjson'), '{"status":"sent"}\n');
+      process.env.DROPBOX_APP_KEY = 'k';
+      process.env.DROPBOX_APP_SECRET = 's';
+      process.env.DROPBOX_REFRESH_TOKEN = 'r';
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('exchanges the refresh token, uploads every file recursively, then prunes old runs', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(okJson({ access_token: 'at-123' })) // token exchange
+        .mockResolvedValueOnce(okJson({})) // upload venue.ndjson
+        .mockResolvedValueOnce(okJson({})) // upload sub/outreach.ndjson
+        .mockResolvedValueOnce(okJson({ // list_folder — 9 folders total (default retention keeps 8)
+          entries: [
+            { '.tag': 'folder', name: '2019-01-01T00-00-00-000Z' }, // oldest — the only one pruned
+            { '.tag': 'folder', name: '2020-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2021-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2022-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2023-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2024-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2025-01-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: '2025-06-01T00-00-00-000Z' },
+            { '.tag': 'folder', name: 'run-newest' },
+            { '.tag': 'file', name: 'not-a-folder' },
+          ],
+        }))
+        .mockResolvedValueOnce(okJson({})); // delete the pruned folder
+      vi.stubGlobal('fetch', fetchMock);
+
+      await uploadBackupAndPrune(tmpDir, 'run-newest');
+
+      expect(fetchMock.mock.calls[0][0]).toContain('oauth2/token');
+      const uploadCalls = fetchMock.mock.calls.slice(1, 3).map((c) => (c[1] as any).headers['Dropbox-API-Arg']);
+      expect(uploadCalls.some((h: string) => h.includes(`${BACKUP_ROOT}/run-newest/venue.ndjson`))).toBe(true);
+      expect(uploadCalls.some((h: string) => h.includes(`${BACKUP_ROOT}/run-newest/sub/outreach.ndjson`))).toBe(true);
+
+      const listCall = fetchMock.mock.calls[3];
+      expect(listCall[0]).toContain('list_folder');
+
+      const deleteCall = fetchMock.mock.calls[4];
+      expect(deleteCall[0]).toContain('delete_v2');
+      expect(JSON.parse((deleteCall[1] as any).body).path).toBe(`${BACKUP_ROOT}/2019-01-01T00-00-00-000Z`);
+    });
+
+    it('throws when the token exchange fails', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' }));
+      await expect(uploadBackupAndPrune(tmpDir, 'run-x')).rejects.toThrow(/token exchange failed/);
+    });
+
+    it('throws when an upload fails', async () => {
+      vi.stubGlobal('fetch', vi.fn()
+        .mockResolvedValueOnce(okJson({ access_token: 'at-123' }))
+        .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' }));
+      await expect(uploadBackupAndPrune(tmpDir, 'run-x')).rejects.toThrow(/upload failed/);
+    });
+
+    it('treats a 409 list_folder (folder does not exist yet) as an empty list — nothing to prune', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(okJson({ access_token: 'at-123' }))
+        .mockResolvedValueOnce(okJson({}))
+        .mockResolvedValueOnce(okJson({}))
+        .mockResolvedValueOnce({ ok: false, status: 409, statusText: 'Conflict' });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await uploadBackupAndPrune(tmpDir, 'run-first-ever');
+      expect(fetchMock).toHaveBeenCalledTimes(4); // no delete call follows
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /admin/backup`: exports every collection of both prod databases (webjamsalem via `MONGO_DB_URI`, webjamsocket via the existing `GIGS_MONGO_DB_URI`) to EJSON, uploads to Dropbox (refresh-token flow), and prunes runs beyond the newest 8 (web-jam-tools#116)
- Adds `scripts/restore-backup.mjs` to restore a dated export back into a target Mongo database (drop + reinsert per collection), guarded against accidentally targeting anything that isn't local/dev/test unless `--force` is passed
- Route responds 202 immediately; export + upload run async so the request never rides Heroku's 30s timeout
- This same toolset is designed to be reused, unchanged, by web-jam-tools#897 (wj-prod → web-jam-data migration): the restore script already parameterizes its target `--uri`/`--db` (never hardcoded), and now exposes an optional `--transform` module-path hook — a `(doc, collectionName) => doc` function run before insert, defaulting to a no-op passthrough — as the seam #897 will use to add an `artist` field on import. That field-adding logic itself is intentionally NOT implemented in this PR
- Documented in `docs/mongo-backup.md` (one-time Dropbox app setup, env vars, restore/drill steps, and the parameterization seam)
- `.gitignore`: added `.worktrees/` (untracked parallel-agent worktrees, never repo content)

Closes #905

## How to test locally
Run the full suite (eslint + jscpd + typecheck-covering vitest + coverage gate):
```sh
npm test
```
Expect: all test files green, coverage above the 90/90/80/80 gate. Also run typecheck standalone:
```sh
npm run typecheck
```
Expect: no errors (this covers the new test files too, not just src).

Exercise the new route directly once deployed to a review env:
```sh
curl -X POST https://REVIEW_APP_HOST/admin/backup -H "Authorization: Bearer SERVICE_JWT"
```
Expect: `202` with body `{\"message\":\"backup started\"}`, then (if `DROPBOX_*` configured) a new dated folder under /webjam-backups in Dropbox shortly after.

Restore drill (local/dev only):
```sh
node scripts/restore-backup.mjs --folder RUN_FOLDER_PATH --db webjamsalem
```
Expect: per-collection counts printed, matching that run's manifest.json.

## Test evidence
```
 Test Files  34 passed (34)
      Tests  462 passed (462)
   Duration  59.18s

 % Coverage report from v8
 All files          |   91.67 |    84.28 |   85.76 |   92.38

=============================== Coverage summary ===============================
Statements   : 91.67% ( 1795/1958 )
Branches     : 84.28% ( 1067/1266 )
Functions    : 85.76% ( 265/309 )
Lines        : 92.38% ( 1481/1603 )
```
Backup-specific specs run in isolation: 3 files, 19 tests, all passed.
`npm run typecheck` (tsc --noEmit on tsconfig.prod.json + full tsconfig, covering test files): no output, exit 0.

🤖 Work by Claude Code — Opus 4.8