### PR TITLE
Venue↔gig linkage backend: venueId + name-match fallback, last/next gig on GET /venue, gig-aware outreach candidates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -21,6 +21,7 @@
     "copy:assets": "node scripts/copy-assets.mjs",
     "seed:outreach": "node scripts/seed-outreach.mjs",
     "migrate:target-weekend": "node build/src/scripts/migrate-target-weekend.js",
+    "migrate:gig-venue-id": "node build/src/scripts/migrate-gig-venue-id.js",
     "restore:backup": "node scripts/restore-backup.mjs",
     "ts-watch": "tsc -w",
     "ts-start": "DEBUG=web-jam-back:* node --watch --trace-deprecation build/src/index.js",

--- a/src/lib/gig-venue-link.ts
+++ b/src/lib/gig-venue-link.ts
@@ -1,0 +1,91 @@
+// src/lib/gig-venue-link.ts — web-jam-back#958
+//
+// Shared venue<->gig resolution logic (locked design, #955): a gig links to a
+// venue via `venueId` first; failing that, an EXACT normalized-name match
+// (case/punctuation-insensitive) against `venue.name` — NEVER fuzzy. A name
+// that matches more than one venue is ambiguous and resolves to nothing (no
+// guessing). This one module is the single source of truth for that rule, so
+// the migration script (src/scripts/migrate-gig-venue-id.ts), GET /venue's
+// lastGig/nextGig/locationFallback (venue-controller.ts), and the
+// GET /outreach/candidates safety exclusion + weekend-gig surfacing
+// (outreach-controller.ts) can never drift into three subtly different
+// matching implementations.
+//
+// Gigs are shared across artists (#885); every caller here scopes its OWN gig
+// query with JOSH_GIGS_FILTER (Josh & Maria's gigs, or pre-#885 records with no
+// artist field) — mirrors the existing convention in venue-controller's
+// filterEligible so Tim's calendar (#922) never leaks into Josh's venue/outreach
+// linkage.
+export const JOSH_GIGS_FILTER = { $or: [{ artist: 'josh' }, { artist: { $exists: false } }] };
+
+export interface LinkableGig {
+  _id?: unknown;
+  venueId?: unknown;
+  venue?: string;
+  datetime?: Date | string;
+  [key: string]: unknown;
+}
+
+export interface LinkableVenue {
+  _id?: unknown;
+  name?: string;
+}
+
+// Lowercase + strip punctuation (keep letters/numbers/whitespace) + collapse
+// whitespace. `[^\p{L}\p{N}\s]` is a negated Unicode-property class — linear,
+// no nested quantifiers, safe from catastrophic backtracking despite the
+// generic slow-regex lint warning.
+// eslint-disable-next-line sonarjs/slow-regex
+const PUNCTUATION_RE = /[^\p{L}\p{N}\s]/gu;
+export function normalizeVenueName(name: string | undefined | null): string {
+  return (name || '')
+    .toLowerCase()
+    .replace(PUNCTUATION_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Build normalizedName -> venue _id (string), INCLUDING ONLY names unambiguous
+// across the given venue list (exactly one venue owns that normalized name).
+// A normalized name shared by 2+ venues is deliberately left out of the map —
+// "never fuzzy" means an ambiguous name resolves to nothing, not a guess.
+export function buildUnambiguousNameIndex(venues: LinkableVenue[]): Map<string, string> {
+  const counts = new Map<string, string[]>();
+  for (const v of venues) {
+    const key = normalizeVenueName(v.name);
+    if (!key) continue;
+    const ids = counts.get(key) || [];
+    ids.push(String(v._id));
+    counts.set(key, ids);
+  }
+  const index = new Map<string, string>();
+  for (const [key, ids] of counts) {
+    if (ids.length === 1) index.set(key, ids[0]);
+  }
+  return index;
+}
+
+// Resolve which venue (by _id string) a gig belongs to, or null when
+// unresolvable. venueId wins when present (trusted, no re-matching); otherwise
+// an EXACT normalized-name match against the unambiguous index.
+export function resolveGigVenueId(gig: LinkableGig, nameIndex: Map<string, string>): string | null {
+  if (gig.venueId) return String(gig.venueId);
+  const key = normalizeVenueName(gig.venue);
+  if (!key) return null;
+  return nameIndex.get(key) || null;
+}
+
+// Group gigs by resolved venue _id (string) — ONE pass over `gigs` (already
+// fetched in a single query by the caller), never a per-venue query (no N+1).
+export function groupGigsByVenue(gigs: LinkableGig[], venues: LinkableVenue[]): Map<string, LinkableGig[]> {
+  const nameIndex = buildUnambiguousNameIndex(venues);
+  const groups = new Map<string, LinkableGig[]>();
+  for (const gig of gigs) {
+    const venueId = resolveGigVenueId(gig, nameIndex);
+    if (!venueId) continue;
+    const list = groups.get(venueId) || [];
+    list.push(gig);
+    groups.set(venueId, list);
+  }
+  return groups;
+}

--- a/src/model/gig/gig-schema.ts
+++ b/src/model/gig/gig-schema.ts
@@ -27,6 +27,14 @@ const gigSchema = new Schema({
   // Artist/tenant slug (#885). Absent on all pre-#885 records, which read as
   // the default (JaMmusic) artist.
   artist: { type: String, required: false },
+  // Venue linkage (#958). Optional: resolution everywhere is venueId FIRST,
+  // else an EXACT normalized-name match against venue.name (never fuzzy) — see
+  // src/lib/gig-venue-link.ts, the single shared implementation of that rule.
+  // Backfilled onto existing gigs by the idempotent, dry-run-default migration
+  // at src/scripts/migrate-gig-venue-id.ts; new gigs may set it directly.
+  venueId: {
+    type: Schema.Types.ObjectId, ref: 'Venue', required: false,
+  },
 }, options);
 
 export default mongoose.models.Gig || mongoose.model('Gig', gigSchema, 'gigs');

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -14,6 +14,10 @@ import outreachConfigModel from './outreach-config-facade.js';
 import venueModel from '../venue/venue-facade.js';
 import templateModel from '../template/template-facade.js';
 import userModel from '../user/user-facade.js';
+import gigModel from '../gig/gig-facade.js';
+import {
+  JOSH_GIGS_FILTER, groupGigsByVenue, type LinkableGig, type LinkableVenue,
+} from '#src/lib/gig-venue-link.js';
 import { MAX_STEP, nextTouchDueAfter, touchAt } from './cadence.js';
 
 // Every gig pitch CCs Josh + Maria so they see each send land (mirrors the
@@ -792,15 +796,51 @@ class OutreachController extends Controller {
     return res.status(200).json(result);
   }
 
+  // #958 SAFETY — a venue with an upcoming (datetime >= now) linked gig must
+  // never be offered as an outreach candidate: it's already booked (by phone,
+  // in person, whatever route), so pitching it again is the same failure
+  // class as the 2026-07-08 incident (Durty Bull: booked Nov 16 as a gig
+  // record, yet invisible to venue data and Batch Outreach). Resolution uses
+  // the shared venueId-first/exact-normalized-name rule (never fuzzy — see
+  // src/lib/gig-venue-link.ts). `gigs` is fetched ONCE by the caller (no
+  // per-venue query/N+1).
+  static excludeUpcomingGigVenues(venues: LinkableVenue[], gigs: LinkableGig[]): LinkableVenue[] {
+    const groups = groupGigsByVenue(gigs, venues);
+    const now = Date.now();
+    return venues.filter((v) => {
+      const linked = groups.get(String(v._id)) || [];
+      return !linked.some((g) => g.datetime && new Date(g.datetime as string).getTime() >= now);
+    });
+  }
+
+  // #958 — weekend awareness: every linked-or-unlinked gig (any venue) whose
+  // datetime falls inside the requested target weekend, so the UI can warn
+  // "you already have a gig that weekend" while curating a candidate list for
+  // it. Independent of excludeUpcomingGigVenues above, which only hides the
+  // SPECIFIC venue that's already booked — this surfaces Josh's whole
+  // schedule for the window regardless of which venue.
+  static gigsInWeekend(gigs: LinkableGig[], tw: TargetWeekend): LinkableGig[] {
+    return gigs.filter((g) => {
+      if (!g.datetime) return false;
+      const t = new Date(g.datetime as string).getTime();
+      return t >= tw.start.getTime() && t <= tw.end.getTime();
+    });
+  }
+
   // GET /outreach/candidates — propose the target list (#844): vetted
   // (outreachEligible), non-archived venues with an email, minus any that
-  // already have an active outreach with an OVERLAPPING targetWeekend. #898:
-  // this filter is now targetWeekend/date-range aware (matching the dedup
-  // guard's overlap semantics) rather than the old targetDates string filter —
-  // the note in PR #933 deferred this rekey to this issue, since #923 already
-  // established targetDates no longer participates in any logic. Read-only.
+  // already have an active outreach with an OVERLAPPING targetWeekend, AND
+  // (#958) minus any venue with an upcoming linked gig — see
+  // excludeUpcomingGigVenues. #898: the targetWeekend filter is date-range
+  // aware (matching the dedup guard's overlap semantics) rather than the old
+  // targetDates string filter — the note in PR #933 deferred this rekey to
+  // this issue, since #923 already established targetDates no longer
+  // participates in any logic. Read-only.
   // Optional query: targetWeekend {start, end} (bracket-notation query params
-  // over HTTP, e.g. ?targetWeekend[start]=...&targetWeekend[end]=...).
+  // over HTTP, e.g. ?targetWeekend[start]=...&targetWeekend[end]=...). When
+  // given, the response is `{ candidates, weekendGigs }` (weekendGigs = #958's
+  // weekend-awareness surfacing); when omitted, the response stays the plain
+  // candidates array (unchanged, back-compat with existing callers).
   async getCandidates(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -829,8 +869,20 @@ class OutreachController extends Controller {
       }
       handled = new Set(active.map((a) => String(a.venueId)));
     }
-    const candidates = venues.filter((v) => !handled.has(String(v._id)));
-    return res.status(200).json(candidates);
+    let candidates = venues.filter((v) => !handled.has(String(v._id)));
+
+    // #958 — one extra gig query total (not per-venue): feeds both the SAFETY
+    // exclusion (always applied) and, when a targetWeekend was requested, the
+    // weekendGigs surfacing below.
+    let gigs: LinkableGig[];
+    try {
+      gigs = await gigModel.find(JOSH_GIGS_FILTER) as unknown as LinkableGig[];
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    candidates = OutreachController.excludeUpcomingGigVenues(candidates as unknown as LinkableVenue[], gigs) as unknown as { _id?: unknown }[];
+
+    if (!tw) return res.status(200).json(candidates);
+    const weekendGigs = OutreachController.gigsInWeekend(gigs, tw);
+    return res.status(200).json({ candidates, weekendGigs });
   }
 
   // GET /outreach/preview — render the exact email a venue would get, WITHOUT

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -5,6 +5,9 @@ import { Icontroller } from '#src/lib/routeUtils.js';
 import venueModel from './venue-facade.js';
 import userModel from '../user/user-facade.js';
 import gigModel from '../gig/gig-facade.js';
+import {
+  JOSH_GIGS_FILTER, groupGigsByVenue, type LinkableGig, type LinkableVenue,
+} from '#src/lib/gig-venue-link.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s.@]+$/;
 const VENUE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'];
@@ -277,6 +280,42 @@ class VenueController extends Controller {
     });
   }
 
+  // #958 — attach computed lastGig/nextGig + locationFallback onto each venue
+  // via ONE extra gig query for the whole batch (never a per-venue query — no
+  // N+1), scoped to Josh's gigs like filterEligible above. Resolution is the
+  // shared venueId-first/exact-normalized-name-fallback rule (never fuzzy —
+  // see src/lib/gig-venue-link.ts). lastGig = the most recent linked gig with
+  // datetime in the past; nextGig = the earliest linked gig with datetime >=
+  // now. locationFallback is display-only (city/usState off whichever of
+  // those two gigs is more relevant — lastGig if there is one, else nextGig,
+  // so a venue with only a FUTURE booked gig, like Durty Bull's Nov 16, still
+  // gets a location — never written back to the venue record).
+  static async attachGigLinks(venues: Record<string, unknown>[]): Promise<Record<string, unknown>[]> {
+    let gigs: LinkableGig[];
+    try {
+      gigs = await gigModel.find(JOSH_GIGS_FILTER) as unknown as LinkableGig[];
+    } catch (e) { return Promise.reject(e); }
+    const groups = groupGigsByVenue(gigs, venues as unknown as LinkableVenue[]);
+    const now = Date.now();
+    return venues.map((v) => {
+      const linked = (groups.get(String(v._id)) || [])
+        .filter((g) => g.datetime && !Number.isNaN(new Date(g.datetime as string).getTime()))
+        .slice()
+        .sort((a, b) => new Date(a.datetime as string).getTime() - new Date(b.datetime as string).getTime());
+      const past = linked.filter((g) => new Date(g.datetime as string).getTime() < now);
+      const future = linked.filter((g) => new Date(g.datetime as string).getTime() >= now);
+      const lastGig = past.length ? past[past.length - 1] : null;
+      const nextGig = future.length ? future[0] : null;
+      const fallbackGig = lastGig || nextGig;
+      const locationFallback = fallbackGig && (fallbackGig.city || fallbackGig.usState)
+        ? { city: fallbackGig.city, usState: fallbackGig.usState }
+        : null;
+      return {
+        ...v, lastGig, nextGig, locationFallback,
+      };
+    });
+  }
+
   // GET /venue — list venues (filters: status, venueType, eligibleFor=<date>).
   async listVenues(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, VENUE_WRITE_CAPS);
@@ -293,6 +332,9 @@ class VenueController extends Controller {
         return res.status(500).json({ message: (e as Error).message });
       }
     }
+    try { venues = await VenueController.attachGigLinks(venues); } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
     return res.status(200).json(venues);
   }
 
@@ -301,10 +343,12 @@ class VenueController extends Controller {
     const guardErr = await this.authorize(req, VENUE_WRITE_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     if (!mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Find id is invalid' });
-    let doc;
+    let doc: Record<string, unknown> | null;
     try { doc = await this.model.findById(req.params.id); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
     if (!doc) return res.status(400).json({ message: 'nothing found with id provided' });
-    return res.status(200).json(doc);
+    let withLinks: Record<string, unknown>[];
+    try { withLinks = await VenueController.attachGigLinks([doc]); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    return res.status(200).json(withLinks[0]);
   }
 
   // Find an existing venue for dedupe: by email when given (strongest key),

--- a/src/scripts/migrate-gig-venue-id.ts
+++ b/src/scripts/migrate-gig-venue-id.ts
@@ -1,0 +1,117 @@
+// src/scripts/migrate-gig-venue-id.ts — web-jam-back#958
+//
+// Backfills `venueId` onto gig records that don't have one yet, by matching
+// the gig's free-text `venue` name against `venue.name` using the shared
+// EXACT normalized-name match (case/punctuation-insensitive, never fuzzy —
+// see src/lib/gig-venue-link.ts). A gig whose normalized venue name matches
+// zero or MORE THAN ONE venue is left unlinked (ambiguous matches are never
+// guessed).
+//
+// Idempotent: only considers gigs with no venueId yet, so a re-run after a
+// prior --apply only touches what's still unlinked. Read-only DRY RUN by
+// default — prints exactly what it would change; pass --apply to write.
+//
+// SAFETY GUARD (mirrors scripts/restore-backup.mjs): this migration writes
+// venueId onto real gig history, so — unlike migrate-target-weekend.ts (which
+// is explicitly meant to eventually run against prod, protected only by its
+// dry-run default) — it refuses to run at all against anything that doesn't
+// look like local/DEV/TEST (db name containing 'dev'/'test', or
+// localhost/127.0.0.1) unless --force is passed. Running it for real against
+// prod is a deliberate act: `--force --apply` together, run manually (e.g.
+// `heroku run node build/src/scripts/migrate-gig-venue-id.js -- --force
+// --apply`) — never wired into build/postinstall/Procfile/CI.
+//
+// Usage:
+//   npm run migrate:gig-venue-id                    # dry run against DEV/local
+//   npm run migrate:gig-venue-id -- --apply          # writes, DEV/local only
+//   npm run migrate:gig-venue-id -- --force --apply  # writes for real (prod)
+
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import gigModel from '#src/model/gig/gig-facade.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+import {
+  JOSH_GIGS_FILTER, buildUnambiguousNameIndex, normalizeVenueName, type LinkableGig, type LinkableVenue,
+} from '#src/lib/gig-venue-link.js';
+
+config(); // load .env if present
+
+interface Args { apply: boolean; force: boolean }
+function parseArgs(argv: string[]): Args {
+  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
+}
+
+// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
+// Mirrors scripts/restore-backup.mjs's guard exactly: only db names/hosts that
+// look local/DEV/TEST are allowed without --force. Returns true when safe to
+// proceed, false when blocked — a pure predicate (no process.exit) so it's
+// unit-testable; run() below is what actually exits the process.
+export function isSafeToRun(uri: string, force: boolean): boolean {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+  return isLocal || isDevOrTest || force;
+}
+
+async function run(): Promise<void> {
+  const { apply, force } = parseArgs(process.argv.slice(2));
+  const uri = process.env.MONGO_DB_URI || '';
+  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
+  if (!isSafeToRun(uri, force)) {
+    const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+    console.error('ERROR: migrate-gig-venue-id only runs against a local, DEV, or TEST database by default — never release/production.');
+    console.error(`Target MONGO URI: ${maskedUri}`);
+    console.error(`Parsed database name: ${dbName || '(none)'}`);
+    console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
+  console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
+
+  const venues = (await venueModel.find({})) as unknown as LinkableVenue[];
+  const nameIndex = buildUnambiguousNameIndex(venues);
+
+  const candidates = (await gigModel.find({
+    ...JOSH_GIGS_FILTER, venueId: { $exists: false },
+  })) as unknown as LinkableGig[];
+
+  let matched = 0;
+  let ambiguousOrUnmatched = 0;
+  let applied = 0;
+  for (const gig of candidates) {
+    const key = normalizeVenueName(gig.venue);
+    const venueId = key ? nameIndex.get(key) : undefined;
+    if (!venueId) { ambiguousOrUnmatched += 1; continue; }
+    matched += 1;
+    const label = `${apply ? 'WRITE' : 'PLAN'}: gig ${String(gig._id)} venue="${gig.venue}" -> venueId ${venueId}`;
+    console.log(`  ${label}`);
+    if (apply) {
+      // eslint-disable-next-line no-await-in-loop
+      await gigModel.findByIdAndUpdate(String(gig._id), { venueId });
+      applied += 1;
+    }
+  }
+
+  console.log(`\n${candidates.length} gig(s) scanned (no venueId yet); ${matched} matched exactly one venue by name; `
+    + `${ambiguousOrUnmatched} left unlinked (no match or ambiguous).`);
+  console.log(apply
+    ? `${applied} gig(s) updated.`
+    : `Dry run — ${matched} gig(s) WOULD be updated. Re-run with --apply to write for real.`);
+
+  await mongoose.connection.close();
+}
+
+// Only auto-execute when run directly — NOT when imported by a unit test.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+/* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
+if (isMain) {
+  run().catch((err) => {
+    console.error('Migration failed:', (err as Error).message);
+    process.exit(1);
+  });
+}
+
+export { parseArgs, run };

--- a/test/unit/lib/gig-venue-link.spec.ts
+++ b/test/unit/lib/gig-venue-link.spec.ts
@@ -1,0 +1,94 @@
+// Unit tests for the shared venue<->gig resolution logic (web-jam-back#958).
+import mongoose from 'mongoose';
+import {
+  normalizeVenueName, buildUnambiguousNameIndex, resolveGigVenueId, groupGigsByVenue, JOSH_GIGS_FILTER,
+} from '#src/lib/gig-venue-link.js';
+
+const oid = () => new mongoose.Types.ObjectId().toString();
+
+describe('gig-venue-link (#958)', () => {
+  describe('normalizeVenueName', () => {
+    it('lowercases, strips punctuation, and collapses whitespace', () => {
+      expect(normalizeVenueName("Durty Bull's Brewing Co.")).toBe('durty bulls brewing co');
+      expect(normalizeVenueName('The   Spot,  Kirk')).toBe('the spot kirk');
+      expect(normalizeVenueName('DURTY BULL')).toBe('durty bull');
+    });
+
+    it('treats differently-punctuated names as the same key', () => {
+      expect(normalizeVenueName('Durty Bull Brewing Co.')).toBe(normalizeVenueName('Durty Bull Brewing Co'));
+    });
+
+    it('handles missing/empty input', () => {
+      expect(normalizeVenueName(undefined)).toBe('');
+      expect(normalizeVenueName(null)).toBe('');
+      expect(normalizeVenueName('')).toBe('');
+    });
+  });
+
+  describe('buildUnambiguousNameIndex', () => {
+    it('indexes a unique normalized name to its venue id', () => {
+      const id = oid();
+      const index = buildUnambiguousNameIndex([{ _id: id, name: 'Durty Bull' }]);
+      expect(index.get('durty bull')).toBe(id);
+    });
+
+    it('excludes a name shared by 2+ venues (ambiguous — never fuzzy)', () => {
+      const index = buildUnambiguousNameIndex([
+        { _id: oid(), name: 'The Spot' },
+        { _id: oid(), name: 'the spot' },
+      ]);
+      expect(index.has('the spot')).toBe(false);
+    });
+
+    it('skips venues with no name', () => {
+      const index = buildUnambiguousNameIndex([{ _id: oid() }]);
+      expect(index.size).toBe(0);
+    });
+  });
+
+  describe('resolveGigVenueId', () => {
+    it('prefers venueId when present, without consulting the name index', () => {
+      const venueId = oid();
+      const index = new Map<string, string>(); // deliberately empty/unrelated
+      expect(resolveGigVenueId({ venueId, venue: 'Unrelated Name' }, index)).toBe(venueId);
+    });
+
+    it('falls back to an exact normalized-name match when venueId is absent', () => {
+      const venueId = oid();
+      const index = new Map([['durty bull', venueId]]);
+      expect(resolveGigVenueId({ venue: 'DURTY BULL' }, index)).toBe(venueId);
+    });
+
+    it('returns null when the name has no unambiguous match', () => {
+      const index = new Map<string, string>();
+      expect(resolveGigVenueId({ venue: 'Nowhere' }, index)).toBeNull();
+    });
+
+    it('returns null when venue text is empty and there is no venueId', () => {
+      const index = new Map([['x', oid()]]);
+      expect(resolveGigVenueId({ venue: '' }, index)).toBeNull();
+    });
+  });
+
+  describe('groupGigsByVenue', () => {
+    it('groups gigs by resolved venue id in one pass (no per-venue query)', () => {
+      const venueA = { _id: oid(), name: 'The Spot' };
+      const venueB = { _id: oid(), name: 'Durty Bull' };
+      const gigs = [
+        { _id: oid(), venue: 'The Spot', datetime: '2026-01-01' },
+        { _id: oid(), venueId: venueB._id, venue: 'Somewhere Else Entirely' },
+        { _id: oid(), venue: 'Unmatched Venue' },
+      ];
+      const groups = groupGigsByVenue(gigs, [venueA, venueB]);
+      expect(groups.get(String(venueA._id))).toHaveLength(1);
+      expect(groups.get(String(venueB._id))).toHaveLength(1);
+      expect(groups.has('undefined')).toBe(false);
+    });
+  });
+
+  describe('JOSH_GIGS_FILTER', () => {
+    it("scopes to Josh's gigs or pre-#885 records with no artist field", () => {
+      expect(JOSH_GIGS_FILTER).toEqual({ $or: [{ artist: 'josh' }, { artist: { $exists: false } }] });
+    });
+  });
+});

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -30,6 +30,7 @@ const { default: userModel } = await import('#src/model/user/user-facade.js');
 const { default: venueModel } = await import('#src/model/venue/venue-facade.js');
 const { default: templateModel } = await import('#src/model/template/template-facade.js');
 const { default: configModel } = await import('#src/model/outreach/outreach-config-facade.js');
+const { default: gigModel } = await import('#src/model/gig/gig-facade.js');
 
 const c = controller as any;
 const oid = () => new mongoose.Types.ObjectId().toString();
@@ -107,6 +108,10 @@ describe('Outreach Controller (#844 batch model)', () => {
     c.model.find = vi.fn(() => Promise.resolve([]));
     c.model.create = vi.fn((doc: any) => Promise.resolve({ _id: 'o1', ...doc }));
     c.model.findByIdAndUpdate = vi.fn((id: string, f: any) => Promise.resolve({ _id: id, ...f }));
+    // #958 — getCandidates now always calls gigModel.find once (safety
+    // exclusion + weekend surfacing); default to empty so unrelated tests
+    // never hit the real DB. Tests exercising the linkage override this.
+    (gigModel as any).find = vi.fn(() => Promise.resolve([]));
   });
 
   describe('authorize', () => {
@@ -531,18 +536,88 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect((venueModel as any).find).toHaveBeenCalledWith(expect.objectContaining({ doNotContact: { $ne: true } }));
     });
 
+    // #958 — a targetWeekend request wraps the response in { candidates,
+    // weekendGigs } (weekendGigs added below); no targetWeekend keeps the
+    // plain array (see 'does not filter...' below).
     it('excludes venues already pitched for an overlapping target weekend (#898)', async () => {
       (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
       const findMock = vi.fn(() => Promise.resolve([{ venueId: 'a' }]));
       c.model.find = findMock;
       await c.getCandidates({ user: 'a', query: { targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
-      expect(payload).toHaveLength(1);
-      expect(payload[0]._id).toBe('b');
+      expect(payload.candidates).toHaveLength(1);
+      expect(payload.candidates[0]._id).toBe('b');
+      expect(payload.weekendGigs).toEqual([]);
       expect(findMock).toHaveBeenCalledWith(expect.objectContaining({
         status: { $in: ['sent', 'replied'] },
         'targetWeekend.start': { $exists: true, $lte: new Date(VALID_WEEKEND.end) },
         'targetWeekend.end': { $exists: true, $gte: new Date(VALID_WEEKEND.start) },
       }));
+    });
+
+    // #958 SAFETY — the core motivation for this issue: a venue booked
+    // outside the pitch flow (phone/in-person) must never be re-suggested.
+    describe('excludes venues with an upcoming linked gig (#958 SAFETY)', () => {
+      it('drops a venue matched by venueId with a future gig', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: new Date(Date.now() + 86400000).toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toHaveLength(1);
+        expect(payload[0]._id).toBe('b');
+      });
+
+      it('drops a venue matched by exact normalized name with a future gig', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', name: 'Durty Bull' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venue: 'DURTY, BULL!', datetime: new Date(Date.now() + 86400000).toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toHaveLength(0);
+      });
+
+      it('does NOT drop a venue whose linked gig is in the past', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: new Date(Date.now() - 86400000).toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toHaveLength(1);
+      });
+
+      it('500s when the gig query throws', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        (gigModel as any).find = vi.fn(() => Promise.reject(new Error('db down')));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(500);
+      });
+    });
+
+    // #958 — weekend awareness: surfaces Josh's whole gig schedule for the
+    // requested weekend (any venue), independent of the per-venue safety
+    // exclusion above.
+    describe('weekendGigs surfacing (#958)', () => {
+      it('includes gigs inside the requested target weekend', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venue: 'Some Other Venue', datetime: '2026-09-26T00:00:00.000Z' },
+          { venue: 'Out Of Range', datetime: '2026-10-10T00:00:00.000Z' },
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.weekendGigs).toHaveLength(1);
+        expect(payload.weekendGigs[0].venue).toBe('Some Other Venue');
+      });
+
+      it('omits weekendGigs entirely when no targetWeekend is requested', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(Array.isArray(payload)).toBe(true);
+      });
     });
 
     // #898 — targetDates is display-only per #923; a bare targetDates with no

--- a/test/unit/scripts/migrate-gig-venue-id.spec.ts
+++ b/test/unit/scripts/migrate-gig-venue-id.spec.ts
@@ -1,0 +1,40 @@
+// Unit tests for the #958 migration script's pure logic. Importing the module
+// must NOT touch Mongo or process.exit (no top-level side effects beyond
+// dotenv) — run()'s isMain guard is never true under vitest.
+import { isSafeToRun, parseArgs } from '#src/scripts/migrate-gig-venue-id.js';
+
+describe('migrate-gig-venue-id (#958)', () => {
+  describe('parseArgs', () => {
+    it('reads --apply and --force flags', () => {
+      expect(parseArgs([])).toEqual({ apply: false, force: false });
+      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
+      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
+    });
+  });
+
+  describe('isSafeToRun', () => {
+    it('allows a localhost URI', () => {
+      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a 127.0.0.1 URI', () => {
+      expect(isSafeToRun('mongodb://127.0.0.1:27017/anything', false)).toBe(true);
+    });
+
+    it('allows a DEV Atlas db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a TEST db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-test', false)).toBe(true);
+    });
+
+    it('blocks a prod-looking (release) db name without --force', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
+    });
+
+    it('allows a prod-looking db name when --force is passed', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+});

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -25,6 +25,10 @@ describe('Venue Controller', () => {
     status = 0;
     payload = undefined;
     asAgent();
+    // #958 — listVenues/getVenue now always call gigModel.find once (for
+    // attachGigLinks); default it to empty so tests that don't care about gig
+    // linkage never hit the real DB. Tests exercising the linkage override this.
+    (gigModel as any).find = vi.fn(() => Promise.resolve([]));
   });
 
   describe('authorize', () => {
@@ -221,6 +225,31 @@ describe('Venue Controller', () => {
       expect(status).toBe(200);
       expect(payload.name).toBe('The Spot');
     });
+
+    // #958 — GET /venue/:id gets the same computed lastGig/nextGig/
+    // locationFallback as the list route (see attachGigLinks tests below).
+    it('attaches lastGig/nextGig/locationFallback (#958)', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, name: 'The Spot' }));
+      (gigModel as any).find = vi.fn(() => Promise.resolve([
+        {
+          venueId: id, datetime: new Date(Date.now() + 86400000).toISOString(), city: 'Roanoke', usState: 'Virginia',
+        },
+      ]));
+      await c.getVenue({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.nextGig).toBeTruthy();
+      expect(payload.lastGig).toBeNull();
+      expect(payload.locationFallback).toEqual({ city: 'Roanoke', usState: 'Virginia' });
+    });
+
+    it('500s when the gig-link query throws', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, name: 'The Spot' }));
+      (gigModel as any).find = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.getVenue({ user: 'a', params: { id } }, resStub);
+      expect(status).toBe(500);
+    });
   });
 
   describe('listVenues', () => {
@@ -269,6 +298,77 @@ describe('Venue Controller', () => {
       await c.listVenues({ user: 'a', query: { eligibleFor: '2026-07-01' } }, resStub);
       expect(status).toBe(200);
       expect(payload.map((v: any) => v.name)).toEqual(['Venue X']);
+    });
+
+    // #958 — computed lastGig/nextGig/locationFallback, resolved via
+    // venueId-first / exact-normalized-name fallback (src/lib/gig-venue-link.ts).
+    describe('attachGigLinks (#958)', () => {
+      it('resolves lastGig (past) and nextGig (future) via venueId', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'The Spot' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: idA, datetime: '2026-01-01T00:00:00.000Z' }, // past
+          { venueId: idA, datetime: '2099-01-01T00:00:00.000Z' }, // future
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload[0].lastGig.datetime).toBe('2026-01-01T00:00:00.000Z');
+        expect(payload[0].nextGig.datetime).toBe('2099-01-01T00:00:00.000Z');
+      });
+
+      it('resolves via exact normalized-name match when venueId is absent', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'Durty Bull' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venue: 'DURTY, BULL!', datetime: '2099-01-01T00:00:00.000Z' },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload[0].nextGig).toBeTruthy();
+      });
+
+      it('never fuzzy-matches: an ambiguous name (2+ venues) resolves nothing', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: new mongoose.Types.ObjectId().toString(), name: 'The Spot' },
+          { _id: new mongoose.Types.ObjectId().toString(), name: 'the spot' },
+        ]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venue: 'The Spot', datetime: '2099-01-01T00:00:00.000Z' },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload.every((v: any) => v.nextGig === null)).toBe(true);
+      });
+
+      it('prefers lastGig for locationFallback, falling back to nextGig when there is no past gig (Durty Bull case)', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'Durty Bull', city: '', usState: '' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          {
+            venueId: idA, datetime: '2099-11-16T00:00:00.000Z', city: 'Roanoke', usState: 'Virginia',
+          },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload[0].lastGig).toBeNull();
+        expect(payload[0].locationFallback).toEqual({ city: 'Roanoke', usState: 'Virginia' });
+      });
+
+      it('locationFallback is null when there is no linked gig', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: new mongoose.Types.ObjectId().toString(), name: 'No Gigs Here' }]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload[0].locationFallback).toBeNull();
+        expect(payload[0].lastGig).toBeNull();
+        expect(payload[0].nextGig).toBeNull();
+      });
+
+      it('500s when the gig-link query throws', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: new mongoose.Types.ObjectId().toString(), name: 'X' }]));
+        (gigModel as any).find = vi.fn(() => Promise.reject(new Error('db down')));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(500);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Gig gains an optional `venueId`; resolution everywhere is venueId first, else an EXACT normalized-name match (case/punctuation-insensitive, never fuzzy) — the one shared implementation lives in `src/lib/gig-venue-link.ts` so the migration, `GET /venue`, and outreach candidates can't drift into three different matchers.
- `src/scripts/migrate-gig-venue-id.ts`: idempotent, dry-run-default backfill of `venueId` onto existing gigs (unambiguous exact-name matches only). Refuses to run against anything that doesn't look like local/DEV/TEST unless `--force` (mirrors `scripts/restore-backup.mjs`'s guard) — this migration writes onto real gig history, so a prod run is a deliberate, reviewed `--force --apply`.
- `GET /venue` and `GET /venue/:id` now compute `lastGig` (most recent past linked gig), `nextGig` (earliest upcoming linked gig), and `locationFallback` (display-only city/usState, preferring `lastGig` then falling back to `nextGig` — so a venue with only a *future* booked gig, like Durty Bull's Nov 16, still shows a location). One extra gig query per request (not per-venue — no N+1).
- `GET /outreach/candidates` SAFETY fix: excludes any venue with an upcoming (`datetime >= now`) linked gig — a venue booked outside the pitch flow must never be re-suggested (the Durty Bull incident this issue was filed over).
- `GET /outreach/candidates` weekend awareness: when a `targetWeekend` is requested, the response becomes `{ candidates, weekendGigs }` — `weekendGigs` is Josh's whole gig schedule (any venue) inside that weekend, so the UI can warn "you already have a gig that weekend." Response stays a plain array when no `targetWeekend` is given (backward-compatible).

**Judgment call worth flagging:** the issue said "via one `$lookup` aggregation" for the venue computed fields. I implemented it as one extra `gigModel.find()` per request (not per-venue — same "no N+1" guarantee) with the exact-normalized-name matching done in JS via the shared `gig-venue-link.ts` module, rather than a raw Mongo `$lookup` pipeline — Mongo aggregation has no native regex-replace operator, so reproducing "case/punctuation-insensitive exact match, ambiguous-name-safe" reliably inside a `$lookup` pipeline would be fragile and hard to unit-test. The single-query/no-N+1 property is preserved; only the "$lookup" mechanism differs from the literal issue text.

Closes #958

## How to test locally
Run the repo's full gate:

```sh
npm test
```
Expect: eslint clean, jscpd under the 5% threshold, typecheck clean, and all vitest unit tests green with coverage over the 90/90/80/80 gate.

Then exercise the change itself (against DEV Atlas, e.g. via `npm run dev`):

```sh
# lastGig/nextGig/locationFallback on a venue with only a future gig
curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:8080/venue/VENUE_ID_HERE"
# expect: lastGig: null, nextGig: {...}, locationFallback: {city, usState} from nextGig

# outreach candidates safety exclusion — a venue with an upcoming linked gig
# must be ABSENT from the list
curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8080/outreach/candidates

# weekend awareness — response becomes { candidates, weekendGigs }
curl -s -H "Authorization: Bearer $TOKEN" \
  "http://localhost:8080/outreach/candidates?targetWeekend[start]=2026-09-25&targetWeekend[end]=2026-09-27"

# migration dry run (no writes) against DEV Atlas
npm run migrate:gig-venue-id
# expect: "Mode: DRY RUN" + a PLAN line per unambiguous gig->venue name match,
# and a final "N record(s) scanned ... M matched ... Re-run with --apply" summary
```

## Test evidence
```

> web-jam-back@2.3.6 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit


> web-jam-back@2.3.6 jscpd
> jscpd src

Using config from .jscpd.json
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/lib/artist-controller.ts[39m[22m [68:26 - 74:18] (7 lines, 87 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/lib/artist-controller.ts [77:26 - 83:18]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/lib/controller.ts[39m[22m [104:5 - 110:28] (7 lines, 88 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [601:5 - 612:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/admin-user/admin-user-router.ts[39m[22m [2:52 - 18:48] (17 lines, 108 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/subscriber/admin-subscriber-router.ts [2:52 - 21:48]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/inquiry/format-inquiry.ts[39m[22m [31:77 - 44:9] (14 lines, 67 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [206:121 - 225:9]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [39:67 - 44:52] (6 lines, 58 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [32:36 - 37:52]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [130:79 - 144:9] (15 lines, 96 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [136:92 - 149:9]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [160:75 - 172:35] (13 lines, 106 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [207:12 - 221:35]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [161:1 - 172:35] (12 lines, 105 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [81:1 - 93:35]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [363:26 - 371:4] (9 lines, 100 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [154:26 - 164:4]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [363:26 - 376:108] (14 lines, 138 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [226:23 - 242:22]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [364:77 - 369:66] (6 lines, 71 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/promo/promo-controller.ts [36:88 - 41:66]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [415:65 - 430:8] (16 lines, 150 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [190:67 - 202:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [430:23 - 436:37] (7 lines, 111 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [558:22 - 564:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [431:64 - 436:37] (6 lines, 84 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [1239:61 - 1244:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [431:64 - 436:49] (6 lines, 86 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [440:63 - 443:56]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [570:95 - 575:10] (6 lines, 53 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [274:62 - 276:20]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [735:74 - 748:10] (14 lines, 105 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [765:87 - 777:10]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [918:32 - 925:11] (8 lines, 59 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [937:92 - 944:7]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [1238:24 - 1244:33] (7 lines, 109 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [396:20 - 400:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [1238:24 - 1244:33] (7 lines, 109 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [418:17 - 422:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/subscriber/subscriber-controller.ts[39m[22m [64:47 - 70:8] (7 lines, 84 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/subscriber/subscriber-controller.ts [129:20 - 134:7]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [229:26 - 237:20] (9 lines, 106 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [371:47 - 379:20]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [242:74 - 248:10] (7 lines, 52 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [383:51 - 388:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [276:98 - 288:8] (13 lines, 104 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [403:66 - 418:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-gig-venue-id.ts[39m[22m [102:95 - 115:2] (14 lines, 80 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-target-weekend.ts [112:98 - 127:2]
[90m┌────────────┬────────────────┬─────────────┬──────────────┬──────────────┬──────────────────┬───────────────────┐[39m
[90m│[39m[31m Format     [39m[90m│[39m[31m Files analyzed [39m[90m│[39m[31m Total lines [39m[90m│[39m[31m Total tokens [39m[90m│[39m[31m Clones found [39m[90m│[39m[31m Duplicated lines [39m[90m│[39m[31m Duplicated tokens [39m[90m│[39m
[90m├────────────┼────────────────┼─────────────┼──────────────┼──────────────┼──────────────────┼───────────────────┤[39m
[90m│[39m typescript [90m│[39m 69             [90m│[39m 6724        [90m│[39m 46167        [90m│[39m 25           [90m│[39m 222 (3.30%)      [90m│[39m 2316 (5.02%)      [90m│[39m
[90m├────────────┼────────────────┼─────────────┼──────────────┼──────────────┼──────────────────┼───────────────────┤[39m
[90m│[39m [1mTotal:[22m     [90m│[39m 69             [90m│[39m 6724        [90m│[39m 46167        [90m│[39m 25           [90m│[39m 222 (3.30%)      [90m│[39m 2316 (5.02%)      [90m│[39m
[90m└────────────┴────────────────┴─────────────┴──────────────┴──────────────┴──────────────────┴───────────────────┘[39m
[90mFound 25 clones.[39m
[90mtime: 13.726ms[39m

[90m💡 Auto-refactor with AI: [1m[39mnpx skills add https://github.com/kucherenko/jscpd --skill dry-refactoring[90m[22m
[90m🎩 New: Gangsta Agents — discipline your AI coding → gangsta.page[39m
[90m💖 Support jscpd project → https://opencollective.com/jscpd[39m

> web-jam-back@2.3.6 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit


> web-jam-back@2.3.6 test:unit
> vitest run --coverage


 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back
      Coverage enabled with v8

GET /gig?artist=tim 200 172 - 25.375 ms
GET /gig 200 334 - 16.804 ms
POST /gig 201 173 - 40.876 ms
POST /gig 201 170 - 36.351 ms
POST /gig 201 179 - 34.872 ms
PUT /gig/6a5899408a6fdd82e7d0b366 200 164 - 56.965 ms
PUT /gig/6a5899408a6fdd82e7d0b367 403 44 - 32.076 ms
PUT /gig/6a5899408a6fdd82e7d0b368 403 44 - 30.577 ms
DELETE /gig/6a5899408a6fdd82e7d0b369 403 44 - 29.500 ms
DELETE /gig/6a5899408a6fdd82e7d0b36a 200 42 - 50.121 ms
GET /book/one?type=bio&artist=tim 200 194 - 16.729 ms
PUT /book/one?type=bio 200 185 - 35.935 ms
PUT /book/one?type=bio 200 189 - 34.130 ms
GET /setlist 200 149 - 36.332 ms
GET /setlist/6a589945c44f4359b7d4a213 200 209 - 20.342 ms
GET /setlist/not-an-id 400 32 - 0.313 ms
GET /setlist/6a53da5b8c4f9aa55d290d99 400 44 - 17.571 ms
POST /setlist 201 172 - 43.004 ms
POST /setlist 401 63 - 0.247 ms
POST /setlist 500 71 - 20.438 ms
POST /setlist 500 96 - 18.112 ms
POST /setlist 201 158 - 47.497 ms
PUT /setlist/6a589946c44f4359b7d4a21e 200 188 - 38.416 ms
PUT /setlist/6a589946c44f4359b7d4a222 400 30 - 16.188 ms
DELETE /setlist/6a589946c44f4359b7d4a223 200 46 - 36.541 ms
DELETE /setlist?name=Bulk+Set 200 47 - 37.948 ms
GET /setlist/6a589946c44f4359b7d4a226 200 307 - 33.367 ms
GET /setlist/6a589946c44f4359b7d4a228 200 414 - 32.929 ms
GET /setlist 200 416 - 32.789 ms
GET /book/one?type=paperback 200 171 - 23.854 ms
GET /book/one?type=magazine 400 29 - 17.512 ms
PUT /book/one?type=paperback 200 160 - 42.361 ms
PUT /book/one?type=stewardshipPageContent 200 191 - 66.082 ms
DELETE /book/6a58994b85470f9859b2f207 200 43 - 38.588 ms
GET /book/findcheckedout/33333 200 196 - 32.879 ms
PUT /book/6a58994b85470f9859b2f209 200 189 - 34.961 ms
GET /book/6a58994b85470f9859b2f20a 200 194 - 30.222 ms
GET /book 200 173 - 16.250 ms
POST /book 201 191 - 36.614 ms
DELETE /book?type=paperback 200 44 - 35.092 ms
GET /gig 200 202 - 25.520 ms
GET /gig/6a589951d3ae241711723fad 200 200 - 37.824 ms
POST /gig 201 222 - 38.077 ms
PUT /gig/6a589951d3ae241711723faf 200 155 - 58.202 ms
DELETE /gig/6a589951d3ae241711723fb0 200 42 - 37.357 ms
DELETE /gig?city=Salem 200 43 - 53.348 ms
GET /facebook/feed 200 31 - 3.361 ms
PUT /facebook/token 401 63 - 0.846 ms
PUT /facebook/token 400 35 - 21.103 ms
PUT /facebook/token 200 69 - 83.543 ms
GET /facebook/feed 200 152 - 0.286 ms
PUT /facebook/token 400 37 - 18.594 ms
PUT /facebook/token 400 23 - 16.955 ms
PUT /facebook/token 200 69 - 54.604 ms
GET /facebook/feed?pageId=111111111111111 200 88 - 0.236 ms
GET /facebook/feed 200 31 - 0.190 ms
POST /inquiry 200 24 - 3.481 ms
GET /user?name=tester 200 2 - 490.538 ms
GET /user?name=tester 401 28 - 0.364 ms
POST /user 401 63 - 0.515 ms
POST /user 400 25 - 181.235 ms
POST /user/auth/google 500 73 - 1.216 ms
GET /livestream/current 200 32 - 3.200 ms
GET /livestream/current 200 74 - 0.878 ms
GET /livestream/current 200 79 - 0.343 ms
GET /livestream/current 200 32 - 0.295 ms
GET /livestream/current 200 32 - 0.254 ms
GET /livestream/current 200 37 - 0.327 ms
GET /livestream/current 200 37 - 0.165 ms
POST /admin/backup 401 63 - 5.004 ms
POST /admin/backup 401 51 - 1.215 ms
POST /admin/backup 202 28 - 0.987 ms

 Test Files  43 passed (43)
      Tests  638 passed (638)
   Start at  04:41:33
   Duration  53.56s (transform 837ms, setup 0ms, import 10.77s, tests 33.54s, environment 7ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   92.62 |    86.59 |   87.53 |   93.35 |                   
 src               |   95.83 |      100 |      60 |   97.82 |                   
  index.ts         |    93.1 |      100 |      50 |   96.29 | 74                
 src/auth          |    98.8 |       80 |    90.9 |     100 |                   
  authUtils.ts     |     100 |    70.27 |     100 |     100 | ...47,50-76,83-88 
  google.ts        |   96.66 |     87.5 |   66.66 |     100 | 22,63             
 src/lib           |   94.49 |    85.59 |   94.23 |   95.97 |                   
  ...controller.ts |    87.5 |    97.14 |      80 |   91.66 | 45,54,97          
  artist.ts        |     100 |       90 |     100 |     100 | 25,44             
  backup-export.ts |   85.71 |    72.72 |   77.77 |   88.88 | 90-94             
  ...sify-reply.ts |      96 |    92.59 |     100 |     100 | 38-48             
  controller.ts    |   94.87 |    80.95 |     100 |   92.59 | 45-48,57          
  dropbox.ts       |   96.15 |    76.66 |     100 |     100 | 32-34,43,73-84    
  imap-replies.ts  |   96.09 |    83.89 |   94.73 |   97.95 | 271-272           
  mailer.ts        |   78.94 |    52.94 |      80 |   83.33 | 13-22             
  utils.ts         |     100 |    83.33 |     100 |     100 | 5                 
 ...del/admin-user |   92.85 |      100 |      70 |   91.04 |                   
  ...ser-router.ts |      40 |      100 |       0 |      40 | 10-15,22-23       
 src/model/backup  |   79.16 |    63.63 |     100 |   79.16 |                   
  ...controller.ts |      75 |    63.63 |     100 |      75 | 39-41,46,54       
 ...model/facebook |   98.95 |    78.78 |     100 |    98.8 |                   
  ...Controller.ts |   98.83 |    78.12 |     100 |   98.66 | 41                
 src/model/inquiry |   93.05 |    90.19 |   91.66 |    93.1 |                   
  ...Controller.ts |      84 |    73.68 |      75 |      85 | 34-43             
  index.ts         |   83.33 |      100 |     100 |   83.33 | 13                
 ...del/livestream |   97.36 |       90 |     100 |   96.96 |                   
  ...Controller.ts |     100 |       90 |     100 |     100 | 30-31             
  index.ts         |   83.33 |      100 |     100 |   83.33 | 13                
 ...model/outreach |   93.67 |    86.74 |   82.35 |   93.63 |                   
  ...controller.ts |   98.24 |    86.36 |     100 |   99.54 | 172,1249          
  ...ach-router.ts |   30.23 |      100 |       0 |   30.23 | ...06-107,112-121 
 src/model/promo   |   86.04 |    78.57 |      80 |   87.17 |                   
  ...controller.ts |   89.74 |    78.57 |     100 |   91.42 | 40,68,79          
  promo-router.ts  |      50 |      100 |       0 |      50 | 12-13             
 ...del/subscriber |      80 |    82.08 |   57.14 |    81.7 |                   
  ...ber-router.ts |   42.85 |      100 |       0 |   42.85 | 12-17             
  ...controller.ts |   84.52 |    81.53 |   88.88 |   87.87 | ...19,145,158-160 
  ...ber-router.ts |   57.14 |      100 |       0 |   57.14 | 9,12,15           
 ...model/template |   84.83 |    82.14 |      75 |   86.33 |                   
  ...controller.ts |    90.5 |    81.81 |     100 |   94.11 | ...44,256,281,296 
  ...ate-router.ts |      25 |      100 |       0 |      25 | 14-19,24-25,30-39 
 src/model/venue   |   88.75 |    88.72 |   84.61 |   89.55 |                   
  ...controller.ts |   92.82 |    88.61 |     100 |      95 | ...85,391,407,447 
  venue-router.ts  |      25 |      100 |       0 |      25 | 14-19,24-33,40-41 
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 92.62% ( 2161/2333 )
Branches     : 86.59% ( 1337/1544 )
Functions    : 87.53% ( 330/377 )
Lines        : 93.35% ( 1784/1911 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5