### PR TITLE
Update tests to expect slug-derived tim-admin userType

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Powers timshermanmusic.com login and booking integrations. All four must be set 
 
 | Env var | Purpose | Example |
 |---------|---------|---------|
-| `ArtistAdmins` | JSON map of lower-cased login email → artist slug. A matching email is provisioned at login as an artist-scoped admin (`userType: artist-admin`). Unmatched emails are untouched. | `{"tim@example.com":"tim"}` |
+| `ArtistAdmins` | JSON map of lower-cased login email → artist slug. A matching email is provisioned at login as an artist-scoped admin with a slug-derived `userType` (`<slug>-admin`, e.g. `tim-admin` — same convention as the existing `clc-admin`). Unmatched emails are untouched. | `{"tim@example.com":"tim"}` |
 | `InquiryRecipients` | JSON map of artist slug → booking email. Routes contact/booking inquiries for that artist; unmapped artists fall back to the default JaMmusic recipients. | `{"tim":"booking@example.com"}` |
 | `TimGoogleClientId` | Google OAuth client ID for timshermanmusic.com login (its own GCP project). | (obtain from GCP Console) |
 | `TimGoogleClientSecret` | Google OAuth client secret for timshermanmusic.com login. **Secret — server-side only.** | (obtain from GCP Console) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/artist.ts
+++ b/src/lib/artist.ts
@@ -33,16 +33,18 @@ export function artistListFilter(query: Record<string, unknown>): Record<string,
 
 // Login-time role grant driven by the `ArtistAdmins` env var — a JSON map of
 // lower-cased email -> artist slug, e.g. {"tim@example.com":"tim"}. A matched
-// email is provisioned as an artist-scoped admin (userType `artist-admin`,
-// `artist` = the slug). Josh sets Tim's real email here; unmatched emails (incl.
-// Josh's own Developer account) get no grant and are left untouched.
+// email is provisioned as an artist-scoped admin with a slug-derived userType
+// (`<slug>-admin`, e.g. `tim-admin`), `artist` = the slug. This keeps per-tenant
+// role names (like the pre-existing `clc-admin`) without hand-maintaining one
+// per artist. Josh sets Tim's real email here; unmatched emails (incl. Josh's
+// own Developer account) get no grant and are left untouched.
 export function artistGrantForEmail(email: string): { userType: string; artist: string } | null {
   let map: Record<string, string>;
   try { map = JSON.parse(process.env.ArtistAdmins || '{}') as Record<string, string>; } catch { return null; }
   const key = (email || '').toLowerCase();
   // eslint-disable-next-line security/detect-object-injection
   const slug = map[key];
-  return typeof slug === 'string' && slug ? { userType: 'artist-admin', artist: slug } : null;
+  return typeof slug === 'string' && slug ? { userType: `${slug}-admin`, artist: slug } : null;
 }
 
 export default {

--- a/src/model/user/user-controller.ts
+++ b/src/model/user/user-controller.ts
@@ -44,7 +44,7 @@ class UserController extends Controller {
   }
 
   async handleNewUser(name:string, email:string, req: Request, res: Response) {
-    // Persist the real schema fields (name/email) plus any artist-admin grant.
+    // Persist the real schema fields (name/email) plus any artist-scoped admin grant.
     const user = { name, email, verifiedEmail: true, ...grantFor(email) };
     const newUser = await this.model.create(user);
     newUser.password = '';
@@ -58,7 +58,7 @@ class UserController extends Controller {
       const name = names[0].displayName;
       const email = emailAddresses[0].value;
       // Step 3. Create a new user account or return an existing one. A returning
-      // artist-admin has their grant (userType/artist) refreshed from config.
+      // artist-scoped admin has their grant (userType/artist) refreshed from config.
       const update: UserHandler = {
         arg1: '', arg2: name, verified: true, ...grantFor(email),
       };

--- a/test/unit/lib/artist.spec.ts
+++ b/test/unit/lib/artist.spec.ts
@@ -32,9 +32,9 @@ describe('lib/artist', () => {
     expect(artistListFilter({ artist: 'jammusic' }).$or).toBeDefined();
   });
 
-  it('artistGrantForEmail returns a grant for a configured email (case-insensitive)', () => {
+  it('artistGrantForEmail returns a slug-derived grant for a configured email (case-insensitive)', () => {
     process.env.ArtistAdmins = JSON.stringify({ 'tim@example.com': 'tim' });
-    expect(artistGrantForEmail('Tim@Example.com')).toEqual({ userType: 'artist-admin', artist: 'tim' });
+    expect(artistGrantForEmail('Tim@Example.com')).toEqual({ userType: 'tim-admin', artist: 'tim' });
   });
 
   it('artistGrantForEmail returns null for an unlisted email', () => {

--- a/test/unit/user/user-controller.spec.ts
+++ b/test/unit/user/user-controller.spec.ts
@@ -38,7 +38,7 @@ describe('User Controller', () => {
     await controller.google({ body: {} } as any, resStub);
     expect(status).toBe(201);
   });
-  it('stamps the artist-admin grant for a configured email on login (#885)', async () => {
+  it('stamps the slug-derived artist-admin grant for a configured email on login (#885)', async () => {
     const prev = process.env.ArtistAdmins;
     process.env.ArtistAdmins = JSON.stringify({ 'tim@sherman.com': 'tim' });
     const update = vi.fn(() => Promise.resolve({ email: 'tim@sherman.com' }));
@@ -46,7 +46,7 @@ describe('User Controller', () => {
     const authMock:any = vi.fn(() => Promise.resolve({ names: [{ displayName: 'Tim' }], emailAddresses: [{ value: 'tim@sherman.com' }] }));
     authGoogle.authenticate = authMock;
     await controller.google({ body: {} } as any, resStub);
-    expect((update.mock.calls[0] as unknown[])[1]).toMatchObject({ userType: 'artist-admin', artist: 'tim' });
+    expect((update.mock.calls[0] as unknown[])[1]).toMatchObject({ userType: 'tim-admin', artist: 'tim' });
     process.env.ArtistAdmins = prev;
     testObj = {};
   });


### PR DESCRIPTION
## Summary
- Part of the TimShermanMusic#34 tim-admin rename: web-jam-back's artist-scoped admin role is now slug-derived instead of a hardcoded generic literal.
- `artistGrantForEmail()` in `src/lib/artist.ts` now returns `userType: `${slug}-admin`` instead of the literal `'artist-admin'` (so artist `tim` -> `tim-admin`), matching the existing `clc-admin`/`JaM-admin` per-tenant naming convention. Future artists auto-get `<slug>-admin` with no code change.
- Updated every real reference to the old literal: doc comments in `src/lib/artist.ts` and `src/model/user/user-controller.ts`, the `README.md` artist-scoping env var table, and the two tests that asserted the literal (`test/unit/lib/artist.spec.ts`, `test/unit/user/user-controller.spec.ts`) now expect `tim-admin`.
- Verified `ArtistController` (`src/lib/artist-controller.ts`) already scopes writes purely via `req.userArtist` / the record's `artist` field (`scopedArtist()`/`guardScopedArtist()`), never a literal `userType === 'artist-admin'` string — so the guard needed NO change and continues to work unmodified with the new slug-derived userType.

## How to test locally
Run:
```sh
npm test
```
Expect: eslint clean, jscpd runs (pre-existing clone warnings unrelated to this change), and all unit tests pass (594 tests / 41 files) with coverage above the repo's gate.

Also ran:
```sh
npm run typecheck
```
Expect: no type errors.

## Test evidence
```
> web-jam-back@2.3.4 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
(no output — clean)

> web-jam-back@2.3.4 test
> eslint ./src && npm run jscpd && rimraf coverage && npm run test:unit

 Test Files  41 passed (41)
      Tests  594 passed (594)
   Duration  46.88s

=============================== Coverage summary ===============================
Statements   : 92.39% ( 2042/2210 )
Branches     : 86.14% ( 1275/1480 )
Functions    : 87.07% ( 310/356 )
Lines        : 93.09% ( 1686/1811 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5