### PR TITLE
bug on gig email template, hi there It@#39;s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -41,6 +41,47 @@ export interface MailInput {
   attachments?: MailAttachment[];
 }
 
+// Named entities the outreach templates/senders actually produce (outreach-
+// controller's escapeHtml covers the same five characters, plus &nbsp; from
+// pasted copy). Numeric entities (&#39;, &#8217;, &#x27; ...) are decoded
+// generically below, not listed here.
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z0-9]+);/gi, (match, code: string) => {
+    if (code[0] === '#') {
+      const isHex = code[1] === 'x' || code[1] === 'X';
+      const codePoint = parseInt(isHex ? code.slice(2) : code.slice(1), isHex ? 16 : 10);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+    const key = code.toLowerCase();
+    return Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, key) ? NAMED_ENTITIES[key] : match;
+  });
+}
+
+// Derive a readable text/plain alternative from a rendered HTML body. Used as
+// the fallback whenever a caller doesn't supply its own `text` — without this,
+// nodemailer would ship the raw HTML string (tags AND entities like &#39;) as
+// the text/plain part, and Gmail's inbox list/preview — which reads text/plain,
+// not text/html — showed raw markup and escaped entities instead of readable
+// copy (e.g. "It&#39;s" instead of "It's", gig-outreach #909).
+export function htmlToText(html: string): string {
+  const withBreaks = html.replace(/<(br|\/p|\/div|\/tr|\/li|\/h[1-6])\s*\/?>/gi, '\n');
+  // `<[^>]+>` is linear (negated class, no nested quantifier) — safe from
+  // catastrophic backtracking despite the generic slow-regex warning (same
+  // false positive already noted at venue-controller.ts's stripHtml).
+  // eslint-disable-next-line sonarjs/slow-regex
+  const stripped = withBreaks.replace(/<[^>]+>/g, '');
+  // Trailing-whitespace/blank-line cleanup below: both patterns are a single
+  // bounded class, no nested quantifier — safe from catastrophic backtracking.
+  return decodeEntities(stripped)
+    .replace(/[ \t]+\n/g, '\n') // eslint-disable-line sonarjs/slow-regex
+    .replace(/\n{3,}/g, '\n\n') // eslint-disable-line sonarjs/slow-regex
+    .trim();
+}
+
 // Sends one email and returns the RFC Message-ID Gmail assigned it (used by the
 // outreach log to later match replies, #823). No-ops under NODE_ENV=test so unit
 // tests never hit Gmail — returns a stub id so callers can persist a value.
@@ -53,7 +94,7 @@ export async function sendMail(input: MailInput): Promise<{ messageId: string }>
         to: input.to,
         cc: input.cc,
         subject: input.subject,
-        text: input.text || input.html,
+        text: input.text || htmlToText(input.html),
         html: input.html,
         attachments: input.attachments,
       });
@@ -66,4 +107,4 @@ export async function sendMail(input: MailInput): Promise<{ messageId: string }>
   return { messageId: 'test-message-id' };
 }
 
-export default { sendMail };
+export default { sendMail, htmlToText };

--- a/test/unit/lib/mailer.spec.ts
+++ b/test/unit/lib/mailer.spec.ts
@@ -1,0 +1,52 @@
+import { htmlToText, sendMail } from '#src/lib/mailer.js';
+
+// #909 — Gmail's inbox LIST/preview reads the text/plain part of a message,
+// not text/html. mailer.sendMail falls back to htmlToText(html) whenever a
+// caller (outreach-controller's buildPitchEmail/buildFollowUpEmail) sends only
+// an `html` body — so that fallback must strip tags AND decode entities, not
+// just reuse the raw HTML string.
+describe('mailer.ts — htmlToText', () => {
+  it('decodes an apostrophe entity produced by an assembled outreach email, not the raw entity', () => {
+    // Mirrors outreach-controller's renderCustomHtml/escapeHtml output for a
+    // customIntro of "It's wonderful to e-meet you!" wrapped into a <p>, plus
+    // a template bodyHtml paragraph — i.e. a realistic buildPitchEmail html.
+    const html = [
+      "<p>Hi there,</p>\n<p>It&#39;s wonderful to e-meet you!</p>",
+      '<p>Josh &amp; Maria play acoustic sets &mdash; here&#8217;s our clip: '
+        + '<a href="https://example.com">link</a></p>',
+    ].join('\n');
+
+    const text = htmlToText(html);
+
+    expect(text).toContain("It's wonderful to e-meet you!");
+    expect(text).not.toContain('&#39;');
+    expect(text).toContain('Josh & Maria');
+    expect(text).not.toContain('&amp;');
+    expect(text).toContain('here’s');
+    expect(text).not.toContain('&#8217;');
+    expect(text.includes('<') || text.includes('>')).toBe(false);
+  });
+
+  it('decodes the other four HTML-significant entities outreach-controller escapes', () => {
+    const html = '<p>&lt;script&gt; &amp; &quot;quoted&quot; &amp; it&#39;s fine</p>';
+    const text = htmlToText(html);
+    expect(text).toBe('<script> & "quoted" & it\'s fine');
+  });
+
+  it('turns <br> and block-closing tags into newlines instead of running text together', () => {
+    const html = '<p>Line one<br>Line two</p><p>Second paragraph</p>';
+    const text = htmlToText(html);
+    expect(text).toBe('Line one\nLine two\nSecond paragraph');
+  });
+
+  it('leaves plain text with no markup or entities untouched (aside from trimming)', () => {
+    expect(htmlToText('  Hello there  ')).toBe('Hello there');
+  });
+});
+
+describe('mailer.ts — sendMail', () => {
+  it('no-ops under NODE_ENV=test and returns a stub message id', async () => {
+    const result = await sendMail({ to: 'venue@example.com', subject: 'Hi', html: '<p>It&#39;s us</p>' });
+    expect(result).toEqual({ messageId: 'test-message-id' });
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause: `sendMail()` in `src/lib/mailer.ts` fell back to `text: input.text || input.html` whenever a caller sent HTML-only (outreach-controller's `buildPitchEmail`/`buildFollowUpEmail` never pass `text`) — nodemailer shipped the raw HTML string, tags and entities (e.g. `&#39;` from outreach-controller's `escapeHtml`) included, as the text/plain part
- Gmail's inbox LIST/preview reads text/plain, so it rendered `It&#39;s` instead of `It's` even though the opened message (text/html) looked correct
- Add `htmlToText()` to `src/lib/mailer.ts`: strips tags, turns `<br>`/block-closing tags into newlines, and decodes named (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;` `&nbsp;`) and numeric (`&#39;`, `&#8217;`, `&#x27;`, ...) entities
- `sendMail()` now falls back to `htmlToText(input.html)` instead of the raw HTML when no explicit `text` is supplied
- No new dependency added — the repo had no html-to-text/entity-decoding library already installed, so a small well-scoped inline decoder was used (same footprint as the existing `stripHtml` pattern in `venue-controller.ts`)
- Bumped package.json to 2.2.2 (patch — bugfix)

Closes #909

## How to test locally
Run:
```sh
npm test
```
Expect: eslint clean, jscpd report (pre-existing clones, unrelated), all unit tests green, coverage above the 90/90/80/80 gate.

Also exercises the fix directly — `test/unit/lib/mailer.spec.ts` feeds `htmlToText()` an HTML string shaped like an assembled outreach email (an escaped customIntro paragraph plus a template body paragraph, matching outreach-controller's `renderCustomHtml`/`escapeHtml` output) and asserts the decoded text contains a literal apostrophe (`It's wonderful to e-meet you!`) and does NOT contain `&#39;`, plus the other four escaped entities and a numeric entity (`&#8217;`).

## Test evidence
```
> web-jam-back@2.2.2 test
> eslint ./src && npm run jscpd && rimraf coverage && npm run test:unit

(eslint: no output, exit 0)

Found 22 clones (pre-existing, unrelated to this change)

> web-jam-back@2.2.2 test:unit
> vitest run --coverage

 Test Files  36 passed (36)
      Tests  490 passed (490)

=============================== Coverage summary ===============================
Statements   : 91.88% ( 1824/1985 )
Branches     : 84.44% ( 1091/1292 )
Functions    : 86.47% ( 275/318 )
Lines        : 92.61% ( 1506/1626 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5