### PR TITLE
Consolidate gigs into web-jam-data and retire the wj-prod Atlas cluster (Atlas simplification)

### DIFF
--- a/docs/mongo-backup.md
+++ b/docs/mongo-backup.md
@@ -118,12 +118,39 @@ issue's local/dev backup drill:
   exported subfolder to restore. #897 passes its own `--uri`/`--db` rather than
   needing a fork of this script.
 - **`--transform <path-to-module>`** is an optional per-record hook: the
-  module's default export, `(doc, collectionName) => doc`, runs on every
-  document immediately after `EJSON.parse` and before `insertMany`. It
-  defaults to an identity passthrough, so a plain #116 restore is unaffected.
-  #897 will point this at a small transform module that adds the `artist`
-  field expected by web-jam-data — that logic is intentionally **not**
-  implemented here, only the seam it plugs into.
+  module's default export, `(doc, collectionName) => result`, runs on every
+  document immediately after `EJSON.parse` and before `insertMany`. `result`
+  is one of:
+  - a plain document object — inserted into the **same** collection as the
+    source file (this is what the default identity passthrough returns, so a
+    plain #116 restore is unaffected).
+  - `null` / `undefined` — the document is **dropped** (not inserted
+    anywhere).
+  - `{ collection, doc }` — the document is **redirected**: `doc` is inserted
+    into `collection` instead of the source file's collection name.
+
+  A source collection is only dropped-and-reinserted in the target database if
+  at least one document actually resolves to it, so a collection that's
+  entirely redirected/dropped by a transform is never touched in the target
+  (see `scripts/transforms/josh-migration.mjs` below).
+
+  #897's implementation lives in `scripts/transforms/josh-migration.mjs`:
+  every `gigs` doc gets `artist: "josh"` added (same collection); every `book`
+  doc is kept only if `type === 'JaMmusic-music'` and, if kept, redirected into
+  a **new** `jamPics` collection — not `book`, since web-jam-data already has
+  its own `book` collection (CollegeLutheran's) that this migration must never
+  touch. Non-kept `book` docs are dropped. Unit tests for this module live at
+  `test/unit/backup/josh-migration.spec.ts`.
+
+  Example invocation (into a DEV/TEST `web-jam-data` target only — the safety
+  guard above still applies, and this step is never run with `--force`):
+
+  ```sh
+  node scripts/restore-backup.mjs \
+    --folder <run-folder> --db webjamsocket \
+    --uri "<dev-or-test web-jam-data Mongo URI>" \
+    --transform scripts/transforms/josh-migration.mjs
+  ```
 
 ### End-to-end restore drill
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/scripts/restore-backup.mjs
+++ b/scripts/restore-backup.mjs
@@ -29,11 +29,23 @@
 // not attempt to recreate them itself.
 //
 // TRANSFORM SEAM (for web-jam-tools#897): --transform <path> dynamically
-// imports a module whose default export is `(doc, collectionName) => doc`,
-// run on every document immediately after EJSON.parse and before insertMany.
-// Defaults to an identity passthrough, so plain #116 restores are unaffected.
-// #897 will use this (not implemented here) to add an `artist` field to
-// migrated documents on the way into web-jam-data — see docs/mongo-backup.md.
+// imports a module whose default export is a per-document hook,
+// `(doc, collectionName) => result`, run on every document immediately after
+// EJSON.parse and before insertMany. `result` is one of:
+//   - a plain document object  -> inserted into the SAME collection as the
+//     source file (this is what an identity/#116 passthrough returns).
+//   - `null` or `undefined`    -> the document is DROPPED (not inserted
+//     anywhere).
+//   - `{ collection, doc }`    -> the document is redirected: `doc` is
+//     inserted into `collection` instead of the source file's collection
+//     name (e.g. #897's book -> jamPics filtered remap).
+// Defaults to an identity passthrough (returns `doc` unchanged, same
+// collection, nothing dropped), so plain #116 restores are unaffected.
+// A source collection is only touched (dropped + reinserted) if at least one
+// document actually resolves to it — so a collection that's entirely
+// redirected/dropped (like #897's `book`) is never created or cleared in the
+// target database. See docs/mongo-backup.md and
+// scripts/transforms/josh-migration.mjs (the #897 implementation).
 
 import { config } from 'dotenv';
 import mongoose from 'mongoose';
@@ -88,10 +100,34 @@ if (!isLocal && !isDevOrTest && !args.force) {
   process.exit(1);
 }
 
-async function restoreCollection(db, name, filePath, transform) {
+// Reads one exported <collection>.ndjson file and buckets its (transformed)
+// documents by DESTINATION collection name — usually just `name` (identity),
+// but a transform may redirect some/all docs elsewhere via `{ collection, doc
+// }`, or drop a doc entirely via `null`/`undefined`. Returns a Map of
+// destination-collection-name -> docs[]. An empty source file still yields a
+// `name -> []` entry (preserves the pre-#897 "replace with empty" behavior
+// for a collection that legitimately has zero documents).
+function readAndTransform(name, filePath, transform) {
   const raw = fs.readFileSync(filePath, 'utf8');
   const lines = raw.split('\n').filter((line) => line.trim().length > 0);
-  const docs = lines.map((line) => transform(EJSON.parse(line), name));
+  const byDestination = new Map();
+  if (lines.length === 0) {
+    byDestination.set(name, []);
+    return byDestination;
+  }
+  for (const line of lines) {
+    const result = transform(EJSON.parse(line), name);
+    if (result === null || result === undefined) continue; // dropped
+    const isRedirect = typeof result === 'object' && !Array.isArray(result) && 'doc' in result && 'collection' in result;
+    const destName = isRedirect ? result.collection : name;
+    const doc = isRedirect ? result.doc : result;
+    if (!byDestination.has(destName)) byDestination.set(destName, []);
+    byDestination.get(destName).push(doc);
+  }
+  return byDestination;
+}
+
+async function insertIntoCollection(db, name, docs) {
   try { await db.dropCollection(name); } catch { /* collection didn't exist yet — fine */ }
   if (docs.length === 0) return 0;
   const result = await db.collection(name).insertMany(docs, { ordered: false });
@@ -105,11 +141,23 @@ async function main() {
   const conn = await mongoose.createConnection(uri).asPromise();
   const { db } = conn;
   const files = fs.readdirSync(dbDir).filter((f) => f.endsWith('.ndjson')).sort();
-  const counts = {};
+
+  // Merge every source file's per-destination buckets (a redirect target like
+  // `jamPics` may receive docs from more than one source file, in principle).
+  const merged = new Map();
   for (const file of files) {
     const name = file.replace(/\.ndjson$/, '');
+    const byDestination = readAndTransform(name, path.join(dbDir, file), transform);
+    for (const [destName, docs] of byDestination) {
+      if (!merged.has(destName)) merged.set(destName, []);
+      merged.get(destName).push(...docs);
+    }
+  }
+
+  const counts = {};
+  for (const [destName, docs] of merged) {
     // eslint-disable-next-line no-await-in-loop
-    counts[name] = await restoreCollection(db, name, path.join(dbDir, file), transform);
+    counts[destName] = await insertIntoCollection(db, destName, docs);
   }
   await conn.close();
 

--- a/scripts/transforms/josh-migration.mjs
+++ b/scripts/transforms/josh-migration.mjs
@@ -1,0 +1,33 @@
+// scripts/transforms/josh-migration.mjs — the web-jam-tools#897 ("897a")
+// restore transform: reshapes wj-prod's webjamsocket export on its way into
+// web-jam-data.
+//
+// Plugs into scripts/restore-backup.mjs's --transform seam (see that file's
+// header comment and docs/mongo-backup.md for the full contract). This
+// module's default export is `(doc, collectionName) => result`, where
+// `result` is a plain doc (same collection), `null`/`undefined` (drop the
+// doc), or `{ collection, doc }` (redirect the doc to a different
+// collection).
+//
+// Per-collection behavior:
+//   - gigs (133 docs in the wj-prod export): web-jam-data has no gigs of its
+//     own, so this is a clean move — every doc is tagged `artist: "josh"`
+//     (web-jam-data is expected to host more than one artist's gigs
+//     eventually; wj-prod only ever tracked Josh's).
+//   - book (11 docs, JaMmusic slideshow images): only docs with
+//     `type === 'JaMmusic-music'` are kept; everything else is dropped. Kept
+//     docs are redirected into a NEW collection, `jamPics` — NOT `book`,
+//     because web-jam-data already has its own `book` collection
+//     (CollegeLutheran's), which this migration must never touch or clear.
+//   - anything else: passed through unchanged (identity), so pointing this
+//     transform at an export containing other collections is harmless.
+export default function joshMigrationTransform(doc, collectionName) {
+  if (collectionName === 'gigs') {
+    return { ...doc, artist: 'josh' };
+  }
+  if (collectionName === 'book') {
+    if (doc.type !== 'JaMmusic-music') return null;
+    return { collection: 'jamPics', doc };
+  }
+  return doc;
+}

--- a/test/unit/backup/josh-migration.spec.ts
+++ b/test/unit/backup/josh-migration.spec.ts
@@ -1,0 +1,78 @@
+// Unit tests for scripts/transforms/josh-migration.mjs — the web-jam-tools#897
+// ("897a") restore transform. Loaded via a non-literal dynamic `import()` so
+// tsc doesn't need a declaration file for this plain .mjs script module (the
+// specifier isn't a string literal, so TypeScript treats the result as `any`
+// instead of trying to resolve types for it — scripts/ is intentionally
+// outside the tsconfig `include` glob, same as scripts/restore-backup.mjs).
+type JoshMigrationTransform = (
+  doc: Record<string, unknown>,
+  collectionName: string,
+) => Record<string, unknown> | { collection: string; doc: Record<string, unknown> } | null | undefined;
+
+async function loadTransform(): Promise<JoshMigrationTransform> {
+  const modulePath = '../../../scripts/transforms/josh-migration.mjs';
+  const mod = await import(modulePath) as { default: JoshMigrationTransform };
+  return mod.default;
+}
+
+describe('scripts/transforms/josh-migration.mjs', () => {
+  describe('gigs', () => {
+    it('tags every gig doc with artist: "josh", leaving other fields untouched', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'abc123', venue: 'The Bridge', date: 'Oct 4, 2019' };
+
+      const result = transform(doc, 'gigs');
+
+      expect(result).toEqual({ _id: 'abc123', venue: 'The Bridge', date: 'Oct 4, 2019', artist: 'josh' });
+    });
+
+    it('does not mutate the original doc object', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'abc123' };
+
+      transform(doc, 'gigs');
+
+      expect(doc).toEqual({ _id: 'abc123' });
+    });
+  });
+
+  describe('book', () => {
+    it('redirects a JaMmusic-music doc into the jamPics collection, preserving _id and fields', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'book1', type: 'JaMmusic-music', title: 'Valhalla Winery 2019', url: 'https://example.com/x.png' };
+
+      const result = transform(doc, 'book');
+
+      expect(result).toEqual({ collection: 'jamPics', doc });
+    });
+
+    it('drops a non-JaMmusic-music doc (returns null)', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'book2', type: 'CollegeLutheran-photo', title: 'Not ours' };
+
+      const result = transform(doc, 'book');
+
+      expect(result).toBeNull();
+    });
+
+    it('drops a doc with no type field at all', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'book3', title: 'Untyped' };
+
+      const result = transform(doc, 'book');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('any other collection', () => {
+    it('passes the doc through unchanged (identity)', async () => {
+      const transform = await loadTransform();
+      const doc = { _id: 'user1', name: 'Someone' };
+
+      const result = transform(doc, 'user');
+
+      expect(result).toBe(doc);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `scripts/restore-backup.mjs`'s `--transform` seam so a transform can DROP a document (return `null`/`undefined`) or REDIRECT it to a different target collection (return `{ collection, doc }`), in addition to the existing identity contract (return the doc unchanged, same collection).
- A source collection is only dropped-and-reinserted in the target if at least one document actually resolves to it — a fully redirected/dropped source (e.g. `book`) is never touched in the target, so an unrelated same-named collection there is never clobbered.
- Adds the #897 ("897a") migration transform, `scripts/transforms/josh-migration.mjs`: tags every `gigs` doc with `artist: "josh"`; keeps only `book` docs with `type === 'JaMmusic-music'` and redirects the kept ones into a NEW `jamPics` collection (never `book`, since web-jam-data has its own unrelated `book`/`books` collection).
- Adds unit tests (`test/unit/backup/josh-migration.spec.ts`) and updates `docs/mongo-backup.md` to document the extended seam contract + the #897 transform + an example invocation.
- This is one step of #897 (data-migration transform); it does not perform or gate the actual prod cutover into `web-jam-data`, which is a separate, human-gated step.

Part of #897

## How to test locally
Run the full gated suite:
```sh
npm test
```
Expect: eslint clean, jscpd clean, all vitest suites green, coverage at/above the 90/90/80/80 gate.

Then exercise the change itself with a DEV-only dry run (never prod): restore the Dropbox wj-prod safety-net snapshot (`~/Dropbox/WebJamApps/backups/wj-prod-2026-07-03/`, gigs 133 / books 11) reshaped into the restore script's run-folder layout, into the local DEV Atlas `web-jam-dev` database (from `MONGO_DB_URI`, which the restore script's safety guard already requires to contain `dev`/`test` unless `--force` is passed — never passed here):
```sh
node scripts/restore-backup.mjs \
  --folder RUN_FOLDER --db webjamsocket \
  --transform scripts/transforms/josh-migration.mjs
```
Expect: prints `gigs: 133` and `jamPics: 11`, no `book` in the printed counts. Then verify in Mongo: every `gigs` doc has `artist: "josh"`, `jamPics` has 11 docs each with `type: "JaMmusic-music"`, `_id`s preserved, and the target's own `book`/`books` collection is untouched.

## Test evidence
`npm test`:
```
Test Files  35 passed (35)
     Tests  484 passed (484)
Coverage: Statements 91.74% | Branches 84.53% | Functions 86.03% | Lines 92.44%
```

DEV dry-run (node scripts/restore-backup.mjs --folder RUN_FOLDER --db webjamsocket --transform scripts/transforms/josh-migration.mjs, target `web-jam-dev`):
```
Restore complete. Per-collection document counts:
  jamPics: 11
  gigs: 133
```
Follow-up Mongo check: `gigsCount 133`, `gigsWithArtist 133` (every gig doc), `jamPicsCount 11`; `db.listCollections()` shows no `book` collection created by this run (the target's pre-existing `books` collection, CollegeLutheran's own, is a different name and was untouched); one sampled gig and one sampled jamPics doc both round-tripped with their original `_id` and fields intact.

🤖 Work by Claude Code — Sonnet 5