### PR TITLE
Structured "touches" interaction log on venue records (backend)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.2.7",
+  "version": "2.3.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -132,6 +132,30 @@ function parseTargetWeekend(raw: RawTargetWeekend | undefined): TargetWeekend | 
   return { start, end };
 }
 
+// The Mongo overlap clause for "an outreach whose targetWeekend range overlaps
+// `tw`" — shared by the dedup guard, the #898 target-filled auto-flip, and the
+// #898 candidates target-weekend filter, so the three stay in lockstep instead
+// of drifting into subtly different date-overlap logic. A legacy record with
+// no targetWeekend can never match (both clauses require the field to exist).
+function targetWeekendOverlapClause(tw: TargetWeekend): Record<string, unknown> {
+  return {
+    'targetWeekend.start': { $exists: true, $lte: tw.end },
+    'targetWeekend.end': { $exists: true, $gte: tw.start },
+  };
+}
+
+// #898 — the outcome values recordOutcome accepts. Deliberately narrower than
+// the full OUTREACH_STATUSES enum below: this endpoint records a HUMAN (or
+// auto-flip) DECISION about a pitch, not the sent/replied/no-response
+// lifecycle states, which stay on updateOutreach.
+const OUTCOME_VALUES = ['interested', 'not-interested', 'booked', 'target-filled'];
+
+interface OutcomeBody { status?: string; bookedDate?: string; actor?: string }
+interface TouchRecord {
+  date: Date; type: string; note?: string; templateType?: string; targetWeekend?: TargetWeekend;
+  outcome?: string; bookedDate?: Date; outreachId?: string; actor?: string;
+}
+
 function checkAccess(user: AuthedUser, required: string[]): AuthzResult {
   const privileges = user.privileges || [];
   if (privileges.length) {
@@ -409,6 +433,139 @@ class OutreachController extends Controller {
     return res.status(200).json(doc);
   }
 
+  // Append one venue timeline touch (#898). Best-effort: a venue-write hiccup
+  // must never fail the outreach status change, which is the critical write
+  // here (mirrors the existing lastContacted / recordBounce best-effort
+  // pattern elsewhere in this file).
+  async appendVenueTouch(venueId: unknown, touch: TouchRecord): Promise<void> {
+    try {
+      await venueModel.findByIdAndUpdate(String(venueId), { $push: { touches: touch } } as unknown as Record<string, unknown>);
+    } catch { /* best-effort */ }
+  }
+
+  // Auto-flip every OTHER active (`sent`) record whose targetWeekend overlaps
+  // the just-booked record's targetWeekend to `target-filled` (#898/#923): not
+  // a rejection, the venue returns to the pool for a future target. Runs ONLY
+  // when the booked record itself carries a targetWeekend (a legacy record
+  // with none has nothing to compare against, so nothing is flipped). Each
+  // flipped record is also stamped outcomeAt/outcomeBy (actor
+  // 'outcome-auto-flip', distinguishing an automatic flip from a human-
+  // recorded one) and gets a matching 'outcome' touch on ITS OWN venue's
+  // timeline, so every affected venue's history reflects the target-filled
+  // outcome, not just the venue that got booked. One bad record must not
+  // abort the rest of the flip, so each write is individually swallowed.
+  async autoFlipTargetFilled(recordId: string, tw: TargetWeekend | null): Promise<void> {
+    if (!tw) return;
+    let others: OutreachDoc[];
+    try {
+      others = await this.model.find({
+        _id: { $ne: recordId }, status: 'sent', ...targetWeekendOverlapClause(tw),
+      }) as unknown as OutreachDoc[];
+    } catch { return; }
+    const now = new Date();
+    for (const o of others) {
+      try {
+        await this.model.findByIdAndUpdate(String(o._id), { // eslint-disable-line no-await-in-loop
+          status: 'target-filled', nextTouchDue: null, outcomeAt: now, outcomeBy: 'outcome-auto-flip', lastModifiedBy: 'outcome-auto-flip',
+        });
+      } catch { /* one bad record shouldn't abort the rest of the flip */ }
+      await this.appendVenueTouch(o.venueId, { // eslint-disable-line no-await-in-loop
+        date: now, type: 'outcome', outcome: 'target-filled', targetWeekend: tw, outreachId: String(o._id), actor: 'outcome-auto-flip',
+      });
+    }
+  }
+
+  // Validate a recordOutcome body. Returns an error message, or '' when valid.
+  // Split out of recordOutcome to keep its cognitive complexity down.
+  static validateOutcomeBody(body: OutcomeBody): string {
+    if (!body.status || OUTCOME_VALUES.indexOf(body.status) === -1) {
+      return `status must be one of ${OUTCOME_VALUES.join(', ')}`;
+    }
+    if (body.status === 'booked' && (!body.bookedDate || Number.isNaN(new Date(body.bookedDate).getTime()))) {
+      return 'bookedDate (valid date) is required for a booked outcome';
+    }
+    return '';
+  }
+
+  // The venue-side effects of recording an outcome (#898) — split out of
+  // recordOutcome to keep its cognitive complexity down. All best-effort
+  // (mirrors recordBounce elsewhere in this file): the outreach status change
+  // already committed by the caller is the critical write; a venue hiccup
+  // here shouldn't undo it.
+  //   - not-interested → venue.doNotContact = true (PERMANENT, per #923).
+  //   - booked → bookedDate + bookingStatus:'booked' on the venue (a judgment
+  //     call: the venue's coarse booking standing should track the specific
+  //     gig date recorded here), plus the target-filled auto-flip.
+  // Every outcome also gets a matching timeline touch on the venue.
+  async applyOutcomeSideEffects(
+    existing: OutreachDoc,
+    status: string,
+    bookedDate: Date | undefined,
+    actor: string,
+    outcomeAt: Date,
+    recordId: string,
+  ): Promise<void> {
+    const tw = (existing as unknown as { targetWeekend?: TargetWeekend }).targetWeekend;
+    if (status === 'not-interested') {
+      try { await venueModel.findByIdAndUpdate(String(existing.venueId), { doNotContact: true, lastModifiedBy: actor }); } catch { /* best-effort */ }
+    }
+    if (status === 'booked') {
+      try {
+        await venueModel.findByIdAndUpdate(String(existing.venueId), {
+          bookedDate, bookingStatus: 'booked', lastModifiedBy: actor,
+        });
+      } catch { /* best-effort */ }
+    }
+    await this.appendVenueTouch(existing.venueId, {
+      date: outcomeAt, type: 'outcome', outcome: status, targetWeekend: tw, bookedDate, outreachId: recordId, actor,
+    });
+    if (status === 'booked') await this.autoFlipTargetFilled(recordId, tw || null);
+  }
+
+  // POST /outreach/:id/outcome — the single choke point for recording an
+  // outcome on a pitch (#898, per #923's design). Sets status (interested /
+  // not-interested / booked / target-filled), stamps outcomeAt + outcomeBy,
+  // nulls nextTouchDue (the same #850 "any non-sent status halts the cadence"
+  // rule updateOutreach already applies), writes the corresponding venue
+  // timeline event, and runs the status-specific side effects documented on
+  // applyOutcomeSideEffects above. Distinct from the generic updateOutreach
+  // (PUT /outreach/:id, which only does status/gmailThreadId and does NOT
+  // stamp outcomeAt/outcomeBy or run any side effect) — recordOutcome is the
+  // ONLY path that does either.
+  async recordOutcome(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['outreach:edit']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Update id is invalid' });
+    }
+    const body = (req.body || {}) as OutcomeBody;
+    const invalid = OutreachController.validateOutcomeBody(body);
+    if (invalid) return res.status(400).json({ message: invalid });
+    const bookedDate = body.status === 'booked' ? new Date(body.bookedDate as string) : undefined;
+
+    let existing: OutreachDoc | null;
+    try { existing = await this.model.findById(req.params.id) as unknown as OutreachDoc | null; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!existing) return res.status(400).json({ message: 'Id Not Found' });
+
+    const actor = resolveActor(req, body);
+    const outcomeAt = new Date();
+    const update: Record<string, unknown> = {
+      status: body.status, outcomeAt, outcomeBy: actor, nextTouchDue: null, lastModifiedBy: actor,
+    };
+    if (bookedDate) update.bookedDate = bookedDate;
+
+    let updated: OutreachDoc | null;
+    try { updated = await this.model.findByIdAndUpdate(req.params.id, update) as unknown as OutreachDoc | null; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!updated) return res.status(400).json({ message: 'Id Not Found' });
+
+    await this.applyOutcomeSideEffects(existing, body.status as string, bookedDate, actor, outcomeAt, req.params.id);
+    return res.status(200).json(updated);
+  }
+
   // DELETE /outreach/:id — hard-delete an outreach record (#857). Outreach is a
   // log, not a venue, so a bad / test / mis-sent record is removed outright
   // rather than archived. Requires outreach:delete.
@@ -460,10 +617,7 @@ class OutreachController extends Controller {
   // legacy records don't block. Returns the error envelope to relay, or null.
   async dedupGuard(venueId: string | undefined, tw: TargetWeekend | null): Promise<AuthzError | null> {
     const query: Record<string, unknown> = { venueId, status: { $in: ACTIVE_STATUSES } };
-    if (tw) {
-      query['targetWeekend.start'] = { $exists: true, $lte: tw.end };
-      query['targetWeekend.end'] = { $exists: true, $gte: tw.start };
-    }
+    if (tw) Object.assign(query, targetWeekendOverlapClause(tw));
     let dupe;
     try {
       dupe = await this.model.findOne(query);
@@ -537,6 +691,12 @@ class OutreachController extends Controller {
     try {
       await venueModel.findByIdAndUpdate(String(venue._id), { lastContacted: new Date(), lastModifiedBy: actor });
     } catch { /* best-effort */ }
+    // #898 — log this send on the venue's timeline: email + which template +
+    // which target weekend the pitch was for (the rescope's "pitched for Sept
+    // 26 vs Oct 10" requirement). Best-effort, like the lastContacted stamp.
+    await this.appendVenueTouch(venue._id, {
+      date: sentAt, type: 'email', templateType: type, targetWeekend: fields.targetWeekend, outreachId: String(record._id), actor,
+    });
     return { ok: true, record };
   }
 
@@ -614,9 +774,14 @@ class OutreachController extends Controller {
   }
 
   // GET /outreach/candidates — propose the target list (#844): vetted
-  // (outreachEligible), non-archived venues with an email, minus any that already
-  // have an active outreach for the given targetDates. Read-only. Optional query:
-  // targetDates (to exclude already-pitched venues for that window).
+  // (outreachEligible), non-archived venues with an email, minus any that
+  // already have an active outreach with an OVERLAPPING targetWeekend. #898:
+  // this filter is now targetWeekend/date-range aware (matching the dedup
+  // guard's overlap semantics) rather than the old targetDates string filter —
+  // the note in PR #933 deferred this rekey to this issue, since #923 already
+  // established targetDates no longer participates in any logic. Read-only.
+  // Optional query: targetWeekend {start, end} (bracket-notation query params
+  // over HTTP, e.g. ?targetWeekend[start]=...&targetWeekend[end]=...).
   async getCandidates(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -629,11 +794,18 @@ class OutreachController extends Controller {
       });
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
 
-    const targetDates = typeof (req.query || {}).targetDates === 'string' ? (req.query as { targetDates: string }).targetDates : undefined;
+    const query = (req.query || {}) as { targetWeekend?: RawTargetWeekend };
+    let tw: TargetWeekend | null = null;
+    if (query.targetWeekend !== undefined) {
+      tw = parseTargetWeekend(query.targetWeekend);
+      if (!tw) return res.status(400).json({ message: 'targetWeekend must include valid start and end' });
+    }
     let handled = new Set<string>();
-    if (targetDates) {
+    if (tw) {
       let active: { venueId?: unknown }[];
-      try { active = await this.model.find({ targetDates, status: { $in: ACTIVE_STATUSES } }); } catch (e) {
+      try {
+        active = await this.model.find({ status: { $in: ACTIVE_STATUSES }, ...targetWeekendOverlapClause(tw) });
+      } catch (e) {
         return res.status(500).json({ message: (e as Error).message });
       }
       handled = new Set(active.map((a) => String(a.venueId)));

--- a/src/model/outreach/outreach-router.ts
+++ b/src/model/outreach/outreach-router.ts
@@ -96,6 +96,17 @@ router.route('/:id/apply-suggestion')
     void action();
   });
 
+// POST /outreach/:id/outcome — record an outcome (interested / not-interested
+// / booked / target-filled) on a pitch (#898). The single choke point: stamps
+// outcomeAt/outcomeBy, halts the cadence, writes the venue timeline event, and
+// runs the not-interested/booked side effects (incl. the target-filled
+// auto-flip on booking). See outreach-controller.recordOutcome.
+router.route('/:id/outcome')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'recordOutcome', controller, authUtils);
+    void action();
+  });
+
 router.route('/:id')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'getOutreach', controller, authUtils);

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -13,6 +13,9 @@ const BOOKING_STATUSES = ['booking', 'not-booking', 'booked'];
 // Prospect-ranking enums (#867) — drive the AdminVenues "Prospect Score" sort.
 const ORIGINALS_FIT = ['none', 'some', 'loves'];
 const TRAVEL_BANDS = ['local', 'regional', 'far'];
+// Per-venue timeline (#898) — mirrors touchSchema's enums in venue-schema.ts.
+const TOUCH_TYPES = ['visit', 'form', 'card', 'call', 'email', 'gig', 'other', 'outcome'];
+const TOUCH_OUTCOMES = ['interested', 'not-interested', 'booked', 'target-filled'];
 
 // Role fallback for human admins who authorize by role (no privileges array).
 // AI agents pass via the venue:* capabilities on the shared web-jam-llm identity.
@@ -66,6 +69,21 @@ interface VenueBody {
 
 interface GigDoc { venue?: string; datetime?: string | Date }
 
+// #898 — wire shape for POST /venue/:id/touch. `targetWeekend` mirrors the
+// outreach schema's shape (strings over the wire; parsed to Dates below).
+interface RawTargetWeekend { start?: string | Date; end?: string | Date }
+interface TouchBody {
+  date?: string;
+  type?: string;
+  note?: string;
+  templateType?: string;
+  targetWeekend?: RawTargetWeekend;
+  outcome?: string;
+  bookedDate?: string;
+  outreachId?: string;
+  actor?: string;
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -79,7 +97,7 @@ function stripHtml(value: string): string {
 
 // The actor that performed a write: an explicit `actor` (stamped by the MCP
 // server / agent) wins; otherwise fall back to the authenticated token subject.
-function resolveActor(req: AuthRequest, body: VenueBody): string {
+function resolveActor(req: AuthRequest, body: { actor?: string }): string {
   return (body.actor || '').trim() || req.user || '';
 }
 
@@ -105,6 +123,69 @@ function invalidEnum(body: VenueBody): string {
     return v !== undefined && v !== '' && f.allowed.indexOf(v) === -1;
   });
   return bad ? `${bad.key} not valid` : '';
+}
+
+// #898 — parse + validate a wire-shape targetWeekend into real Dates. Returns
+// null for anything malformed (missing either bound, unparseable, or an
+// inverted range) — mirrors outreach-controller's parseTargetWeekend. Kept as
+// a local copy (not shared) so venue-controller has no import dependency on
+// outreach-controller.
+function parseTargetWeekend(raw: RawTargetWeekend | undefined): { start: Date; end: Date } | null {
+  if (!raw || !raw.start || !raw.end) return null;
+  const start = new Date(raw.start);
+  const end = new Date(raw.end);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+  if (start.getTime() > end.getTime()) return null;
+  return { start, end };
+}
+
+// Outcome-specific validation for a `type: 'outcome'` touch — split out of
+// validateTouchBody to keep its cognitive complexity down. Returns an error
+// message, or '' when valid. A 'booked' outcome additionally requires a valid
+// `bookedDate` (the actual gig date being recorded).
+function validateTouchOutcome(body: TouchBody): string {
+  if (!body.outcome || TOUCH_OUTCOMES.indexOf(body.outcome) === -1) {
+    return `outcome must be one of ${TOUCH_OUTCOMES.join(', ')} for an outcome touch`;
+  }
+  if (body.outcome === 'booked' && (!body.bookedDate || Number.isNaN(new Date(body.bookedDate).getTime()))) {
+    return 'bookedDate (valid date) is required for a booked outcome touch';
+  }
+  return '';
+}
+
+// Validate a POST /venue/:id/touch body. Returns an error message, or '' when
+// valid. `type` is always required; `outcome` is required (and enum-checked,
+// see validateTouchOutcome) only for an 'outcome' touch.
+function validateTouchBody(body: TouchBody): string {
+  if (!body.type || TOUCH_TYPES.indexOf(body.type) === -1) return `type must be one of ${TOUCH_TYPES.join(', ')}`;
+  if (body.targetWeekend !== undefined && !parseTargetWeekend(body.targetWeekend)) {
+    return 'targetWeekend must include valid start and end';
+  }
+  if (body.type === 'outcome') {
+    const outcomeErr = validateTouchOutcome(body);
+    if (outcomeErr) return outcomeErr;
+  } else if (body.outcome !== undefined) {
+    return 'outcome is only valid on an outcome touch';
+  }
+  if (body.outreachId !== undefined && !mongoose.Types.ObjectId.isValid(body.outreachId)) return 'outreachId is invalid';
+  if (body.date !== undefined && Number.isNaN(new Date(body.date).getTime())) return 'date must be a valid date';
+  return '';
+}
+
+// Build the touch subdocument to append, from a validated body.
+function buildTouch(body: TouchBody, actor: string): Record<string, unknown> {
+  const tw = parseTargetWeekend(body.targetWeekend);
+  return {
+    date: body.date ? new Date(body.date) : new Date(),
+    type: body.type,
+    note: body.note,
+    templateType: body.templateType,
+    targetWeekend: tw || undefined,
+    outcome: body.outcome,
+    bookedDate: body.bookedDate ? new Date(body.bookedDate) : undefined,
+    outreachId: body.outreachId,
+    actor,
+  };
 }
 
 function invalidPriority(priority: number | undefined): boolean {
@@ -282,6 +363,31 @@ class VenueController extends Controller {
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
     if (!doc) return res.status(400).json({ message: 'Id Not Found' });
     return res.status(200).json(doc);
+  }
+
+  // POST /venue/:id/touch — append one timeline event (#898). Gated by
+  // `venue:edit` like every other venue mutation (no dedicated capability —
+  // a touch is just another field write on the venue). Used for manual
+  // contact events (visit/form/card/call/gig/other) AND, from the outreach
+  // side, by the outcome-recording endpoint (#898's recordOutcome in
+  // outreach-controller) to log email sends and recorded outcomes.
+  async addTouch(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, ['venue:edit']);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Update id is invalid' });
+    const body = (req.body || {}) as TouchBody;
+    const invalid = validateTouchBody(body);
+    if (invalid) return res.status(400).json({ message: invalid });
+    const actor = resolveActor(req, body);
+    const touch = buildTouch(body, actor);
+    let doc;
+    try {
+      doc = await this.model.findByIdAndUpdate(req.params.id, {
+        $push: { touches: touch }, lastModifiedBy: actor,
+      } as unknown as Record<string, unknown>);
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    if (!doc) return res.status(400).json({ message: 'Id Not Found' });
+    return res.status(201).json(doc);
   }
 
   // DELETE /venue/:id — soft-delete (archive), never a hard remove, so history

--- a/src/model/venue/venue-router.ts
+++ b/src/model/venue/venue-router.ts
@@ -33,4 +33,12 @@ router.route('/:id')
     void action();
   });
 
+// POST /venue/:id/touch — append one timeline event (#898). See
+// venue-controller.addTouch for the touch shape + validation.
+router.route('/:id/touch')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'addTouch', controller, authUtils);
+    void action();
+  });
+
 export default router;

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -6,6 +6,59 @@ const options = {
   timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
 };
 
+// The target weekend a touch relates to (#898/#923) — same shape as the
+// outreach schema's targetWeekend, duplicated here (rather than shared) so the
+// venue model has no import dependency on the outreach model. Optional: only
+// send/outcome touches carry one; a plain visit/call/card touch does not.
+const touchTargetWeekendSchema = new Schema({
+  start: { type: Date, required: false },
+  end: { type: Date, required: false },
+}, { _id: false });
+
+// Per-venue contact timeline (#898) — the backend of the JaMmusic outreach
+// workspace's per-venue history view. Kept as a small embedded array (not its
+// own collection like `outreach`, #823): a touch is a lightweight timeline
+// entry, always read as part of "show me this venue's history," never queried
+// across venues on its own.
+//
+// `type` covers both manual/offline contact (visit/form/card/call/gig/other)
+// AND the two events the 2026-07-10 rescope (#898 comments) called out
+// specifically:
+//   - 'email': an outreach send (pitch or follow-up). Carries `templateType`
+//     (which template rendered) + `targetWeekend` (which weekend the pitch was
+//     for), so the UI can show "pitched for Sept 26" vs "pitched for Oct 10"
+//     distinctly per the rescope's example.
+//   - 'outcome': a recorded outcome (interested / not-interested / booked /
+//     target-filled). Carries `outcome` (the recorded value), `targetWeekend`
+//     (which pitch this outcome answers), and `bookedDate` when the outcome is
+//     'booked' (the actual gig date, distinct from the weekend range pitched).
+// `outreachId` links a touch back to the outreach record that generated it,
+// when there is one (a manual 'visit'/'card' touch has none). `actor` is who
+// or what recorded the touch (human name or agent identity, #818 convention).
+//
+// Written by POST /venue/:id/touch (manual touches) and by the outcome-
+// recording endpoint (#898, outreach-controller.recordOutcome) for email-sent
+// and outcome touches.
+const touchSchema = new Schema({
+  date: { type: Date, required: true, default: Date.now },
+  type: {
+    type: String,
+    required: true,
+    enum: ['visit', 'form', 'card', 'call', 'email', 'gig', 'other', 'outcome'],
+  },
+  note: { type: String, required: false, trim: true },
+  templateType: { type: String, required: false, trim: true },
+  targetWeekend: { type: touchTargetWeekendSchema, required: false },
+  outcome: {
+    type: String,
+    required: false,
+    enum: ['interested', 'not-interested', 'booked', 'target-filled'],
+  },
+  bookedDate: { type: Date, required: false },
+  outreachId: { type: Schema.Types.ObjectId, ref: 'Outreach', required: false },
+  actor: { type: String, required: false, trim: true },
+}, { _id: false });
+
 // Booking-outreach venues. As of web-jam-back#819 Mongo is the single master
 // for venues (the Gig Booking Worksheet xlsx is retired). Unlike gigs — which
 // live in WebJamSocketCluster's DB and are read via a dedicated connection —
@@ -87,6 +140,8 @@ const venueSchema = new Schema({
   // by the outcome-recording endpoint (#898) — this issue only adds the fields.
   doNotContact: { type: Boolean, required: false, default: false },
   bookedDate: { type: Date, required: false },
+  // Per-venue contact timeline (#898) — see touchSchema above.
+  touches: { type: [touchSchema], required: false, default: [] },
   // The AI agent or human that last wrote this record (#818 `actor` field — one
   // shared agent identity authenticates, but each write records who acted).
   lastModifiedBy: { type: String, required: false },

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -531,12 +531,38 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect((venueModel as any).find).toHaveBeenCalledWith(expect.objectContaining({ doNotContact: { $ne: true } }));
     });
 
-    it('excludes venues already pitched for the target dates', async () => {
+    it('excludes venues already pitched for an overlapping target weekend (#898)', async () => {
       (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
-      c.model.find = vi.fn(() => Promise.resolve([{ venueId: 'a' }]));
+      const findMock = vi.fn(() => Promise.resolve([{ venueId: 'a' }]));
+      c.model.find = findMock;
       await c.getCandidates({ user: 'a', query: { targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
       expect(payload).toHaveLength(1);
       expect(payload[0]._id).toBe('b');
+      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({
+        status: { $in: ['sent', 'replied'] },
+        'targetWeekend.start': { $exists: true, $lte: new Date(VALID_WEEKEND.end) },
+        'targetWeekend.end': { $exists: true, $gte: new Date(VALID_WEEKEND.start) },
+      }));
+    });
+
+    // #898 — targetDates is display-only per #923; a bare targetDates with no
+    // targetWeekend must NOT filter anything (the old string-equality filter
+    // is gone).
+    it('does not filter when only the legacy targetDates is given (#898)', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
+      const findMock = vi.fn(() => Promise.resolve([{ venueId: 'a' }]));
+      c.model.find = findMock;
+      await c.getCandidates({ user: 'a', query: { targetDates: 'Aug 14-16' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toHaveLength(2);
+      expect(findMock).not.toHaveBeenCalled();
+    });
+
+    it('400s an invalid/incomplete targetWeekend (#898)', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+      await c.getCandidates({ user: 'a', query: { targetWeekend: { start: '2026-09-25' } } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('targetWeekend');
     });
 
     it('500s when the venue query throws', async () => {
@@ -1427,6 +1453,246 @@ describe('Outreach Controller (#844 batch model)', () => {
         await c.applySuggestion({ user: 'a', params: { id: String(rec._id) }, body: {} }, resStub);
         expect(status).toBe(500);
       });
+    });
+  });
+
+  describe('performSend logs a venue timeline touch (#898)', () => {
+    it('appends an email touch with templateType + targetWeekend on sendPitch', async () => {
+      asApprover();
+      c.model.create = vi.fn((doc: any) => Promise.resolve({ _id: 'o42', ...doc }));
+      const venueUpd = vi.fn(() => Promise.resolve({}));
+      (venueModel as any).findByIdAndUpdate = venueUpd;
+      const venue = validVenue();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(venue));
+      await c.sendPitch({
+        user: 'josh', body: { venueId: venue._id, targetDates: 'Sept 25-27', targetWeekend: VALID_WEEKEND },
+      }, resStub);
+      expect(status).toBe(201);
+      const touchCall = (venueUpd.mock.calls as any[]).find((call: any) => call[1].$push) as any;
+      expect(touchCall[0]).toBe(String(venue._id));
+      expect(touchCall[1].$push.touches).toMatchObject({
+        type: 'email', templateType: 'Originals', outreachId: 'o42',
+        targetWeekend: { start: new Date(VALID_WEEKEND.start), end: new Date(VALID_WEEKEND.end) },
+      });
+    });
+
+    it('does not fail the send when the venue touch write throws', async () => {
+      asApprover();
+      c.model.create = vi.fn((doc: any) => Promise.resolve({ _id: 'o43', ...doc }));
+      (venueModel as any).findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('venue down')));
+      await c.sendPitch({
+        user: 'josh', body: { venueId: oid(), targetDates: 'Sept 25-27', targetWeekend: VALID_WEEKEND },
+      }, resStub);
+      expect(status).toBe(201);
+    });
+  });
+
+  describe('recordOutcome (#898) — the single choke point (#923)', () => {
+    const outreachRec = (over = {}) => ({
+      _id: oid(), venueId: oid(), status: 'sent', targetWeekend: { start: new Date(VALID_WEEKEND.start), end: new Date(VALID_WEEKEND.end) }, ...over,
+    });
+
+    beforeEach(() => {
+      asAgent(['outreach:edit']);
+    });
+
+    it('403s without outreach:edit', async () => {
+      asAgent(['outreach:create']);
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('400s on an invalid id', async () => {
+      await c.recordOutcome({ user: 'a', params: { id: 'bad' }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('400s on an invalid/missing status', async () => {
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: {} }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('status must be one of');
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'sent' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('400s a booked outcome with no bookedDate', async () => {
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'booked' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('bookedDate');
+    });
+
+    it('400s a booked outcome with an invalid bookedDate', async () => {
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'booked', bookedDate: 'not-a-date' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('400s when the record is not found', async () => {
+      c.model.findById = vi.fn(() => Promise.resolve(null));
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('500s when the load throws', async () => {
+      c.model.findById = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.recordOutcome({ user: 'a', params: { id: oid() }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('500s when the outreach update throws', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('400s when the outreach update returns nothing', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve(null));
+      await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'interested' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('stamps status/outcomeAt/outcomeBy and nulls nextTouchDue on an interested outcome', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const upd = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      c.model.findByIdAndUpdate = upd;
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'interested', actor: 'josh' },
+      }, resStub);
+      expect(status).toBe(200);
+      expect(upd).toHaveBeenCalledWith(String(rec._id), expect.objectContaining({
+        status: 'interested', outcomeBy: 'josh', nextTouchDue: null,
+      }));
+      expect((upd.mock.calls[0] as any)[1].outcomeAt).toBeInstanceOf(Date);
+    });
+
+    it('writes a venue timeline touch for the outcome', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const venueUpd = vi.fn(() => Promise.resolve({}));
+      (venueModel as any).findByIdAndUpdate = venueUpd;
+      await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'interested', actor: 'josh' } }, resStub);
+      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({
+        $push: { touches: expect.objectContaining({ type: 'outcome', outcome: 'interested', actor: 'josh' }) },
+      }));
+    });
+
+    it('not-interested sets venue.doNotContact permanently', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const venueUpd = vi.fn(() => Promise.resolve({}));
+      (venueModel as any).findByIdAndUpdate = venueUpd;
+      await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'not-interested' } }, resStub);
+      expect(status).toBe(200);
+      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({ doNotContact: true }));
+    });
+
+    it('booked stamps bookedDate on the record + venue, and marks venue.bookingStatus booked', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const outreachUpd = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      c.model.findByIdAndUpdate = outreachUpd;
+      const venueUpd = vi.fn(() => Promise.resolve({}));
+      (venueModel as any).findByIdAndUpdate = venueUpd;
+      c.model.find = vi.fn(() => Promise.resolve([]));
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'booked', bookedDate: '2026-09-26', actor: 'josh' },
+      }, resStub);
+      expect(status).toBe(200);
+      expect((outreachUpd.mock.calls[0] as any)[1].bookedDate).toEqual(new Date('2026-09-26'));
+      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({
+        bookedDate: new Date('2026-09-26'), bookingStatus: 'booked',
+      }));
+    });
+
+    it('booked auto-flips every OTHER sent+overlapping record to target-filled (+ nextTouchDue null)', async () => {
+      const rec = outreachRec();
+      const other1 = { _id: oid(), venueId: oid(), status: 'sent' };
+      const other2 = { _id: oid(), venueId: oid(), status: 'sent' };
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const outreachUpd = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      c.model.findByIdAndUpdate = outreachUpd;
+      const findMock = vi.fn((q: any) => {
+        // dedup/candidates use different filters elsewhere; the auto-flip query
+        // excludes the booked record itself and matches status:'sent'.
+        if (q._id && q._id.$ne === String(rec._id)) return Promise.resolve([other1, other2]);
+        return Promise.resolve([]);
+      });
+      c.model.find = findMock;
+      const venueUpd = vi.fn(() => Promise.resolve({}));
+      (venueModel as any).findByIdAndUpdate = venueUpd;
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'booked', bookedDate: '2026-09-26' },
+      }, resStub);
+      expect(status).toBe(200);
+      expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ _id: { $ne: String(rec._id) }, status: 'sent' }));
+      const flipCalls = outreachUpd.mock.calls.filter((call: any) => call[1].status === 'target-filled');
+      expect(flipCalls).toHaveLength(2);
+      expect(flipCalls[0][1]).toMatchObject({ status: 'target-filled', nextTouchDue: null, outcomeBy: 'outcome-auto-flip' });
+      // Each flipped record's OWN venue also gets a target-filled touch.
+      expect(venueUpd).toHaveBeenCalledWith(String(other1.venueId), expect.objectContaining({
+        $push: { touches: expect.objectContaining({ type: 'outcome', outcome: 'target-filled' }) },
+      }));
+      expect(venueUpd).toHaveBeenCalledWith(String(other2.venueId), expect.objectContaining({
+        $push: { touches: expect.objectContaining({ type: 'outcome', outcome: 'target-filled' }) },
+      }));
+    });
+
+    it('booked with no targetWeekend on the record skips the auto-flip entirely', async () => {
+      const rec = outreachRec({ targetWeekend: undefined });
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      c.model.findByIdAndUpdate = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      const findMock = vi.fn(() => Promise.resolve([{ _id: oid(), venueId: oid(), status: 'sent' }]));
+      c.model.find = findMock;
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'booked', bookedDate: '2026-09-26' },
+      }, resStub);
+      expect(status).toBe(200);
+      expect(findMock).not.toHaveBeenCalled();
+    });
+
+    it('the primary outcome write still succeeds when the auto-flip lookup itself throws', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      c.model.findByIdAndUpdate = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      c.model.find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'booked', bookedDate: '2026-09-26' },
+      }, resStub);
+      expect(status).toBe(200);
+    });
+
+    it('a bad record in the auto-flip batch does not abort the rest', async () => {
+      const rec = outreachRec();
+      const other1 = { _id: oid(), venueId: oid(), status: 'sent' };
+      const other2 = { _id: oid(), venueId: oid(), status: 'sent' };
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      c.model.find = vi.fn(() => Promise.resolve([other1, other2]));
+      let calls = 0;
+      c.model.findByIdAndUpdate = vi.fn((id: string, u: any) => {
+        calls += 1;
+        if (calls === 2) return Promise.reject(new Error('db down')); // fails flipping other1
+        return Promise.resolve({ _id: id, ...u });
+      });
+      await c.recordOutcome({
+        user: 'a', params: { id: String(rec._id) }, body: { status: 'booked', bookedDate: '2026-09-26' },
+      }, resStub);
+      expect(status).toBe(200); // the primary write (call 1) succeeded before the flip ran
+    });
+
+    it('target-filled can be recorded directly (no auto-flip side effects)', async () => {
+      const rec = outreachRec();
+      c.model.findById = vi.fn(() => Promise.resolve(rec));
+      const outreachUpd = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
+      c.model.findByIdAndUpdate = outreachUpd;
+      const findMock = vi.fn(() => Promise.resolve([]));
+      c.model.find = findMock;
+      await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'target-filled' } }, resStub);
+      expect(status).toBe(200);
+      expect(findMock).not.toHaveBeenCalled(); // auto-flip only runs off a 'booked' recording
     });
   });
 });

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -328,6 +328,137 @@ describe('Venue Controller', () => {
     });
   });
 
+  describe('addTouch — POST /venue/:id/touch (#898)', () => {
+    it('403s without venue:edit', async () => {
+      asAgent(['venue:create']);
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'call' } }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('rejects an invalid venue id', async () => {
+      await c.addTouch({ user: 'a', params: { id: 'nope' }, body: { type: 'call' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('rejects a missing/invalid type', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: {} }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('type must be one of');
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'smoke-signal' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('rejects an invalid targetWeekend', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({
+        user: 'a', params: { id }, body: { type: 'email', targetWeekend: { start: '2026-09-25' } },
+      }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('targetWeekend');
+    });
+
+    it('rejects an outcome touch missing/invalid outcome', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'outcome' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('outcome must be one of');
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'outcome', outcome: 'meh' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('rejects a booked outcome touch with no/invalid bookedDate', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'outcome', outcome: 'booked' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('bookedDate');
+      await c.addTouch({
+        user: 'a', params: { id }, body: { type: 'outcome', outcome: 'booked', bookedDate: 'nope' },
+      }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('rejects outcome set on a non-outcome touch', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'call', outcome: 'booked' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('only valid on an outcome touch');
+    });
+
+    it('rejects an invalid outreachId', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'email', outreachId: 'bad' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('outreachId');
+    });
+
+    it('rejects an invalid explicit date', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'call', date: 'whenever' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('date');
+    });
+
+    it('appends a manual touch (visit/call/card/etc.)', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id, touches: [{ type: 'call' }] }));
+      c.model.findByIdAndUpdate = upd;
+      await c.addTouch({
+        user: 'agent', params: { id }, body: { type: 'call', note: 'left voicemail', actor: 'josh' },
+      }, resStub);
+      expect(status).toBe(201);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({
+        $push: { touches: expect.objectContaining({ type: 'call', note: 'left voicemail', actor: 'josh' }) },
+        lastModifiedBy: 'josh',
+      }));
+    });
+
+    it('appends an email-sent touch with templateType + targetWeekend', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.addTouch({
+        user: 'agent',
+        params: { id },
+        body: {
+          type: 'email', templateType: 'Originals', targetWeekend: { start: '2026-09-25', end: '2026-09-27' },
+        },
+      }, resStub);
+      expect(status).toBe(201);
+      const touch = (upd.mock.calls[0] as any)[1].$push.touches;
+      expect(touch).toMatchObject({
+        type: 'email', templateType: 'Originals', targetWeekend: { start: new Date('2026-09-25'), end: new Date('2026-09-27') },
+      });
+    });
+
+    it('appends an outcome touch (booked) with bookedDate', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.addTouch({
+        user: 'agent', params: { id }, body: { type: 'outcome', outcome: 'booked', bookedDate: '2026-09-26' },
+      }, resStub);
+      expect(status).toBe(201);
+      const touch = (upd.mock.calls[0] as any)[1].$push.touches;
+      expect(touch).toMatchObject({ type: 'outcome', outcome: 'booked', bookedDate: new Date('2026-09-26') });
+    });
+
+    it('400s when the id is not found', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve(null));
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'visit' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('500s when the write throws', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.addTouch({ user: 'a', params: { id }, body: { type: 'visit' } }, resStub);
+      expect(status).toBe(500);
+    });
+  });
+
   describe('outreachEligible tagging (#843)', () => {
     it('persists outreachEligible on create (passes through ...body)', async () => {
       c.model.findOne = vi.fn(() => Promise.resolve(null));


### PR DESCRIPTION
## Summary
- **Venue touch timeline (#898)**: new embedded `touches` array on the venue schema — `{ date, type, note, templateType, targetWeekend {start,end}, outcome, bookedDate, outreachId, actor }`. `type` enum is `visit | form | card | call | email | gig | other | outcome`. Design calls made:
  - Kept the original 7 offline-contact types unchanged and added an 8th, `outcome`, for recorded outcomes — rather than overloading `type` with the outcome values themselves.
  - `templateType` + `targetWeekend` live on `email` touches (satisfies "pitched for Sept 26 vs Oct 10"); `outcome` + `bookedDate` live on `outcome` touches.
  - `POST /venue/:id/touch` appends a validated entry. Reuses the existing `venue:edit` capability — no new capability registered.
- **Outcome-recording endpoint (#898/#923)**: `POST /outreach/:id/outcome` — the single choke point. Sets `status` (`interested | not-interested | booked | target-filled`), stamps `outcomeAt`/`outcomeBy`, nulls `nextTouchDue`, writes the matching venue timeline touch, and applies side effects:
  - `not-interested` sets `venue.doNotContact = true` (permanent).
  - `booked` sets `bookedDate` on both the outreach record and the venue, **and** sets `venue.bookingStatus = 'booked'` (judgment call — the venue's coarse standing should track the recorded gig date), **and** auto-flips every OTHER `sent` record whose `targetWeekend` overlaps to `target-filled` (plus `nextTouchDue: null`, `outcomeBy: 'outcome-auto-flip'`), each also logging a `target-filled` touch on ITS OWN venue's timeline.
  - Reuses `outreach:edit` — no new capability.
  - Also wired an `email` touch (template + targetWeekend) into `performSend`, so every pitch/follow-up send is logged on the venue timeline automatically, not just outcomes.
- **GET /outreach/candidates target-weekend filter (deferred item from PR #933)**: replaced the old `targetDates` string-equality filter with a `targetWeekend` date-range overlap filter, sharing the same `targetWeekendOverlapClause` helper as the dedup guard and the auto-flip query (extracted to keep all three in lockstep). A bare `targetDates` with no `targetWeekend` no longer filters anything (matches #923: targetDates is display-only). An invalid/incomplete `targetWeekend` 400s.
- package.json bumped 2.2.7 to 2.3.0 (new feature, no breaking changes).

Closes #898

## How to test locally
Automated:
```sh
npm test
```
Expect: eslint clean, jscpd summary printed (pre-existing repo-wide duplication, unaffected by this PR), 559 vitest tests green, coverage gate (90/90/80/80) passing.

Manual/runnable curl examples (auth: Bearer token for a user holding `venue:edit` / `outreach:edit`; replace ID/TOKEN placeholders):

1) Append a manual venue touch:
```sh
curl -X POST https://webjamsalem.herokuapp.com/venue/VENUE_ID/touch \
  -H "Authorization: Bearer TOKEN" -H "Content-Type: application/json" \
  -d '{"type":"call","note":"left voicemail","actor":"josh"}'
```
Expect: `201` with the updated venue doc, `touches` array containing the new entry.

2) Record a booked outcome (also stamps venue.bookedDate/bookingStatus + auto-flips other same-weekend pitches):
```sh
curl -X POST https://webjamsalem.herokuapp.com/outreach/OUTREACH_ID/outcome \
  -H "Authorization: Bearer TOKEN" -H "Content-Type: application/json" \
  -d '{"status":"booked","bookedDate":"2026-09-26","actor":"josh"}'
```
Expect: `200` with the outreach record showing `status:"booked"`, `bookedDate`, `outcomeAt`, `outcomeBy:"josh"`, `nextTouchDue:null`. Any OTHER `sent` record for an overlapping targetWeekend flips to `status:"target-filled"` in the same call.

3) Record a not-interested outcome (permanent DNC):
```sh
curl -X POST https://webjamsalem.herokuapp.com/outreach/OUTREACH_ID/outcome \
  -H "Authorization: Bearer TOKEN" -H "Content-Type: application/json" \
  -d '{"status":"not-interested","actor":"josh"}'
```
Expect: `200`; the venue record now has `doNotContact:true` and never resurfaces in `/outreach/candidates`.

4) Candidates filtered by target weekend:
```sh
curl "https://webjamsalem.herokuapp.com/outreach/candidates?targetWeekend[start]=2026-10-09&targetWeekend[end]=2026-10-11" \
  -H "Authorization: Bearer TOKEN"
```
Expect: `200` with an array of vetted, non-archived, non-DNC venues that do NOT already have an active (sent/replied) outreach overlapping Oct 9-11. An incomplete targetWeekend (e.g. only `start`) returns `400`.

## Test evidence
$ npx eslint ./src
(no output, exit 0)

$ npm test
...
Test Files  39 passed (39)
     Tests  559 passed (559)
 % Coverage report from v8
=============================== Coverage summary ===============================
Statements   : 92.24% ( 1999/2167 )
Branches     : 85.85% ( 1238/1442 )
Functions    : 86.51% ( 295/341 )
Lines        : 92.95% ( 1649/1774 )
================================================================================
(exit 0 -- jscpd's pre-existing 26 clones/5.97% duplicated tokens are unchanged by this PR's own code style, matching the sibling venue/outreach/template controllers)

$ npx tsc --noEmit -p tsconfig.prod.json && npx tsc --noEmit
(no output, exit 0, both pass)

🤖 Work by Claude Code — Sonnet 5