### PR TITLE
Close the local typecheck gap: npm test should type-check test files like CI does

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -34,9 +34,9 @@
     "smoketest": "npm run cleanup && npm install --omit=dev",
     "node:debug": "node --inspect-brk index.js",
     "jscpd": "jscpd src",
-    "test": "eslint ./src && npm run jscpd && rimraf coverage && npm run test:unit",
+    "test": "eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit",
     "test:lint": "eslint ./src --fix",
-    "test:local": "npm run test:lint && rimraf coverage && npm run test:unit",
+    "test:local": "npm run test:lint && npm run typecheck && rimraf coverage && npm run test:unit",
     "test:unit": "vitest run --coverage",
     "test:all": "npm run test:local"
   },


### PR DESCRIPTION
## Summary
- `npm run typecheck` (`tsc --noEmit -p tsconfig.prod.json && tsc --noEmit`) already fully covers `test/**/*` — the bare `tsc --noEmit` picks up the default `tsconfig.json`, whose `include` is `["./src/**/*", "./test/**/*"]`.
- The gap was that the local `test`/`test:local` npm scripts never called `npm run typecheck` at all, while CI runs `typecheck` as its own separate CircleCI step before `npm test` (see `.circleci/config.yml`).
- Result: a local `npm test` run skipped type-checking entirely, so test-file type errors only surfaced on CI — exactly what happened on #947 (two `TS2345` errors in a spec file).
- Fix: add `npm run typecheck` into both `test` and `test:local` scripts, reusing the exact same `typecheck` command CI runs so the two surfaces can't drift apart again.
- No build/emit behavior changed; `tsconfig.json`/`tsconfig.prod.json` are untouched.

Closes #949

## How to test locally
Run the full suite:
```sh
npm test
```
Expect: eslint, jscpd, typecheck (src + test), then vitest with coverage — all green.

To demonstrate the gap is actually closed, temporarily add a type error to a test file and confirm `npm test` now fails on it:
```sh
# in a test file, e.g. test/unit/book-router.spec.ts
echo "const deliberateTypeErrorProbe: number = 'not-a-number';" >> /tmp/probe.ts  # illustrative; inserted inline in the spec file
npm test
# expect: fails at the 'typecheck' step with
#   test/unit/book-router.spec.ts(N,N): error TS2322: Type 'string' is not assignable to type 'number'.
# then remove the probe line and re-run npm test to confirm green again
```

## Test evidence
```
$ npm test   # WITH deliberate type error added to test/unit/book-router.spec.ts
...
> web-jam-back@2.3.4 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit

test/unit/book-router.spec.ts(8,7): error TS2322: Type 'string' is not assignable to type 'number'.
(npm test exits non-zero here — confirms the gap is closed: a test-file type
error now fails npm test locally, matching CI, instead of only failing on CI)

$ npx eslint ./src && npm run jscpd && npm run typecheck   # probe removed
(exit 0 — eslint clean, jscpd clone-report only (26 pre-existing clones,
non-blocking), typecheck clean for both tsconfig.prod.json and the full
project incl. test/**/*)
```

Note: this sandboxed session could not run the Mongo-integration portion
(`vitest run --coverage`, the 594 tests + 90/90/80/80 coverage gate) because
it has no access to the dev Atlas `MONGO_DB_URI` secret (an isolated worktree
was used deliberately, and a local secret-dump guard blocks copying `.env`
into it — by design). eslint + jscpd + typecheck (the part this PR changes)
were verified directly above with real output; CircleCI will run the full
`npm test` including the DB-backed suite on this PR.

🤖 Work by Claude Code — Sonnet 5