### PR TITLE
gig↔venue exact-name matcher matches 0/135 prod gigs — HTML-wrapped venue field likely not stripped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/gig-venue-link.ts
+++ b/src/lib/gig-venue-link.ts
@@ -31,14 +31,49 @@ export interface LinkableVenue {
   name?: string;
 }
 
-// Lowercase + strip punctuation (keep letters/numbers/whitespace) + collapse
-// whitespace. `[^\p{L}\p{N}\s]` is a negated Unicode-property class — linear,
-// no nested quantifiers, safe from catastrophic backtracking despite the
-// generic slow-regex lint warning.
+// Prod `gig.venue` values come from a TinyMCE rich-text field, e.g.
+// `<p><a href="https://x.com/" target="_blank" rel="noopener">Slow Play
+// Brewing</a></p>` — sometimes with HTML entities (`&amp;`). Both must be
+// stripped/decoded BEFORE the punctuation/case normalization below, or the
+// exact-match never fires (web-jam-back#964: 0/135 prod gigs matched).
+// `<[^>]*>` is a negated-class quantifier — linear, no nested quantifiers,
+// safe from catastrophic backtracking despite the generic slow-regex lint
+// warning.
+// eslint-disable-next-line sonarjs/slow-regex
+const HTML_TAG_RE = /<[^>]*>/g;
+
+// Common named entities TinyMCE/browsers emit, plus numeric/hex entities
+// (&#39; / &#x27;). Decode named entities via a lookup table (no regex
+// alternation blowup); numeric entities via two small linear regexes, applied
+// first so a decoded `&#38;` doesn't get re-interpreted as the start of
+// another entity.
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+const NAMED_ENTITY_RE = /&([a-zA-Z]+);/g;
+const NUMERIC_ENTITY_RE = /&#(\d+);/g;
+const HEX_ENTITY_RE = /&#x([0-9a-fA-F]+);/g;
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(HEX_ENTITY_RE, (_m, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(NUMERIC_ENTITY_RE, (_m, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(NAMED_ENTITY_RE, (m, name: string) => NAMED_ENTITIES[name] ?? m);
+}
+
+// Strip HTML tags, decode entities, then lowercase + strip punctuation (keep
+// letters/numbers/whitespace) + collapse whitespace. `[^\p{L}\p{N}\s]` is a
+// negated Unicode-property class — linear, no nested quantifiers, safe from
+// catastrophic backtracking despite the generic slow-regex lint warning.
 // eslint-disable-next-line sonarjs/slow-regex
 const PUNCTUATION_RE = /[^\p{L}\p{N}\s]/gu;
 export function normalizeVenueName(name: string | undefined | null): string {
-  return (name || '')
+  return decodeHtmlEntities((name || '').replace(HTML_TAG_RE, ' '))
     .toLowerCase()
     .replace(PUNCTUATION_RE, '')
     .replace(/\s+/g, ' ')

--- a/test/unit/lib/gig-venue-link.spec.ts
+++ b/test/unit/lib/gig-venue-link.spec.ts
@@ -23,6 +23,36 @@ describe('gig-venue-link (#958)', () => {
       expect(normalizeVenueName(null)).toBe('');
       expect(normalizeVenueName('')).toBe('');
     });
+
+    // web-jam-back#964: prod gig.venue values are TinyMCE HTML, e.g.
+    // `<p><a href="https://www.slowplaybrewing.com/" target="_blank"
+    // rel="noopener">Slow Play Brewing</a></p>` — 0/135 prod gigs matched
+    // because tags/entities weren't stripped before comparing to plain names.
+    it('strips a TinyMCE anchor-wrapped venue down to the link text', () => {
+      const html = '<p><a href="https://www.slowplaybrewing.com/" target="_blank" rel="noopener">Slow Play Brewing</a></p>';
+      expect(normalizeVenueName(html)).toBe(normalizeVenueName('Slow Play Brewing'));
+    });
+
+    it('decodes &amp;-style HTML entities before comparing', () => {
+      const html = '<p>Smith &amp; Sons Tap Room</p>';
+      expect(normalizeVenueName(html)).toBe(normalizeVenueName('Smith & Sons Tap Room'));
+    });
+
+    it('decodes numeric and hex HTML entities', () => {
+      expect(normalizeVenueName('Tom&#39;s Bar')).toBe(normalizeVenueName("Tom's Bar"));
+      expect(normalizeVenueName('Tom&#x27;s Bar')).toBe(normalizeVenueName("Tom's Bar"));
+    });
+
+    it('matches an unwrapped plain-text venue value identically to itself', () => {
+      expect(normalizeVenueName('Durty Bull Brewing')).toBe(normalizeVenueName('Durty Bull Brewing'));
+    });
+
+    it('does NOT collapse a College-Lutheran-style long prose field into a real venue name', () => {
+      const prose = '<p>Join us for worship this Sunday at 10am, followed by a potluck in the fellowship hall. '
+        + 'All are welcome &amp; encouraged to bring a dish to share!</p>';
+      const index = buildUnambiguousNameIndex([{ _id: oid(), name: 'Slow Play Brewing' }]);
+      expect(index.get(normalizeVenueName(prose))).toBeUndefined();
+    });
   });
 
   describe('buildUnambiguousNameIndex', () => {
@@ -67,6 +97,37 @@ describe('gig-venue-link (#958)', () => {
     it('returns null when venue text is empty and there is no venueId', () => {
       const index = new Map([['x', oid()]]);
       expect(resolveGigVenueId({ venue: '' }, index)).toBeNull();
+    });
+
+    // web-jam-back#964 end-to-end: a gig with a real TinyMCE-shaped venue
+    // field resolves against the plain-text venue name it links to, and a
+    // long-prose (non-venue) field correctly resolves to nothing.
+    it('resolves a TinyMCE HTML-wrapped gig.venue against a plain-text venue name', () => {
+      const venueId = oid();
+      const venues = [{ _id: venueId, name: 'Slow Play Brewing' }];
+      const index = buildUnambiguousNameIndex(venues);
+      const gig = {
+        venue: '<p><a href="https://www.slowplaybrewing.com/" target="_blank" rel="noopener">Slow Play Brewing</a></p>',
+      };
+      expect(resolveGigVenueId(gig, index)).toBe(venueId);
+    });
+
+    it('resolves an HTML-wrapped gig.venue containing &amp; against a venue with a plain "&"', () => {
+      const venueId = oid();
+      const venues = [{ _id: venueId, name: 'Smith & Sons Tap Room' }];
+      const index = buildUnambiguousNameIndex(venues);
+      const gig = { venue: '<p>Smith &amp; Sons Tap Room</p>' };
+      expect(resolveGigVenueId(gig, index)).toBe(venueId);
+    });
+
+    it('leaves a College-Lutheran-style long prose gig.venue unresolved', () => {
+      const venues = [{ _id: oid(), name: 'Slow Play Brewing' }];
+      const index = buildUnambiguousNameIndex(venues);
+      const gig = {
+        venue: '<p>Join us for worship this Sunday at 10am, followed by a potluck in the fellowship hall. '
+          + 'All are welcome &amp; encouraged to bring a dish to share!</p>',
+      };
+      expect(resolveGigVenueId(gig, index)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix `normalizeVenueName` in the shared `src/lib/gig-venue-link.ts` module to strip HTML tags and decode HTML entities (named, decimal, and hex, e.g. `&amp;`, `&#39;`, `&#x27;`) BEFORE the existing lowercase/punctuation normalization
- Root cause confirmed by reading the module: prod `gig.venue` values are TinyMCE HTML (e.g. `<p><a href="https://www.slowplaybrewing.com/" target="_blank" rel="noopener">Slow Play Brewing</a></p>`), and `normalizeVenueName` was comparing that raw HTML against plain-text `venue.name` values, so the exact-match never fired (0/135 prod gigs matched)
- Fix lives in the ONE shared module, so the migration script (`src/scripts/migrate-gig-venue-id.ts`), `GET /venue`'s `lastGig`/`nextGig`/`locationFallback`, and the outreach-candidate upcoming-gig exclusion all pick up the fix together — no per-surface forks
- Added unit tests covering: TinyMCE anchor-wrapped venue values, `&amp;`-style and numeric/hex HTML entities, plain-text values, and a College-Lutheran-style long-prose venue field that correctly resolves to no match
- Bumped `package.json` version `2.3.6` -> `2.3.7` (patch, first commit only)

Part of #964

## How to test locally
Local (run in this PR):
```sh
npx eslint src/lib/gig-venue-link.ts test/unit/lib/gig-venue-link.spec.ts
npx tsc --noEmit -p tsconfig.prod.json && npx tsc --noEmit
npm test
```
Expect: eslint clean, typecheck clean, all vitest suites green, coverage above the 90/90/80/80 (statements/lines/branches/functions) gate.

Post-deploy, Josh/main session — NOT run in this PR:
```sh
heroku run "npm run migrate:gig-venue-id -- --force" -a webjamsalem
```
This is the read-only prod dry-run (no `--apply`) called out in issue #964's acceptance criteria — re-run it after this PR merges and deploys, and report the new matched-gig count (expected to be well above the current 0/135) BEFORE anyone runs `--apply`.

## Test evidence
```
$ npx eslint src/lib/gig-venue-link.ts test/unit/lib/gig-venue-link.spec.ts
(no output — clean)

$ npx tsc --noEmit -p tsconfig.prod.json && npx tsc --noEmit
(no output — clean)

$ npx vitest run test/unit/lib/gig-venue-link.spec.ts
 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  09:02:09
   Duration  298ms

$ npm test
> web-jam-back@2.3.7 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit
...
 Test Files  43 passed (43)
      Tests  646 passed (646)
   Duration  53.26s

 % Coverage report from v8 (relevant file)
 src/lib/gig-venue-link.ts | 100 Stmts | 95 Branch | 100 Funcs | 100 Lines

 Coverage summary (whole repo)
 Statements   : 92.65% ( 2170/2342 )
 Branches     : 86.54% ( 1338/1546 )
 Functions    : 87.66% ( 334/381 )
 Lines        : 93.38% ( 1793/1920 )
 (gate: 90/90/80/80 — all above threshold)
```

🤖 Work by Claude Code — Sonnet 5