### PR TITLE
Setlist: make the hybrid songId reference resolve (populate + no data duplication)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/setlist/setlist-facade.ts
+++ b/src/model/setlist/setlist-facade.ts
@@ -1,8 +1,26 @@
+import type { QueryFilter } from 'mongoose';
 import Model from '../../lib/facade.js';
 import setlistSchema from './setlist-schema.js';
+import { resolveSetlistDoc } from './setlist-resolve.js';
 
+type AnyDoc = Record<string, unknown>;
+
+// Overrides the base Facade's find/findById so the hybrid songId reference
+// actually resolves: populate('items.songId') pulls in the referenced Song,
+// then resolveSetlistDoc collapses each item to the uniform effective shape
+// (title/artist/playLink from the Song when songId is set, else the item's
+// own inline fields) — web-jam-back#946. lean() + populate() together are
+// fine; the prior bug was the missing populate, not lean itself.
 class SetlistModel extends Model {
+  find(query: QueryFilter<AnyDoc>): Promise<AnyDoc[]> {
+    return this.Schema.find(query).populate('items.songId').lean().exec()
+      .then((docs) => (docs as AnyDoc[]).map((doc) => resolveSetlistDoc(doc))) as unknown as Promise<AnyDoc[]>;
+  }
 
+  findById(id: string): Promise<AnyDoc | null> {
+    return this.Schema.findById(id).populate('items.songId').lean().exec()
+      .then((doc) => (doc ? resolveSetlistDoc(doc as AnyDoc) : null)) as unknown as Promise<AnyDoc | null>;
+  }
 }
 
 export default new SetlistModel(setlistSchema);

--- a/src/model/setlist/setlist-resolve.ts
+++ b/src/model/setlist/setlist-resolve.ts
@@ -1,0 +1,86 @@
+// Hybrid-setlist resolution helpers (web-jam-back#937 follow-up, #946). A setlist
+// item either REFERENCES a catalogued Song via songId (source of truth: no
+// duplicated data stored) or carries its own inline title/artist/playLink for an
+// uncatalogued cover. These pure functions turn a populated, lean setlist
+// document into the uniform response shape consumers expect — no stored
+// duplication, resolved at read time.
+
+// Song.url is stored in the WEBSITE-WIDGET form (built for embedding/downloading
+// on the site). A setlist wants a click-to-play PLAYER link instead, so we
+// convert at resolve time rather than storing a second copy of the link.
+export function toSetlistPlayerLink(url?: string): string | undefined {
+  if (!url) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.hostname === 'dl.dropboxusercontent.com') {
+    parsed.hostname = 'www.dropbox.com';
+    if (parsed.searchParams.has('dl')) parsed.searchParams.set('dl', '0');
+    return parsed.toString();
+  }
+  if (parsed.hostname === 'www.youtube.com' && parsed.pathname.startsWith('/embed/')) {
+    const videoId = parsed.pathname.slice('/embed/'.length);
+    return `https://www.youtube.com/watch?v=${videoId}`;
+  }
+  // Spotify or anything else — leave unchanged.
+  return url;
+}
+
+interface SongLean {
+  _id?: unknown;
+  title?: string;
+  artist?: string;
+  url?: string;
+}
+
+export interface SetlistItemLean {
+  _id?: unknown;
+  order?: number;
+  songId?: SongLean | string | null;
+  title?: string;
+  artist?: string;
+  playLink?: string;
+  notes?: string;
+  [key: string]: unknown;
+}
+
+export interface ResolvedSetlistItem {
+  _id?: unknown;
+  order?: number;
+  songId?: unknown;
+  notes?: string;
+  title?: string;
+  artist?: string;
+  playLink?: string;
+}
+
+// A populate('items.songId') result is a Song object when the reference
+// resolved; null when the ref doc no longer exists; absent entirely for a
+// plain inline cover item.
+function populatedSong(item: SetlistItemLean): SongLean | null {
+  const { songId } = item;
+  return songId && typeof songId === 'object' ? (songId as SongLean) : null;
+}
+
+export function resolveSetlistItem(item: SetlistItemLean): ResolvedSetlistItem {
+  const song = populatedSong(item);
+  return {
+    _id: item._id,
+    order: item.order,
+    songId: song ? song._id : (item.songId ?? undefined),
+    notes: item.notes,
+    title: song ? song.title : item.title,
+    artist: song ? song.artist : item.artist,
+    playLink: song ? toSetlistPlayerLink(song.url) : item.playLink,
+  };
+}
+
+export function resolveSetlistDoc<T extends { items?: SetlistItemLean[] }>(doc: T): T {
+  if (!doc || !Array.isArray(doc.items)) return doc;
+  return { ...doc, items: doc.items.map(resolveSetlistItem) };
+}
+
+export default { toSetlistPlayerLink, resolveSetlistItem, resolveSetlistDoc };

--- a/src/model/setlist/setlist-schema.ts
+++ b/src/model/setlist/setlist-schema.ts
@@ -2,39 +2,32 @@ import mongoose from 'mongoose';
 
 const { Schema } = mongoose;
 
-// An ordered item in a setlist. Either references an existing Song (reusing its
-// link/metadata) or carries its own inline title + play link for covers that
-// aren't catalogued — web-jam-back#937.
+// An ordered item in a setlist. Either REFERENCES an existing Song via songId
+// (source of truth — title/artist/link are resolved from the Song at read
+// time, never duplicated here) or carries its own inline title/artist/playLink
+// for a cover that isn't catalogued — web-jam-back#937, hybrid fix #946.
 const setlistItemSchema = new Schema({
   order: { type: Number, required: true },
   songId: { type: Schema.Types.ObjectId, ref: 'Song', required: false },
-  title: { type: String, required: true },
+  // Required only for uncatalogued items — when songId is set, title/artist/
+  // playLink are derived from the referenced Song (see setlist-resolve.ts) and
+  // must not be relied on or required here.
+  title: {
+    type: String,
+    required: [
+      function requiredWhenNoSongId(this: { songId?: unknown }): boolean { return !this.songId; },
+      'title is required when songId is not set',
+    ],
+  },
+  artist: { type: String, required: false },
   playLink: { type: String, required: false },
   notes: { type: String, required: false },
-}, { toJSON: { virtuals: true }, toObject: { virtuals: true } });
-
-// Effective title is always the denormalized copy on the item (seeded from the
-// referenced Song at create time) so listing never needs a join.
-setlistItemSchema.virtual('effectiveTitle').get(function effectiveTitle(this: { title: string }): string {
-  return this.title;
-});
-
-// Effective play link = the item's own playLink when set, else the referenced
-// Song's url (resolvable only when songId is populated). Neither present →
-// undefined, which is a valid item (e.g. a song still being learned).
-setlistItemSchema.virtual('effectivePlayLink').get(function effectivePlayLink(this: {
-  playLink?: string; songId?: unknown;
-}): string | undefined {
-  if (this.playLink) return this.playLink;
-  const song = this.songId as { url?: string } | null | undefined;
-  if (song && typeof song === 'object' && typeof song.url === 'string') return song.url;
-  return undefined;
 });
 
 const setlistSchema = new Schema({
   name: { type: String, required: true },
   description: { type: String, required: false },
   items: { type: [setlistItemSchema], default: [] },
-}, { toJSON: { virtuals: true }, toObject: { virtuals: true } });
+});
 
 export default mongoose.models.Setlist || mongoose.model('Setlist', setlistSchema);

--- a/test/unit/setlist-resolve.spec.ts
+++ b/test/unit/setlist-resolve.spec.ts
@@ -1,0 +1,115 @@
+import {
+  toSetlistPlayerLink, resolveSetlistItem, resolveSetlistDoc,
+} from '#src/model/setlist/setlist-resolve.js';
+
+describe('setlist-resolve', () => {
+  describe('toSetlistPlayerLink', () => {
+    it('returns undefined for an empty/undefined url', () => {
+      expect(toSetlistPlayerLink(undefined)).toBeUndefined();
+      expect(toSetlistPlayerLink('')).toBeUndefined();
+    });
+
+    it('converts a Dropbox widget link (dl=1) to the player form (dl=0), preserving rlkey', () => {
+      const widget = 'https://dl.dropboxusercontent.com/s/abc123/song.mp3?rlkey=xyz789&dl=1';
+      const player = toSetlistPlayerLink(widget);
+      expect(player).toBe('https://www.dropbox.com/s/abc123/song.mp3?rlkey=xyz789&dl=0');
+    });
+
+    it('converts a Dropbox widget link with no dl param, leaving other params alone', () => {
+      const widget = 'https://dl.dropboxusercontent.com/s/abc123/song.mp3';
+      const player = toSetlistPlayerLink(widget);
+      expect(player).toBe('https://www.dropbox.com/s/abc123/song.mp3');
+    });
+
+    it('converts a YouTube embed link to the watch form', () => {
+      const embed = 'https://www.youtube.com/embed/ach2ubW21h4?enablejsapi=1&origin=https://web-jam.com';
+      expect(toSetlistPlayerLink(embed)).toBe('https://www.youtube.com/watch?v=ach2ubW21h4');
+    });
+
+    it('leaves a Spotify link unchanged', () => {
+      const spotify = 'https://open.spotify.com/track/abc123';
+      expect(toSetlistPlayerLink(spotify)).toBe(spotify);
+    });
+
+    it('leaves an already-normal YouTube watch link unchanged', () => {
+      const watch = 'https://www.youtube.com/watch?v=abc123';
+      expect(toSetlistPlayerLink(watch)).toBe(watch);
+    });
+
+    it('returns the original string unchanged when it is not a parseable URL', () => {
+      expect(toSetlistPlayerLink('not a url')).toBe('not a url');
+    });
+  });
+
+  describe('resolveSetlistItem', () => {
+    it('resolves title/artist/playLink from a populated Song, converting the url', () => {
+      const item = resolveSetlistItem({
+        _id: 'item1',
+        order: 1,
+        notes: 'capo 2',
+        songId: {
+          _id: 'song1',
+          title: 'Wagon Wheel',
+          artist: 'Old Crow Medicine Show',
+          url: 'https://www.youtube.com/embed/xyz?enablejsapi=1',
+        },
+      });
+      expect(item).toEqual({
+        _id: 'item1',
+        order: 1,
+        songId: 'song1',
+        notes: 'capo 2',
+        title: 'Wagon Wheel',
+        artist: 'Old Crow Medicine Show',
+        playLink: 'https://www.youtube.com/watch?v=xyz',
+      });
+    });
+
+    it('uses the inline title/artist/playLink for an uncatalogued cover (no songId)', () => {
+      const item = resolveSetlistItem({
+        order: 2,
+        title: 'Folsom Prison Blues',
+        artist: 'Johnny Cash',
+        playLink: 'https://youtu.be/abc',
+      });
+      expect(item.songId).toBeUndefined();
+      expect(item.title).toBe('Folsom Prison Blues');
+      expect(item.artist).toBe('Johnny Cash');
+      expect(item.playLink).toBe('https://youtu.be/abc');
+    });
+
+    it('falls back to the raw songId when the reference did not populate (dangling ref)', () => {
+      const item = resolveSetlistItem({ order: 3, songId: null });
+      expect(item.songId).toBeUndefined();
+      expect(item.title).toBeUndefined();
+    });
+  });
+
+  describe('resolveSetlistDoc', () => {
+    it('resolves every item in a mixed setlist (referenced + inline)', () => {
+      const doc = resolveSetlistDoc({
+        name: 'Gig Set',
+        items: [
+          {
+            order: 1,
+            songId: { _id: 's1', title: 'Ref Song', artist: 'Ref Artist', url: 'https://open.spotify.com/track/x' },
+          },
+          { order: 2, title: 'Inline Cover', artist: 'Cover Artist', playLink: 'https://youtu.be/inline' },
+        ],
+      });
+      expect(doc.items).toHaveLength(2);
+      expect(doc.items[0].title).toBe('Ref Song');
+      expect(doc.items[0].playLink).toBe('https://open.spotify.com/track/x');
+      expect(doc.items[1].title).toBe('Inline Cover');
+    });
+
+    it('passes through a doc with no items array unchanged', () => {
+      const doc = { name: 'Empty' } as { name: string; items?: unknown[] };
+      expect(resolveSetlistDoc(doc)).toBe(doc);
+    });
+
+    it('passes through a null/undefined doc unchanged', () => {
+      expect(resolveSetlistDoc(null as unknown as { items?: unknown[] })).toBeNull();
+    });
+  });
+});

--- a/test/unit/setlist-resolve.spec.ts
+++ b/test/unit/setlist-resolve.spec.ts
@@ -1,5 +1,5 @@
 import {
-  toSetlistPlayerLink, resolveSetlistItem, resolveSetlistDoc,
+  toSetlistPlayerLink, resolveSetlistItem, resolveSetlistDoc, type SetlistItemLean,
 } from '#src/model/setlist/setlist-resolve.js';
 
 describe('setlist-resolve', () => {
@@ -104,12 +104,12 @@ describe('setlist-resolve', () => {
     });
 
     it('passes through a doc with no items array unchanged', () => {
-      const doc = { name: 'Empty' } as { name: string; items?: unknown[] };
+      const doc = { name: 'Empty' } as { name: string; items?: SetlistItemLean[] };
       expect(resolveSetlistDoc(doc)).toBe(doc);
     });
 
     it('passes through a null/undefined doc unchanged', () => {
-      expect(resolveSetlistDoc(null as unknown as { items?: unknown[] })).toBeNull();
+      expect(resolveSetlistDoc(null as unknown as { items?: SetlistItemLean[] })).toBeNull();
     });
   });
 });

--- a/test/unit/setlist-router.spec.ts
+++ b/test/unit/setlist-router.spec.ts
@@ -1,6 +1,5 @@
 import app from '#src/index.js';
 import SetlistModel from '#src/model/setlist/setlist-facade.js';
-import SetlistSchema from '#src/model/setlist/setlist-schema.js';
 import SongModel from '#src/model/song/song-facade.js';
 import userModel from '#src/model/user/user-facade.js';
 import authUtils from '#src/auth/authUtils.js';
@@ -49,6 +48,11 @@ describe('The Setlist API', () => {
     expect(r.status).toBe(400);
   });
 
+  it('returns 400 for a well-formed id that does not exist', async () => {
+    r = await request(app).get('/setlist/6a53da5b8c4f9aa55d290d99').set({ origin: allowedUrl });
+    expect(r.status).toBe(400);
+  });
+
   it('creates a setlist with the admin JWT', async () => {
     r = await request(app)
       .post('/setlist')
@@ -77,13 +81,30 @@ describe('The Setlist API', () => {
     expect(r.status).toBe(500);
   });
 
-  it('rejects a create whose item is missing the required title (validation)', async () => {
+  it('rejects a create whose item is missing both songId and title (validation)', async () => {
     r = await request(app)
       .post('/setlist')
       .set({ origin: allowedUrl })
       .set('Authorization', auth())
       .send({ name: 'Bad Item Set', items: [{ order: 1 }] });
     expect(r.status).toBe(500);
+  });
+
+  it('accepts a create whose item has ONLY a songId — no inline title required', async () => {
+    await SongModel.deleteMany({ title: 'Songid Only Validation Song' });
+    const song = await SongModel.create({
+      title: 'Songid Only Validation Song',
+      artist: 'Some Artist',
+      category: 'pub',
+      url: `https://youtu.be/songid-only-${Date.now()}`,
+    }) as unknown as { _id: string };
+    r = await request(app)
+      .post('/setlist')
+      .set({ origin: allowedUrl })
+      .set('Authorization', auth())
+      .send({ name: 'SongId Only Set', items: [{ order: 1, songId: song._id }] });
+    expect(r.status).toBe(201);
+    await SongModel.deleteMany({ title: 'Songid Only Validation Song' });
   });
 
   it('updates a setlist, replacing its items', async () => {
@@ -131,37 +152,61 @@ describe('The Setlist API', () => {
     expect(r.status).toBe(200);
   });
 
-  describe('title/link resolution rules', () => {
-    it('effectiveTitle is the item title', () => {
-      const doc = new SetlistSchema({ name: 'S', items: [{ order: 1, title: 'My Title' }] });
-      expect(doc.items[0].effectiveTitle).toBe('My Title');
-    });
+  describe('hybrid songId resolution (web-jam-back#946)', () => {
+    let song: { _id: string; url: string };
 
-    it('effectivePlayLink uses the item playLink when present', () => {
-      const doc = new SetlistSchema({ name: 'S', items: [{ order: 1, title: 'T', playLink: 'https://item.link' }] });
-      expect(doc.items[0].effectivePlayLink).toBe('https://item.link');
-    });
-
-    it('effectivePlayLink is undefined when neither playLink nor song is present', () => {
-      const doc = new SetlistSchema({ name: 'S', items: [{ order: 1, title: 'T' }] });
-      expect(doc.items[0].effectivePlayLink).toBeUndefined();
-    });
-
-    it('effectivePlayLink falls back to the referenced Song url when populated and no playLink', async () => {
+    beforeAll(async () => {
       await SongModel.deleteMany({ title: 'Setlist Ref Song' });
-      const song = await SongModel.create({
+      song = await SongModel.create({
         title: 'Setlist Ref Song',
-        artist: 'The Band',
+        artist: 'The Reference Band',
         category: 'pub',
-        url: `https://youtu.be/song-${Date.now()}`,
+        url: 'https://dl.dropboxusercontent.com/s/abc123/song.mp3?rlkey=xyz789&dl=1',
       }) as unknown as { _id: string; url: string };
+    });
+
+    afterAll(async () => {
+      await SongModel.deleteMany({ title: 'Setlist Ref Song' });
+    });
+
+    it('resolves a referenced item to the Song title/artist and a converted (player-form) playLink on GET /setlist/:id', async () => {
       const created = await SetlistModel.create({
         name: 'Ref Set',
-        items: [{ order: 1, songId: song._id, title: 'Setlist Ref Song' }],
+        items: [{ order: 1, songId: song._id, notes: 'watch the bridge' }],
       }) as unknown as { _id: string };
-      const populated = await SetlistSchema.findById(created._id).populate('items.songId');
-      expect(populated.items[0].effectivePlayLink).toBe(song.url);
-      await SongModel.deleteMany({ title: 'Setlist Ref Song' });
+      r = await request(app).get(`/setlist/${created._id}`).set({ origin: allowedUrl });
+      expect(r.status).toBe(200);
+      const [item] = r.body.items;
+      expect(item.title).toBe('Setlist Ref Song');
+      expect(item.artist).toBe('The Reference Band');
+      expect(item.playLink).toBe('https://www.dropbox.com/s/abc123/song.mp3?rlkey=xyz789&dl=0');
+      expect(item.notes).toBe('watch the bridge');
+      expect(item.songId).toBe(song._id.toString());
+    });
+
+    it('resolves a mixed setlist (referenced + inline) on GET /setlist and GET /setlist/:id', async () => {
+      const created = await SetlistModel.create({
+        name: 'Mixed Set',
+        items: [
+          { order: 1, songId: song._id },
+          {
+            order: 2, title: 'Uncatalogued Cover', artist: 'Cover Band', playLink: 'https://youtu.be/cover',
+          },
+        ],
+      }) as unknown as { _id: string };
+
+      const byId = await request(app).get(`/setlist/${created._id}`).set({ origin: allowedUrl });
+      expect(byId.status).toBe(200);
+      expect(byId.body.items[0].title).toBe('Setlist Ref Song');
+      expect(byId.body.items[0].artist).toBe('The Reference Band');
+      expect(byId.body.items[1].title).toBe('Uncatalogued Cover');
+      expect(byId.body.items[1].artist).toBe('Cover Band');
+      expect(byId.body.items[1].playLink).toBe('https://youtu.be/cover');
+
+      const list = await request(app).get('/setlist').set({ origin: allowedUrl });
+      expect(list.status).toBe(200);
+      const found = (list.body as Array<{ _id: string }>).find((s) => s._id === created._id.toString());
+      expect(found).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix the Setlist hybrid model (#937) so a `songId` reference actually resolves: `GET /setlist` and `GET /setlist/:id` now `populate('items.songId')` instead of relying on schema virtuals that never ran under `.lean()`.
- Added `src/model/setlist/setlist-resolve.ts`: pure helpers that collapse each item to a uniform effective shape (`order`, `songId`, `notes`, `title`, `artist`, `playLink`) — resolved from the referenced Song when `songId` is set, else from the item's own inline fields. Nothing is duplicated in storage.
- Song `url` is stored in the website-widget form; `toSetlistPlayerLink()` converts it at resolve time — Dropbox `dl.dropboxusercontent.com` → `www.dropbox.com` + `dl=0` (preserving `rlkey`), YouTube `/embed/<id>` → `/watch?v=<id>`, Spotify/other left unchanged.
- Item schema: added an inline `artist` field; `title` is now required only when `songId` is absent, so a create/update can supply EITHER `songId` OR inline `title`/`playLink`/`artist`.
- Added unit tests for the resolve helpers (URL conversion, referenced/inline/mixed items, dangling ref) and expanded the setlist router integration spec (referenced item resolves Song fields + converted playLink, mixed setlist, songId-only create validation).
- One semver bump: 2.3.2 → 2.3.3.

Closes #946

## How to test locally
Run the full suite (lint + jscpd + typecheck + vitest, coverage-gated at 90/90/80/80):
```sh
npm test
```
Expect all files/tests green and coverage above the gate.

Then exercise the fix directly against the running app (build + start, seed a Song + a Setlist item that references it, hit the PUBLIC read route):
```sh
curl -s http://localhost:7000/setlist/SETLIST_ID
```
Expect the referenced item's title/artist to come from the Song and its playLink to be the Dropbox URL converted to the player form (www.dropbox.com, dl=0, rlkey preserved), while a sibling inline item keeps its own inline fields.

## Test evidence
```
 Test Files  41 passed (41)
      Tests  594 passed (594)
   Duration  45.38s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
All files          |   92.39 |    86.14 |   87.07 |   93.09 |
 src/model/setlist |     100 |    96.87 |     100 |     100 |
-------------------|---------|----------|---------|---------|
Statements   : 92.39% ( 2042/2210 )
Branches     : 86.14% ( 1275/1480 )
Functions    : 87.07% ( 310/356 )
Lines        : 93.09% ( 1686/1811 )

--- manual curl against a running instance (seeded via facades, then cleaned up) ---
$ curl -s http://localhost:7000/setlist/6a53dc3e6e52851d32169882
{
    "_id": "6a53dc3e6e52851d32169882",
    "name": "PR-DEMO Setlist",
    "items": [
        {
            "_id": "6a53dc3e6e52851d32169883",
            "order": 1,
            "songId": "6a53dc3e6e52851d32169881",
            "notes": "watch the bridge",
            "title": "PR-DEMO Setlist Ref Song",
            "artist": "PR-DEMO Artist",
            "playLink": "https://www.dropbox.com/s/abc123/song.mp3?rlkey=xyz789&dl=0"
        },
        {
            "_id": "6a53dc3e6e52851d32169884",
            "order": 2,
            "title": "PR-DEMO Uncatalogued Cover",
            "artist": "Cover Band",
            "playLink": "https://youtu.be/cover-demo"
        }
    ],
    "__v": 0
}
```

🤖 Work by Claude Code — Sonnet 5