### PR TITLE
Consolidate gigs into web-jam-data and retire the wj-prod Atlas cluster (Atlas simplification)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/scripts/transforms/josh-migration.mjs
+++ b/scripts/transforms/josh-migration.mjs
@@ -14,18 +14,23 @@
 //     own, so this is a clean move — every doc is tagged `artist: "josh"`
 //     (web-jam-data is expected to host more than one artist's gigs
 //     eventually; wj-prod only ever tracked Josh's).
-//   - book (11 docs, JaMmusic slideshow images): only docs with
+//   - books (11 docs, JaMmusic slideshow images): only docs with
 //     `type === 'JaMmusic-music'` are kept; everything else is dropped. Kept
-//     docs are redirected into a NEW collection, `jamPics` — NOT `book`,
-//     because web-jam-data already has its own `book` collection
-//     (CollegeLutheran's), which this migration must never touch or clear.
+//     docs are redirected into a NEW collection, `jamPics` — NOT `books`,
+//     because web-jam-data already has its OWN `books` collection
+//     (CollegeLutheran's 287 docs), which this migration must never touch or
+//     clear. NOTE: the live wj-prod collection is `books` (plural, the
+//     Mongoose pluralization of the Book model) — an earlier draft keyed on
+//     `book` (singular), which would have let these docs fall through to the
+//     identity branch and land in — and thus DROP+REPLACE — CollegeLutheran's
+//     `books`. Verified against live wj-prod 2026-07-04.
 //   - anything else: passed through unchanged (identity), so pointing this
 //     transform at an export containing other collections is harmless.
 export default function joshMigrationTransform(doc, collectionName) {
   if (collectionName === 'gigs') {
     return { ...doc, artist: 'josh' };
   }
-  if (collectionName === 'book') {
+  if (collectionName === 'books') {
     if (doc.type !== 'JaMmusic-music') return null;
     return { collection: 'jamPics', doc };
   }

--- a/test/unit/backup/josh-migration.spec.ts
+++ b/test/unit/backup/josh-migration.spec.ts
@@ -36,12 +36,19 @@ describe('scripts/transforms/josh-migration.mjs', () => {
     });
   });
 
-  describe('book', () => {
+  // The live wj-prod collection is `books` (plural — Mongoose pluralizes the
+  // Book model). This is the SAME name as CollegeLutheran's own `books`
+  // collection in the target web-jam-data, so every `books` doc MUST resolve
+  // to a redirect (jamPics) or a drop — never identity — or the restore would
+  // drop+replace CollegeLutheran's books. These tests key on 'books' (plural);
+  // an earlier version keyed on 'book' (singular) and slipped that hazard past
+  // the dry-run. See the transform's header comment.
+  describe('books', () => {
     it('redirects a JaMmusic-music doc into the jamPics collection, preserving _id and fields', async () => {
       const transform = await loadTransform();
       const doc = { _id: 'book1', type: 'JaMmusic-music', title: 'Valhalla Winery 2019', url: 'https://example.com/x.png' };
 
-      const result = transform(doc, 'book');
+      const result = transform(doc, 'books');
 
       expect(result).toEqual({ collection: 'jamPics', doc });
     });
@@ -50,7 +57,7 @@ describe('scripts/transforms/josh-migration.mjs', () => {
       const transform = await loadTransform();
       const doc = { _id: 'book2', type: 'CollegeLutheran-photo', title: 'Not ours' };
 
-      const result = transform(doc, 'book');
+      const result = transform(doc, 'books');
 
       expect(result).toBeNull();
     });
@@ -59,9 +66,23 @@ describe('scripts/transforms/josh-migration.mjs', () => {
       const transform = await loadTransform();
       const doc = { _id: 'book3', title: 'Untyped' };
 
-      const result = transform(doc, 'book');
+      const result = transform(doc, 'books');
 
       expect(result).toBeNull();
+    });
+
+    it('never returns an identity passthrough for a books doc (would clobber CollegeLutheran)', async () => {
+      const transform = await loadTransform();
+      // whatever the doc, a books doc must be either a redirect or a drop —
+      // never the plain doc back (which would keep it in the `books` collection).
+      for (const doc of [
+        { _id: 'a', type: 'JaMmusic-music' },
+        { _id: 'b', type: 'something-else' },
+        { _id: 'c' },
+      ]) {
+        const result = transform(doc, 'books');
+        expect(result).not.toBe(doc);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix the 897a restore transform (`scripts/transforms/josh-migration.mjs`, merged in #910): key on collection name `books` (plural) instead of `book` (singular).
- Live wj-prod uses `books` (Mongoose pluralization of the Book model) — the SAME name as CollegeLutheran's own 287-doc `books` collection in web-jam-data. As merged, the 11 slideshow docs fell through to the identity branch, landed in `books`, and the restore's drop-then-insert would have WIPED CollegeLutheran's 287 books.
- The #910 dry-run only passed because the snapshot happened to be named `book`.
- Update the spec to key on `books` (it would have caught this) and add a test asserting a `books` doc is never returned as an identity passthrough.
- Bump version to 2.2.1 (patch — bugfix).

Part of #897

## How to test locally
Run:
```sh
npx vitest run test/unit/backup/josh-migration.spec.ts
npm test
```
Expect: transform spec green (7 tests); full suite green with coverage above the 90/90/80/80 gate. The fix was also verified end-to-end against live wj-prod on 2026-07-04: a DEV restore left the target `books` collection's content (CollegeLutheran types) untouched while producing `gigs` (133, `artist:josh`) and `jamPics` (11).

## Test evidence
```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```
Full suite coverage summary:
```
Statements   : 91.74% ( 1811/1974 )
Branches     : 84.53% ( 1082/1280 )
Functions    : 86.03% ( 271/315 )
Lines        : 92.44% ( 1493/1615 )
```
Prod verification after the corrected cutover: `gigs` 133 (all `artist:josh`), `jamPics` 11 (`JaMmusic-music`), `books` 287 untouched.

🤖 Work by Claude Code — Opus 4.8