### PR TITLE
filterEligible reads gigs unscoped — Tim's gigs can wrongly block Josh's outreach venue eligibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -168,12 +168,19 @@ class VenueController extends Controller {
 
   // Drop venues that have a gig within ±2 months of the target date. Gigs live
   // in a different DB (read via gigModel); matching is by venue name against the
-  // gig's HTML `venue` text (best-effort, name-based).
+  // gig's HTML `venue` text (best-effort, name-based). Outreach is Josh & Maria's:
+  // scope to Josh's gigs (or pre-migration docs with no artist field) so Tim's
+  // gigs (web-jam-back#922) never gate Josh's venue eligibility.
   static async filterEligible(venues: Record<string, unknown>[], target: Date): Promise<Record<string, unknown>[]> {
     const start = new Date(target); start.setMonth(start.getMonth() - ELIGIBILITY_WINDOW_MONTHS);
     const end = new Date(target); end.setMonth(end.getMonth() + ELIGIBILITY_WINDOW_MONTHS);
     let gigs: GigDoc[];
-    try { gigs = await gigModel.find({}) as unknown as GigDoc[]; } catch (e) { return Promise.reject(e); }
+    try {
+      gigs = await gigModel.find({
+        $or: [{ artist: 'josh' }, { artist: { $exists: false } }],
+      }) as unknown as GigDoc[];
+    } catch (e) { return Promise.reject(e); }
+    // `booked` entries are already lowercased by stripHtml, matching `name` below.
     const booked = gigs
       .filter((g) => g.datetime && new Date(g.datetime) >= start && new Date(g.datetime) <= end)
       .map((g) => stripHtml(String(g.venue || '')));

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -232,6 +232,30 @@ describe('Venue Controller', () => {
       await c.listVenues({ user: 'a', query: { eligibleFor: 'not-a-date' } }, resStub);
       expect(status).toBe(400);
     });
+
+    // web-jam-back#922: gigs is a shared collection — Tim's calendar must never
+    // gate Josh's outreach eligibility.
+    it('does not drop a venue for a Tim-only gig, but still drops for josh/artist-less gigs', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([
+        { name: 'Venue X' }, { name: 'Venue Y' }, { name: 'Venue Z' },
+      ]));
+      (gigModel as any).find = vi.fn((filter: any) => {
+        // Simulate the real Mongo $or predicate against a mixed-artist collection.
+        const all = [
+          { venue: 'Venue X', datetime: '2026-07-15T00:00:00.000Z', artist: 'tim' },
+          { venue: 'Venue Y', datetime: '2026-07-15T00:00:00.000Z', artist: 'josh' },
+          { venue: 'Venue Z', datetime: '2026-07-15T00:00:00.000Z' }, // pre-migration, no artist field
+        ];
+        const matches = all.filter((g) => filter.$or.some((clause: any) => (
+          clause.artist === g.artist
+          || (clause.artist && clause.artist.$exists === false && g.artist === undefined)
+        )));
+        return Promise.resolve(matches);
+      });
+      await c.listVenues({ user: 'a', query: { eligibleFor: '2026-07-01' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.map((v: any) => v.name)).toEqual(['Venue X']);
+    });
   });
 
   describe('buildListFilter', () => {


### PR DESCRIPTION
## Summary
- Scope `VenueController.filterEligible`'s gig lookup (src/model/venue/venue-controller.ts) to Josh's gigs — `{ $or: [{ artist: 'josh' }, { artist: { $exists: false } } ] }` — so Tim's `artist:'tim'` gigs (now sharing the `gigs` collection) can never drop a venue from Josh's outreach eligibility window
- Verified the case-sensitivity wart the issue flagged doesn't actually exist: `stripHtml` already lowercases the booked-venue strings before the `.includes(name)` match — added a comment noting this so it isn't re-flagged
- Added unit test: an `artist:'tim'` gig at a venue within the ±2-month window does NOT drop that venue, while an artist-less gig and an `artist:'josh'` gig still do
- Patch version bump 2.2.4 → 2.2.5

Closes #922

## How to test locally
Run the suite:
```sh
npm test && npm run typecheck
```
Expect: eslint clean, jscpd clean, 502+ vitest tests green, coverage ≥ 90/90/80/80 gate, typecheck clean.

Runnable exercise against a dev DB seeded with a mixed-artist gigs collection (mirrors the acceptance criteria in #922):
```sh
# Seed one tim gig and one josh gig at the same venue name, both inside the
# ±2-month window of the eligibleFor target date, e.g. target=2026-07-01:
# POST /gig  { venue: 'Venue X', datetime: '2026-07-15', artist: 'tim' }
# POST /gig  { venue: 'Venue Y', datetime: '2026-07-15', artist: 'josh' }
# Venue records 'Venue X' and 'Venue Y' both exist and are outreachEligible.

curl -s -H "Authorization: Bearer $TOKEN" \
  'https://YOUR_DEV_HOST/venue?eligibleFor=2026-07-01'
```
Expected: response includes 'Venue X' (Tim's gig does not gate it) and excludes 'Venue Y' (Josh's own gig still gates it, as before).

## Test evidence
$ npm test
...
 Test Files  38 passed (38)
      Tests  502 passed (502)
   Duration  44.82s

=============================== Coverage summary ===============================
Statements   : 92.04% ( 1862/2023 )
Branches     : 85.09% ( 1125/1322 )
Functions    : 86.76% ( 282/325 )
Lines        : 92.69% ( 1536/1657 )
================================================================================
(gate: 90/90/80/80 — all above threshold)

$ npm run typecheck
> web-jam-back@2.2.5 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
(no output, exit 0)

🤖 Work by Claude Code — Sonnet 5