### PR TITLE
Consolidate gigs into web-jam-data and retire the wj-prod Atlas cluster (Atlas simplification)

### DIFF
--- a/docs/mongo-backup.md
+++ b/docs/mongo-backup.md
@@ -4,20 +4,20 @@ Reference: [web-jam-tools#116](https://github.com/WebJamApps/web-jam-tools/issue
 
 ## TL;DR
 
-`POST /admin/backup` exports every collection of **both** prod databases as EJSON
-and uploads them to Dropbox, keeping the newest 8 weekly runs. Free M0 Atlas has
-no snapshots/PITR, so this self-export is the only safety net. Triggered weekly
-by the Deno cron app (`web-jam-tools`, same pattern as `/outreach/advance`) — that
-half is a separate PR in that repo.
+`POST /admin/backup` exports every collection of this app's own database as
+EJSON and uploads them to Dropbox, keeping the newest 8 weekly runs. Free M0
+Atlas has no snapshots/PITR, so this self-export is the only safety net.
+Triggered weekly by the Deno cron app (`web-jam-tools`, same pattern as
+`/outreach/advance`) — that half is a separate PR in that repo.
 
-- Both DBs exported: **webjamsalem** (this app's own `MONGO_DB_URI`) and
-  **webjamsocket** (WebJamSocketCluster's Mongo, via `GIGS_MONGO_DB_URI` — the
-  var `src/model/gig/gig-schema.ts` already uses to read the `gigs` collection
-  from that same cluster; no *new* env var was needed for the second DB).
+- One DB exported: **webjamsalem** (this app's own `MONGO_DB_URI`, the
+  web-jam-data database — gigs live here too as an artist-scoped collection
+  since web-jam-back#897 retired the old WebJamSocketCluster mirror connection
+  and its `GIGS_MONGO_DB_URI` var).
 - Responds **202 immediately**; the export + upload run async so the request
   never rides Heroku's 30s router timeout (H12).
 - Exports collection-by-collection (one collection's documents in memory at a
-  time, never both DBs at once).
+  time).
 - EJSON preserves data + types (ObjectId/Date/etc.) but **not** indexes or
   collection options — Mongoose re-creates indexes on the app's next boot.
 
@@ -56,17 +56,11 @@ heroku config:set DROPBOX_APP_SECRET="<app secret>" -a webjamsalem
 heroku config:set DROPBOX_REFRESH_TOKEN="<refresh token>" -a webjamsalem
 ```
 
-`GIGS_MONGO_DB_URI` should already be set (it powers the existing `gigs` read
-path) — confirm with `heroku config:get GIGS_MONGO_DB_URI -a webjamsalem`. If it
-somehow isn't set, the backup still runs but the `webjamsocket` half is skipped
-(logged, reflected as `ok: false` in that run's `manifest.json`).
-
 ### Environment variables
 
 | Var | Purpose | Without it |
 | --- | --- | --- |
 | `DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET` / `DROPBOX_REFRESH_TOKEN` | Dropbox refresh-token flow | Export still runs, upload is skipped (local disk only) |
-| `GIGS_MONGO_DB_URI` | Already-existing var for the WebJamSocketCluster Mongo (webjamsocket DB) | `webjamsocket` half of the export is skipped |
 | `BACKUP_OUTPUT_DIR` | Optional override for the local export scratch dir (default: OS tmpdir) | n/a |
 | `BACKUP_KEEP_LOCAL` | Set to `true` to keep the local export after a successful Dropbox upload (debugging) | Local export is deleted once safely in Dropbox |
 
@@ -109,13 +103,15 @@ node scripts/restore-backup.mjs --folder <path/to/run-folder> --db webjamsalem
 
 ### Parameterization (reused by web-jam-tools#897)
 
-This same script is designed to be reusable, unchanged, as the import half of
-the wj-prod → web-jam-data migration (web-jam-tools#897) — not just this
-issue's local/dev backup drill:
+This same script was reused, unchanged, as the import half of the wj-prod →
+web-jam-data migration (web-jam-tools#897, now complete — the mirror
+connection and `GIGS_MONGO_DB_URI` it used to feed have since been retired)
+— not just this issue's local/dev backup drill. It stays generic/reusable for
+any future one-off migration:
 
 - **Target database is already parameterized**, never hardcoded: `--uri`
   points the restore at any Mongo connection string, and `--db` selects which
-  exported subfolder to restore. #897 passes its own `--uri`/`--db` rather than
+  exported subfolder to restore. #897 passed its own `--uri`/`--db` rather than
   needing a fork of this script.
 - **`--transform <path-to-module>`** is an optional per-record hook: the
   module's default export, `(doc, collectionName) => result`, runs on every

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/backup-export.ts
+++ b/src/lib/backup-export.ts
@@ -120,27 +120,23 @@ async function exportLabeledDb(
 }
 
 export interface RunBackupOptions {
-  // Defaults: MONGO_DB_URI (webjamsalem, this app's own DB) and
-  // GIGS_MONGO_DB_URI — the WebJamSocketCluster URI ALREADY used by
-  // src/model/gig/gig-schema.ts to read the `gigs` collection from that same
-  // database, so no new Heroku config var is needed for the second DB.
+  // Default: MONGO_DB_URI (webjamsalem, this app's own DB — the only database
+  // this app owns as of web-jam-back#897; the WebJamSocketCluster mirror DB
+  // this used to also export was retired along with GIGS_MONGO_DB_URI).
   primaryUri?: string;
-  secondaryUri?: string;
   connect?: (uri: string) => Promise<OpenDb>;
 }
 
-// Exports both prod databases (web-jam-tools#116) into outDir/<label>/*.ndjson
-// plus a manifest.json summary. A DB whose URI isn't configured is skipped with
-// a logged warning (reflected in the manifest as ok:false), not a thrown error —
-// locally GIGS_MONGO_DB_URI is normally unset.
+// Exports this app's own database (web-jam-tools#116) into
+// outDir/webjamsalem/*.ndjson plus a manifest.json summary. If the URI isn't
+// configured the export is skipped with a logged warning (reflected in the
+// manifest as ok:false), not a thrown error.
 export async function runFullBackup(outDir: string, opts: RunBackupOptions = {}): Promise<BackupManifest> {
   const connect = opts.connect || defaultConnect;
   const primaryUri = opts.primaryUri ?? process.env.MONGO_DB_URI;
-  const secondaryUri = opts.secondaryUri ?? process.env.GIGS_MONGO_DB_URI;
 
   const databases: Record<string, DbExportResult> = {};
   databases.webjamsalem = await exportLabeledDb('webjamsalem', primaryUri, path.join(outDir, 'webjamsalem'), connect);
-  databases.webjamsocket = await exportLabeledDb('webjamsocket', secondaryUri, path.join(outDir, 'webjamsocket'), connect);
 
   const manifest: BackupManifest = { generatedAt: new Date().toISOString(), databases };
   fs.mkdirSync(outDir, { recursive: true });

--- a/src/model/backup/backup-controller.ts
+++ b/src/model/backup/backup-controller.ts
@@ -8,10 +8,10 @@ import dropbox from '#src/lib/dropbox.js';
 import type { Icontroller } from '#src/lib/routeUtils.js';
 
 // POST /admin/backup — weekly Mongo backup (web-jam-tools#116), triggered by the
-// Deno cron app. Exports every collection of BOTH prod DBs as EJSON and uploads
-// them to Dropbox, then prunes old runs. Heroku kills requests at 30s, so the
-// route responds 202 immediately and the export+upload run async — never on the
-// request path.
+// Deno cron app. Exports every collection of this app's own database as EJSON
+// and uploads them to Dropbox, then prunes old runs. Heroku kills requests at
+// 30s, so the route responds 202 immediately and the export+upload run async —
+// never on the request path.
 const debug = Debug('web-jam-back:backup-controller');
 
 // Filesystem/Dropbox-safe run label: an ISO timestamp with `:`/`.` stripped, so

--- a/src/model/gig/gig-schema.ts
+++ b/src/model/gig/gig-schema.ts
@@ -6,9 +6,12 @@ const options = {
   timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
 };
 
-// Mirror of the gig schema owned by WebJamSocketCluster (it writes the data).
-// web-jam-back only reads from the same Mongo `gigs` collection — keep the
-// shape and explicit collection name in sync with that repo.
+// Gigs used to live in WebJamSocketCluster's own Mongo, read here via a
+// dedicated mirror connection (GIGS_MONGO_DB_URI, web-jam-back#814). As of
+// web-jam-back#897 that data has been migrated into web-jam-data (this app's
+// own default database, artist-scoped per #885) and the mirror connection is
+// retired — gigs are now just another collection on the default mongoose
+// connection, like every other model.
 const gigSchema = new Schema({
   date: { type: String, required: false },
   time: { type: String, required: false },
@@ -21,19 +24,9 @@ const gigSchema = new Schema({
   duration: { type: Number, required: false, default: 0 },
   promoImageUrl: { type: String, required: false },
   more: { type: String, required: false },
-  // Artist/tenant slug (#885). Absent on all pre-#885 records, which read as the
-  // default (JaMmusic) artist. Kept in sync with WebJamSocketCluster's mirror.
+  // Artist/tenant slug (#885). Absent on all pre-#885 records, which read as
+  // the default (JaMmusic) artist.
   artist: { type: String, required: false },
 }, options);
 
-// Gigs live in WebJamSocketCluster's Mongo, a DIFFERENT database than
-// web-jam-back's default connection. In production GIGS_MONGO_DB_URI is set to
-// that DB's URI, so bind the Gig model to a dedicated connection. When it's
-// unset (tests/CI) use the default mongoose connection (the test DB) — the same
-// connection every other model uses, which the test harness already manages, so
-// gigs are read/written in the test DB and prod is never reachable from tests.
-// (web-jam-back#814)
-const gigsUri = process.env.GIGS_MONGO_DB_URI;
-const conn = gigsUri ? mongoose.createConnection(gigsUri) : mongoose;
-
-export default conn.models.Gig || conn.model('Gig', gigSchema, 'gigs');
+export default mongoose.models.Gig || mongoose.model('Gig', gigSchema, 'gigs');

--- a/test/unit/lib/backup-export.spec.ts
+++ b/test/unit/lib/backup-export.spec.ts
@@ -97,44 +97,38 @@ describe('backup-export.ts', () => {
       return Promise.resolve({ db, close: () => Promise.resolve() });
     };
 
-    it('exports both databases when both URIs are configured, and writes a manifest', async () => {
-      const primaryDb = fakeDb({ user: [{ name: 'josh' }] });
-      const secondaryDb = fakeDb({ gigs: [{ venue: 'The Bridge' }, { venue: 'Pub Fest' }] });
+    it('exports the app\'s own database when its URI is configured, and writes a manifest', async () => {
+      const primaryDb = fakeDb({ user: [{ name: 'josh' }], gigs: [{ venue: 'The Bridge' }, { venue: 'Pub Fest' }] });
       const outDir = path.join(tmpDir, 'run-1');
 
       const manifest = await runFullBackup(outDir, {
         primaryUri: 'mongodb://primary',
-        secondaryUri: 'mongodb://secondary',
-        connect: fakeConnect({ 'mongodb://primary': primaryDb, 'mongodb://secondary': secondaryDb }),
+        connect: fakeConnect({ 'mongodb://primary': primaryDb }),
       });
 
-      expect(manifest.databases.webjamsalem).toEqual({ ok: true, collections: { user: 1 } });
-      expect(manifest.databases.webjamsocket).toEqual({ ok: true, collections: { gigs: 2 } });
+      expect(manifest.databases.webjamsalem).toEqual({ ok: true, collections: { user: 1, gigs: 2 } });
       expect(fs.existsSync(path.join(outDir, 'webjamsalem', 'user.ndjson'))).toBe(true);
-      expect(fs.existsSync(path.join(outDir, 'webjamsocket', 'gigs.ndjson'))).toBe(true);
+      expect(fs.existsSync(path.join(outDir, 'webjamsalem', 'gigs.ndjson'))).toBe(true);
 
       const manifestOnDisk = JSON.parse(fs.readFileSync(path.join(outDir, 'manifest.json'), 'utf8'));
       expect(manifestOnDisk.databases.webjamsalem.ok).toBe(true);
       expect(typeof manifestOnDisk.generatedAt).toBe('string');
     });
 
-    it('skips a database with no URI configured (logged, not thrown) — the local GIGS_MONGO_DB_URI-unset case', async () => {
-      const primaryDb = fakeDb({ user: [] });
+    it('skips the database with no URI configured (logged, not thrown)', async () => {
       const outDir = path.join(tmpDir, 'run-2');
 
       const manifest = await runFullBackup(outDir, {
-        primaryUri: 'mongodb://primary',
-        secondaryUri: undefined,
-        connect: fakeConnect({ 'mongodb://primary': primaryDb }),
+        primaryUri: undefined,
+        connect: fakeConnect({}),
       });
 
-      expect(manifest.databases.webjamsalem.ok).toBe(true);
-      expect(manifest.databases.webjamsocket).toEqual({
+      expect(manifest.databases.webjamsalem).toEqual({
         ok: false,
-        reason: 'webjamsocket skipped — no URI configured for this database',
+        reason: 'webjamsalem skipped — no URI configured for this database',
         collections: {},
       });
-      expect(fs.existsSync(path.join(outDir, 'webjamsocket'))).toBe(false);
+      expect(fs.existsSync(path.join(outDir, 'webjamsalem'))).toBe(false);
     });
 
     it('records a failed connection as ok:false with the error message, without throwing', async () => {
@@ -143,12 +137,10 @@ describe('backup-export.ts', () => {
 
       const manifest = await runFullBackup(outDir, {
         primaryUri: 'mongodb://primary',
-        secondaryUri: 'mongodb://secondary',
         connect: failingConnect,
       });
 
       expect(manifest.databases.webjamsalem).toEqual({ ok: false, reason: 'bad auth', collections: {} });
-      expect(manifest.databases.webjamsocket).toEqual({ ok: false, reason: 'bad auth', collections: {} });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rework `src/model/gig/gig-schema.ts` to bind the Gig model to the app's default Mongoose connection only (dropped the `GIGS_MONGO_DB_URI`-conditional `mongoose.createConnection` mirror from #814) — gigs now live in `MONGO_DB_URI`'s database (web-jam-data) like every other model, since the #897 migration already moved the artist-scoped gig data there.
- Reworked `src/lib/backup-export.ts`'s `runFullBackup` to export only the app's own database — dropped `RunBackupOptions.secondaryUri` and the `webjamsocket` `exportLabeledDb` call.
- Updated `src/model/backup/backup-controller.ts`'s route comment (no longer "both prod DBs").
- Updated `docs/mongo-backup.md`: removed the "both prod databases"/`GIGS_MONGO_DB_URI` framing, single-DB backup description, and reworded the #897 parameterization section to past tense (that migration is complete).
- Updated `test/unit/lib/backup-export.spec.ts`'s `runFullBackup` tests for the single-database shape.
- `.env.example`/README already had no `GIGS_MONGO_DB_URI` references — nothing to remove there. `scripts/restore-backup.mjs` and `scripts/transforms/` are untouched (still the reusable restore toolset).
- Bumped `package.json` version 2.2.2 -> 2.2.3 (first commit only).

Part of #897

## How to test locally
Run:
```sh
npm test        # eslint + jscpd + vitest run --coverage
npm run typecheck
```
Expect: lint clean, 490/490 tests green, coverage above the 90/90/80/80 (stmt/lines/branch/func) gate, typecheck silent.

Runtime check (post-deploy, cannot be exercised in this sandbox — no live Heroku/Atlas access): after this PR deploys, confirm `GET https://webjamsalem.herokuapp.com/gig` still serves the migrated artist-scoped gigs — i.e. that removing the mirror connection didn't change what's returned, since gigs now come from the same default connection every other read already uses. Also confirm a `POST /admin/backup` run's `manifest.json` only contains a `webjamsalem` entry (no `webjamsocket`).

## Test evidence
eslint: no output (clean)

vitest:
```
 Test Files  36 passed (36)
      Tests  490 passed (490)
   Duration  39.17s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
All files          |   91.87 |    84.54 |   86.47 |    92.6 |
```
(gate: statements 90, lines 90, branches 80, functions 80 — all pass)

typecheck (`tsc --noEmit -p tsconfig.prod.json && tsc --noEmit`): no output (clean)

🤖 Work by Claude Code — Sonnet 5