### PR TITLE
TSM admin login 500 on Google code exchange — verify TimGoogleClientSecret + log Google's error body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -40,7 +40,19 @@ async function authenticate(req: { body: { redirectUri: string; code: string; cl
       headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
       body: params,
     });
-    if (!tokenRes.ok) throw new Error(`${tokenRes.status} ${tokenRes.statusText}`);
+    if (!tokenRes.ok) {
+      // #929: Heroku logs showed nothing diagnosable because `debug()` is a
+      // no-op unless DEBUG is set in prod. Log Google's actual error body
+      // (never the secret/full request config) so failures are traceable.
+      const errBody = await tokenRes.json().catch(() => undefined) as { error?: string; error_description?: string } | undefined;
+      console.error('[auth/google] token exchange failed', { // eslint-disable-line no-console
+        status: tokenRes.status,
+        error: errBody?.error,
+        error_description: errBody?.error_description,
+        clientId: req.body.clientId,
+      });
+      throw new Error(`${tokenRes.status} ${tokenRes.statusText}`);
+    }
     tokenBody = await tokenRes.json() as GoogleTokenResponse;
     debug(tokenBody);
   } catch (e) { debug(e); throw e; }

--- a/test/unit/google.spec.ts
+++ b/test/unit/google.spec.ts
@@ -30,6 +30,29 @@ describe('google.ts', () => {
     const res = await google.authenticate(req);
     expect(res.emailAddresses[0].value).toBe('me@me.com');
   });
+  it('#929 logs Google\'s status/error/error_description and clientId (never the secret) on exchange failure', async () => {
+    const prevSecret = process.env.GoogleClientSecret;
+    process.env.GoogleClientSecret = 'super-secret-value';
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ error: 'invalid_grant', error_description: 'Bad Request' }),
+    }));
+    const req = { body: { code: 'whatever', clientId: 'my-client-id', redirectUri: 'http://whatever.com' } };
+    await expect(google.authenticate(req)).rejects.toThrow('400 Bad Request');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[auth/google] token exchange failed', {
+      status: 400,
+      error: 'invalid_grant',
+      error_description: 'Bad Request',
+      clientId: 'my-client-id',
+    });
+    expect(JSON.stringify(consoleErrorSpy.mock.calls[0])).not.toContain('super-secret-value');
+    consoleErrorSpy.mockRestore();
+    process.env.GoogleClientSecret = prevSecret;
+  });
+
   it("accepts Tim's OAuth client id (#885) and pairs it with Tim's secret", async () => {
     const prevId = process.env.TimGoogleClientId;
     const prevSecret = process.env.TimGoogleClientSecret;


### PR DESCRIPTION
## Summary
- `src/auth/google.ts`: on a failed Step 1 (code-for-token) exchange, parse Google's error response body and `console.error` its HTTP status, `error`, and `error_description` fields, plus the `clientId` in use (JaM vs Tim) — never the client secret or the fetch request config
- Previously the catch only called `debug(e)`, which is a no-op in prod (no `DEBUG` env var on Heroku), leaving zero diagnosable detail behind the generic 500
- Outward behavior unchanged: same 500 status, same `{ message: e.message }` response body, same thrown error text
- `test/unit/google.spec.ts`: added a test asserting the exact `console.error` call shape and that a known dummy client secret never appears in the logged payload
- Bumped `package.json` version 2.2.5 → 2.2.6 (patch)

Part of #929

## How to test locally
Run:
```sh
npm run typecheck
npm test
```
Expect: typecheck clean, eslint clean, jscpd report-only (non-blocking), all vitest suites green, coverage above the 90/90/80/80 gate.

To manually exercise the change once deployed: trigger the Tim admin Google login flow that currently 500s, then check Heroku logs (`heroku logs --app <app> --tail`) for a new `[auth/google] token exchange failed` line showing Google's real status/error/error_description/clientId — this is what should finally reveal the root cause behind #929.

## Test evidence
`npx eslint ./src` → clean, exit 0.

`npm test` (eslint + jscpd + vitest --coverage):
```
 Test Files  38 passed (38)
      Tests  503 passed (503)
   Duration  43.26s

=============================== Coverage summary ===============================
Statements   : 92% ( 1864/2026 )
Branches     : 85.09% ( 1125/1322 )
Functions    : 86.5% ( 282/326 )
Lines        : 92.71% ( 1539/1660 )
================================================================================
```

`npm run typecheck` → both `tsc --noEmit` invocations clean, no output.

🤖 Work by Claude Code — Sonnet 5