### PR TITLE
Gig announce endpoint: POST /gig/:id/announce → Instagram + Web Jam LLC Facebook page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/lib/caption-text.ts
+++ b/src/lib/caption-text.ts
@@ -1,0 +1,47 @@
+// src/lib/caption-text.ts — web-jam-back#962
+//
+// Converts a TinyMCE-authored gig-announce caption (rich HTML) into the plain
+// text the Instagram Content Publishing API and Facebook Pages API both
+// require (neither accepts HTML in a caption/message field). Keeps
+// paragraph/line breaks, flattens `<a href>` links down to their raw URL
+// (both surfaces auto-linkify a bare URL, so the link text isn't needed), and
+// drops all styling tags outright.
+//
+// Reuses decodeHtmlEntities from gig-venue-link.ts (web-jam-back#964) rather
+// than duplicating it — same TinyMCE-entity-decoding need (`&amp;`, `&#39;`,
+// etc.), now shared by both the venue-name matcher and this caption converter.
+import { decodeHtmlEntities } from './gig-venue-link.js';
+
+// Anchors are flattened to their raw href, discarding the link text entirely.
+// The lazy `[\s\S]*?` is bounded by the literal closing tag (no nested
+// quantifiers), so it's linear despite the generic slow-regex lint warning;
+// TinyMCE never emits nested anchors.
+// eslint-disable-next-line sonarjs/slow-regex
+const ANCHOR_RE = /<a\b[^>]*href="([^"]*)"[^>]*>[\s\S]*?<\/a>/gi;
+
+// <br> in any written form -> a single newline.
+const BR_RE = /<br\s*\/?>/gi;
+
+// Closing block-level tags -> a paragraph break (two newlines). The matching
+// opening tags (and every remaining inline/styling tag) are stripped
+// generically by REMAINING_TAG_RE below.
+const BLOCK_CLOSE_RE = /<\/(p|div|li|h[1-6]|blockquote)>/gi;
+
+// Everything left (opening block tags, <strong>/<em>/<span>/etc.) is dropped
+// outright. Negated-class quantifier — linear, no nested quantifiers, safe
+// from catastrophic backtracking despite the generic slow-regex lint warning.
+// eslint-disable-next-line sonarjs/slow-regex
+const REMAINING_TAG_RE = /<[^>]*>/g;
+
+export function htmlCaptionToText(html: string): string {
+  const withLinks = (html || '').replace(ANCHOR_RE, (_m, href: string) => href);
+  const withBreaks = withLinks.replace(BR_RE, '\n').replace(BLOCK_CLOSE_RE, '\n\n');
+  const stripped = withBreaks.replace(REMAINING_TAG_RE, '');
+  const decoded = decodeHtmlEntities(stripped);
+  return decoded
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/lib/gig-venue-link.ts
+++ b/src/lib/gig-venue-link.ts
@@ -59,7 +59,10 @@ const NAMED_ENTITY_RE = /&([a-zA-Z]+);/g;
 const NUMERIC_ENTITY_RE = /&#(\d+);/g;
 const HEX_ENTITY_RE = /&#x([0-9a-fA-F]+);/g;
 
-function decodeHtmlEntities(text: string): string {
+// Exported (web-jam-back#962) — the gig-announce caption HTML->text converter
+// (src/lib/caption-text.ts) needs the exact same TinyMCE-entity-decoding as
+// this module's name matching, so it reuses this rather than duplicating it.
+export function decodeHtmlEntities(text: string): string {
   return text
     .replace(HEX_ENTITY_RE, (_m, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
     .replace(NUMERIC_ENTITY_RE, (_m, dec: string) => String.fromCodePoint(parseInt(dec, 10)))

--- a/src/lib/meta-publish.ts
+++ b/src/lib/meta-publish.ts
@@ -1,0 +1,100 @@
+// src/lib/meta-publish.ts — web-jam-back#962
+//
+// Thin Graph API clients for the two POST /gig/:id/announce legs. Both use
+// plain `fetch` (Node 24 native), the same convention FacebookController
+// already uses for the read-only CollegeLutheran/WebJamLLC feed — trivially
+// mockable in tests via vi.spyOn(global, 'fetch'). Kept decoupled from
+// FacebookController's GRAPH constant/token-refresh machinery on purpose:
+// that flow reads via OAuth-refreshed page tokens stored in Mongo for
+// `pages_show_list`-style access; this is a one-time-per-announce WRITE using
+// its own long-lived tokens (see the two-config-per-leg env vars below),
+// Josh's deliberate simpler setup for this feature (#962 issue body).
+//
+// Config (Heroku config vars on webjamsalem, never committed):
+//   META_IG_USER_ID           — Instagram business/creator account id
+//   META_IG_ACCESS_TOKEN      — long-lived token w/ instagram_content_publish
+//   META_FB_PAGE_ID           — the Web Jam LLC Facebook Page id
+//   META_FB_PAGE_ACCESS_TOKEN — long-lived Page token w/ pages_manage_posts
+
+// Pinned Graph API version — mirrors FacebookController's FB_GRAPH_VERSION
+// choice (Meta supports each version 2+ years; bump when convenient).
+const GRAPH_VERSION = 'v20.0';
+const GRAPH = `https://graph.facebook.com/${GRAPH_VERSION}`;
+
+export interface LegResult { ok: boolean; id?: string; error?: string }
+
+interface GraphError { message?: string }
+interface GraphResponse { id?: string; error?: GraphError }
+
+async function postForm(url: string, params: Record<string, string>): Promise<GraphResponse> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(params).toString(),
+  });
+  return res.json() as Promise<GraphResponse>;
+}
+
+// Leg 1 — Instagram Content Publishing API: create a media container from the
+// public image URL + caption, then publish it (two Graph calls against the
+// IG-linked business/creator account). Never throws — every failure mode
+// (missing config, a Graph error, a network error) resolves to
+// `{ ok: false, error }` so a caller can run both legs with Promise.all and
+// have one leg's failure never affect the other.
+export async function publishToInstagram(caption: string, imageUrl: string): Promise<LegResult> {
+  const igUserId = process.env.META_IG_USER_ID;
+  const token = process.env.META_IG_ACCESS_TOKEN;
+  if (!igUserId || !token) {
+    return { ok: false, error: 'Instagram not configured: set META_IG_USER_ID and META_IG_ACCESS_TOKEN' };
+  }
+  try {
+    const container = await postForm(`${GRAPH}/${igUserId}/media`, {
+      image_url: imageUrl, caption, access_token: token,
+    });
+    if (container.error || !container.id) {
+      return { ok: false, error: container.error?.message || 'Instagram media container creation failed' };
+    }
+    const published = await postForm(`${GRAPH}/${igUserId}/media_publish`, {
+      creation_id: container.id, access_token: token,
+    });
+    if (published.error || !published.id) {
+      return { ok: false, error: published.error?.message || 'Instagram publish failed' };
+    }
+    return { ok: true, id: published.id };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+// Leg 2 — Facebook Pages API: post the image + caption straight to the Web Jam
+// LLC Page's feed via the `/photos` edge (the caption becomes the post
+// message). Same never-throws contract as publishToInstagram.
+export async function publishToFacebookPage(caption: string, imageUrl: string): Promise<LegResult> {
+  const pageId = process.env.META_FB_PAGE_ID;
+  const token = process.env.META_FB_PAGE_ACCESS_TOKEN;
+  if (!pageId || !token) {
+    return { ok: false, error: 'Facebook not configured: set META_FB_PAGE_ID and META_FB_PAGE_ACCESS_TOKEN' };
+  }
+  try {
+    const result = await postForm(`${GRAPH}/${pageId}/photos`, {
+      url: imageUrl, caption, access_token: token,
+    });
+    if (result.error || !result.id) return { ok: false, error: result.error?.message || 'Facebook post failed' };
+    return { ok: true, id: result.id };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+// True when NEITHER leg has ANY of its env vars set — the fresh-deploy case
+// where Josh hasn't done the manual Meta app/token setup yet (issue #962's
+// manual setup steps). The announce endpoint 500s outright in that case
+// (a clear "not configured" response) rather than returning two
+// per-leg "not configured" errors that read like a bug instead of a
+// not-yet-set-up feature. Partial configuration (one leg set, one not) is NOT
+// this case — it proceeds and lets the unconfigured leg fail on its own, same
+// as any other single-leg failure.
+export function isMetaFullyUnconfigured(): boolean {
+  return !process.env.META_IG_USER_ID && !process.env.META_IG_ACCESS_TOKEN
+    && !process.env.META_FB_PAGE_ID && !process.env.META_FB_PAGE_ACCESS_TOKEN;
+}

--- a/src/model/gig/gig-controller.ts
+++ b/src/model/gig/gig-controller.ts
@@ -1,11 +1,138 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import mongoose from 'mongoose';
+import { Request, Response } from 'express';
 import ArtistController from '../../lib/artist-controller.js';
 import gigModel from './gig-facade.js';
 import { Icontroller } from '../../lib/routeUtils.js';
+import userModel from '../user/user-facade.js';
+import { htmlCaptionToText } from '#src/lib/caption-text.js';
+import { publishToInstagram, publishToFacebookPage, isMetaFullyUnconfigured } from '#src/lib/meta-publish.js';
+
+// Role fallback for human admins who authorize by role (no privileges array).
+// Mirrors TemplateController/VenueController/PromoController (#819/#822).
+const ALLOWED_ROLES = ['JaM-admin', 'Developer'];
+const GIG_ANNOUNCE_CAPS = ['gig:announce'];
+
+interface AuthedUser { userType?: string; privileges?: string[] }
+type AuthRequest = Request & { user?: string };
+type AuthIdRequest = Request<{ id: string }> & { user?: string };
+type AuthzError = { status: number; message: string };
+type AuthzResult = AuthzError | null;
+
+interface AnnounceBody {
+  caption?: string;
+  imageUrl?: string;
+}
+
+interface GigDoc {
+  _id?: unknown;
+  promoImageUrl?: string;
+}
+
+// Privilege-first, role-fallback gate (mirrors VenueController/TemplateController).
+function checkAccess(user: AuthedUser, required: string[]): AuthzResult {
+  const privileges = user.privileges || [];
+  if (privileges.length) {
+    if (!privileges.some((p) => required.indexOf(p) !== -1)) {
+      return { status: 403, message: `missing ${required.join('/')} capability` };
+    }
+    return null;
+  }
+  if (ALLOWED_ROLES.indexOf(user.userType || '') === -1) {
+    return { status: 403, message: 'not authorized for gig announce' };
+  }
+  return null;
+}
+
+// Backend's own public base URL (mirrors subscriber-controller's/promo-
+// controller's selfBaseUrl) — used to build the default promo image's public
+// URL, since Meta's Graph API needs an absolute, publicly-fetchable one.
+function selfBaseUrl(req: Request): string {
+  const proto = process.env.NODE_ENV === 'production' ? /* istanbul ignore next */ 'https' : req.protocol;
+  return `${proto}://${req.get('host') ?? ''}`;
+}
+
+// Resolve the bundled default promo image (Josh & Maria's template footer
+// photo, reused here as the announce-endpoint's image-of-last-resort) on
+// disk. Mirrors template-controller's/outreach-controller's
+// resolveFooterAsset — the compiled controller runs from build/, where
+// copy:assets places the jpg; fall back to the source tree so an un-copied
+// dev build still finds it.
+function resolveDefaultPromoAsset(): string | null {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(here, '../template/assets', 'footer-josh-maria.jpg'),
+    path.resolve(process.cwd(), 'src/model/template/assets', 'footer-josh-maria.jpg'),
+  ];
+  return candidates.find((p) => fs.existsSync(p)) || /* istanbul ignore next */ null;
+}
 
 // Gigs are shared across artists (#885): reads scope by ?artist=, writes stamp
 // the artist and respect artist-scoped admins.
 class GigController extends ArtistController {
+  // Load the token's user, then apply the access gate. announce() runs
+  // ensureAuthenticated first (valid token -> req.user); this adds
+  // authorization on top, same pattern as TemplateController/VenueController.
+  async authorize(req: AuthRequest, required: string[]): Promise<AuthzResult> { // eslint-disable-line class-methods-use-this
+    let user: AuthedUser | null;
+    try { user = await userModel.findById(req.user || '') as unknown as AuthedUser | null; } catch (e) {
+      return { status: 500, message: (e as Error).message };
+    }
+    if (!user) return { status: 401, message: 'user not found' };
+    return checkAccess(user, required);
+  }
 
+  // GET /gig/promo-default.jpg — public, no auth (#962). Serves the bundled
+  // default promo image so Meta's Graph API can fetch a public URL for it
+  // when a gig has neither an explicit imageUrl nor its own promoImageUrl.
+  async getDefaultPromoImage(_req: Request, res: Response): Promise<unknown> { // eslint-disable-line class-methods-use-this
+    const assetPath = resolveDefaultPromoAsset();
+    if (!assetPath) return res.status(404).json({ message: 'default promo image not found' });
+    return res.sendFile(assetPath);
+  }
+
+  // POST /gig/:id/announce (#962) — publish an approved caption + image to
+  // Instagram and the Web Jam LLC Facebook Page. Body: { caption (TinyMCE
+  // HTML, required), imageUrl (optional) }. One leg failing never blocks the
+  // other (see meta-publish.ts's never-throws contract); on any leg success
+  // the gig's announcedAt is stamped/updated.
+  async announce(req: AuthIdRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, GIG_ANNOUNCE_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Find id is invalid' });
+
+    const body = (req.body || {}) as AnnounceBody;
+    if (!body.caption || !body.caption.trim()) return res.status(400).json({ message: 'caption is required' });
+
+    if (isMetaFullyUnconfigured()) {
+      return res.status(500).json({
+        message: 'Meta announce is not configured: set META_IG_USER_ID, META_IG_ACCESS_TOKEN, META_FB_PAGE_ID, META_FB_PAGE_ACCESS_TOKEN',
+      });
+    }
+
+    let gig: GigDoc | null;
+    try { gig = await this.model.findById(req.params.id) as unknown as GigDoc | null; } catch (e) {
+      return res.status(500).json({ message: (e as Error).message });
+    }
+    if (!gig) return res.status(400).json({ message: 'nothing found with id provided' });
+
+    const imageUrl = body.imageUrl || gig.promoImageUrl || `${selfBaseUrl(req)}/gig/promo-default.jpg`;
+    const captionText = htmlCaptionToText(body.caption);
+
+    const [instagram, facebook] = await Promise.all([
+      publishToInstagram(captionText, imageUrl),
+      publishToFacebookPage(captionText, imageUrl),
+    ]);
+
+    if (instagram.ok || facebook.ok) {
+      // Stamping failure shouldn't mask the publish result the caller cares about.
+      try { await this.model.findByIdAndUpdate(req.params.id, { announcedAt: new Date() }); } catch { /* ignore */ }
+    }
+
+    return res.status(200).json({ instagram, facebook });
+  }
 }
 
 export default new GigController(gigModel) as unknown as Icontroller;

--- a/src/model/gig/gig-router.ts
+++ b/src/model/gig/gig-router.ts
@@ -9,6 +9,27 @@ const router = express.Router();
 // unauthenticated WebJamSocketCluster `allGigs` channel). setRoot's GET handler
 // runs without ensureAuthenticated; POST/DELETE stay authenticated.
 routeUtils.setRoot(router, controller, authUtils);
+
+// GET /gig/promo-default.jpg is public, no auth (#962): it's the fallback
+// promo image for POST /gig/:id/announce, and Meta's Graph API must be able
+// to fetch it directly over plain HTTP(S) — the same "gigs are public"
+// rationale as GET /gig itself. Registered BEFORE byId's `/:id` below so this
+// literal path isn't swallowed by the `:id` param route (Express matches
+// same-depth routes in registration order).
+router.route('/promo-default.jpg')
+  .get((req, res) => { (async () => { await controller.getDefaultPromoImage(req, res); })(); });
+
+// POST /gig/:id/announce (#962) — admin-authed (ensureAuthenticated here, the
+// controller's own privilege/role gate on top, mirroring VenueController /
+// TemplateController). Registered before byId too; a different path depth
+// than `/:id` so ordering doesn't actually matter here, but keeping the two
+// `/:id/*` routes together reads clearer.
+router.route('/:id/announce')
+  .post((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'announce', controller, authUtils);
+    void action();
+  });
+
 routeUtils.byId(router, controller, authUtils);
 
 export default router;

--- a/src/model/gig/gig-schema.ts
+++ b/src/model/gig/gig-schema.ts
@@ -35,6 +35,10 @@ const gigSchema = new Schema({
   venueId: {
     type: Schema.Types.ObjectId, ref: 'Venue', required: false,
   },
+  // Stamped by POST /gig/:id/announce (#962) on any Instagram/Facebook leg
+  // success. Re-announcing later just overwrites the stamp — this is a "last
+  // announced" marker, not a history log.
+  announcedAt: { type: Date, required: false },
 }, options);
 
 export default mongoose.models.Gig || mongoose.model('Gig', gigSchema, 'gigs');

--- a/src/scripts/migrate-gig-venue-id.ts
+++ b/src/scripts/migrate-gig-venue-id.ts
@@ -11,6 +11,10 @@
 // prior --apply only touches what's still unlinked. Read-only DRY RUN by
 // default — prints exactly what it would change; pass --apply to write.
 //
+// Archived (soft-deleted) venues are excluded from the venue set entirely
+// (#964 follow-up) — an archived venue must never link a gig, nor be able to
+// make an otherwise-unambiguous active-venue name collide.
+//
 // SAFETY GUARD (mirrors scripts/restore-backup.mjs): this migration writes
 // venueId onto real gig history, so — unlike migrate-target-weekend.ts (which
 // is explicitly meant to eventually run against prod, protected only by its
@@ -71,7 +75,11 @@ async function run(): Promise<void> {
   console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
   console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
 
-  const venues = (await venueModel.find({})) as unknown as LinkableVenue[];
+  // Exclude archived (soft-deleted) venues from matching (#964 follow-up):
+  // an archived venue must never link a gig, nor create an ambiguous
+  // same-name collision against an active venue that should have matched
+  // cleanly.
+  const venues = (await venueModel.find({ status: { $ne: 'archived' } })) as unknown as LinkableVenue[];
   const nameIndex = buildUnambiguousNameIndex(venues);
 
   const candidates = (await gigModel.find({

--- a/test/unit/gig-router.spec.ts
+++ b/test/unit/gig-router.spec.ts
@@ -5,7 +5,7 @@ import authUtils from '#src/auth/authUtils.js';
 import request, { type ApiResponse } from '../helpers/api.js';
 
 describe('The Gig API', () => {
-  let r: ApiResponse, newUser: { _id: string; userType: string };
+  let r: ApiResponse, newUser: { _id: string; userType: string }, adminUser: { _id: string }, nonAdminUser: { _id: string };
   const allowedUrl = JSON.parse(process.env.AllowUrl || '{}').urls[0];
   beforeAll(async () => {
     await GigModel.deleteMany({});
@@ -16,6 +16,21 @@ describe('The Gig API', () => {
       userType: JSON.parse(process.env.AUTH_ROLES || '{}').user[0],
     }) as unknown as { _id: { toString(): string }; userType: string };
     newUser = { _id: createdUser._id.toString(), userType: createdUser.userType };
+    // #962 — announce is gated by GigController's own admin check (role
+    // fallback: JaM-admin/Developer), independent of AUTH_ROLES (which has no
+    // 'gig' entry — any authenticated user passes ensureAuthenticated for
+    // /gig/*, same as the CRUD tests above using the plain `user` role).
+    const createdAdmin = await userModel.create({
+      name: 'gig-admin', email: 'gig-admin@example.com', userType: 'JaM-admin',
+    }) as unknown as { _id: { toString(): string } };
+    adminUser = { _id: createdAdmin._id.toString() };
+    // A userType outside GigController's ALLOWED_ROLES (['JaM-admin',
+    // 'Developer']) — `newUser` above is 'Developer' (AUTH_ROLES.user[0]),
+    // which IS admin-allowed, so announce's 403 test needs its own account.
+    const createdNonAdmin = await userModel.create({
+      name: 'gig-non-admin', email: 'gig-non-admin@example.com', userType: 'plain-user',
+    }) as unknown as { _id: { toString(): string } };
+    nonAdminUser = { _id: createdNonAdmin._id.toString() };
   });
   beforeEach(async () => {
     await GigModel.deleteMany({});
@@ -73,6 +88,95 @@ describe('The Gig API', () => {
       .query({ city: 'Salem' });
     expect(r.status).toBe(200);
   });
+  it('serves the default promo image without auth (public, #962)', async () => {
+    r = await request(app)
+      .get('/gig/promo-default.jpg')
+      .set({ origin: allowedUrl });
+    expect(r.status).toBe(200);
+  });
+
+  describe('POST /gig/:id/announce (#962)', () => {
+    const META_ENV_KEYS = ['META_IG_USER_ID', 'META_IG_ACCESS_TOKEN', 'META_FB_PAGE_ID', 'META_FB_PAGE_ACCESS_TOKEN'] as const;
+    let originalEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      originalEnv = {};
+      for (const k of META_ENV_KEYS) originalEnv[k] = process.env[k];
+      process.env.META_IG_USER_ID = 'ig-user-1';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      process.env.META_FB_PAGE_ID = 'page-1';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+    });
+
+    afterEach(() => {
+      for (const k of META_ENV_KEYS) {
+        if (originalEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = originalEnv[k];
+      }
+      vi.restoreAllMocks();
+    });
+
+    it('401s without an Authorization header (routing wiring)', async () => {
+      const gig = await GigModel.create({ venue: 'Announce Venue' });
+      r = await request(app)
+        .post(`/gig/${gig._id}/announce`)
+        .set({ origin: allowedUrl })
+        .send({ caption: '<p>Hi</p>' });
+      expect(r.status).toBe(401);
+    });
+
+    it('403s a non-admin authenticated user (controller authorize wiring)', async () => {
+      const gig = await GigModel.create({ venue: 'Announce Venue' });
+      r = await request(app)
+        .post(`/gig/${gig._id}/announce`)
+        .set({ origin: allowedUrl })
+        .set('Authorization', `Bearer ${authUtils.createJWT({ _id: nonAdminUser._id })}`)
+        .send({ caption: '<p>Hi</p>' });
+      expect(r.status).toBe(403);
+    });
+
+    it('publishes both legs end-to-end (mocked Graph calls) and stamps announcedAt', async () => {
+      const gig = await GigModel.create({ venue: 'Announce Venue', promoImageUrl: 'https://example.com/promo.jpg' });
+      // Only intercept calls to Meta's Graph API — the api.ts test helper
+      // itself uses fetch() to hit the local ephemeral test server, and that
+      // MUST reach the real fetch or the request never actually happens.
+      // Both legs run concurrently (Promise.all in the controller), so match
+      // by URL shape rather than by call order.
+      const realFetch = global.fetch;
+      vi.spyOn(global, 'fetch').mockImplementation((url, init) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/media_publish')) return Promise.resolve({ json: () => Promise.resolve({ id: 'media-1' }) } as Response);
+        if (urlStr.includes('/media')) return Promise.resolve({ json: () => Promise.resolve({ id: 'container-1' }) } as Response);
+        if (urlStr.includes('/photos')) return Promise.resolve({ json: () => Promise.resolve({ id: 'photo-1' }) } as Response);
+        return realFetch(url, init);
+      });
+
+      r = await request(app)
+        .post(`/gig/${gig._id}/announce`)
+        .set({ origin: allowedUrl })
+        .set('Authorization', `Bearer ${authUtils.createJWT({ _id: adminUser._id })}`)
+        .send({ caption: '<p>Big show tonight!</p>' });
+
+      expect(r.status).toBe(200);
+      expect(r.body).toEqual({ instagram: { ok: true, id: 'media-1' }, facebook: { ok: true, id: 'photo-1' } });
+
+      const updated = await GigModel.findById(String(gig._id));
+      expect((updated as unknown as { announcedAt?: Date }).announcedAt).toBeTruthy();
+    });
+
+    it('500s with a clear message when Meta is fully unconfigured', async () => {
+      for (const k of META_ENV_KEYS) delete process.env[k];
+      const gig = await GigModel.create({ venue: 'Announce Venue' });
+      r = await request(app)
+        .post(`/gig/${gig._id}/announce`)
+        .set({ origin: allowedUrl })
+        .set('Authorization', `Bearer ${authUtils.createJWT({ _id: adminUser._id })}`)
+        .send({ caption: '<p>Hi</p>' });
+      expect(r.status).toBe(500);
+      expect(r.body.message).toContain('META_IG_USER_ID');
+    });
+  });
+
   it('should wait unit tests finish before exiting', async () => { // eslint-disable-line vitest/expect-expect
     // eslint-disable-next-line no-promise-executor-return
     const delay = (ms: number) => new Promise((resolve) => setTimeout(() => resolve(true), ms));

--- a/test/unit/gig/gig-announce-controller.spec.ts
+++ b/test/unit/gig/gig-announce-controller.spec.ts
@@ -1,0 +1,244 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Unit tests for POST /gig/:id/announce and GET /gig/promo-default.jpg (#962).
+// The Meta Graph API clients are mocked at the module boundary — meta-publish
+// itself (mocked HTTP) is covered separately in test/unit/lib/meta-publish.spec.ts.
+// NEVER a real network/Meta call here, per the repo's hard safety rule.
+import mongoose from 'mongoose';
+import fs from 'fs';
+import controller from '#src/model/gig/gig-controller.js';
+import userModel from '#src/model/user/user-facade.js';
+import * as metaPublish from '#src/lib/meta-publish.js';
+
+vi.mock('#src/lib/meta-publish.js', () => ({
+  publishToInstagram: vi.fn(),
+  publishToFacebookPage: vi.fn(),
+  isMetaFullyUnconfigured: vi.fn(() => false),
+}));
+
+const c = controller as any;
+const mp = metaPublish as any;
+
+describe('GigController — announce (#962)', () => {
+  let status = 0;
+  let payload: any;
+  const resStub: any = {
+    status: (s: number) => {
+      status = s;
+      return { json: (obj: any) => { payload = obj; return obj; } };
+    },
+  };
+
+  // Default: an admin identity holding the announce capability.
+  const asAgent = (privileges = ['gig:announce']) => {
+    (userModel as any).findById = vi.fn(() => Promise.resolve({ privileges }));
+  };
+
+  beforeEach(() => {
+    status = 0;
+    payload = undefined;
+    asAgent();
+    mp.isMetaFullyUnconfigured.mockReturnValue(false);
+    mp.publishToInstagram.mockResolvedValue({ ok: true, id: 'ig-1' });
+    mp.publishToFacebookPage.mockResolvedValue({ ok: true, id: 'fb-1' });
+  });
+
+  describe('authorize', () => {
+    it('403s when the capability is missing', async () => {
+      asAgent(['unrelated:cap']);
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({
+        user: 'a', params: { id }, body: { caption: '<p>Hi</p>' },
+      }, resStub);
+      expect(status).toBe(403);
+      expect(payload.message).toContain('gig:announce');
+    });
+
+    it('401s when the user is not found', async () => {
+      (userModel as any).findById = vi.fn(() => Promise.resolve(null));
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(401);
+    });
+
+    it('500s when the user lookup itself errors', async () => {
+      (userModel as any).findById = vi.fn(() => Promise.reject(new Error('db down')));
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('403s a privilege-less user whose role is not in the admin allow-list', async () => {
+      (userModel as any).findById = vi.fn(() => Promise.resolve({ userType: 'user', privileges: [] }));
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(403);
+      expect(payload.message).toContain('not authorized for gig announce');
+    });
+
+    it('allows a privilege-less admin via role fallback', async () => {
+      (userModel as any).findById = vi.fn(() => Promise.resolve({ userType: 'JaM-admin', privileges: [] }));
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({ _id: id }));
+      await c.announce({
+        user: 'a', params: { id }, body: { caption: 'Hi' }, protocol: 'http', get: () => 'localhost',
+      }, resStub);
+      expect(status).toBe(200);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects an invalid id', async () => {
+      await c.announce({ user: 'a', params: { id: 'nope' }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('invalid');
+    });
+
+    it('rejects a missing caption', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: {} }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('caption is required');
+    });
+
+    it('rejects a blank caption', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: { caption: '   ' } }, resStub);
+      expect(status).toBe(400);
+    });
+
+    it('500s with a clear message when Meta is fully unconfigured', async () => {
+      mp.isMetaFullyUnconfigured.mockReturnValue(true);
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(500);
+      expect(payload.message).toContain('META_IG_USER_ID');
+      expect(payload.message).toContain('META_FB_PAGE_ACCESS_TOKEN');
+      expect(mp.publishToInstagram).not.toHaveBeenCalled();
+    });
+
+    it('500s when the gig lookup errors', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(500);
+    });
+
+    it('400s when the gig does not exist', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve(null));
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(400);
+    });
+  });
+
+  describe('image fallback chain', () => {
+    const req = (id: string, body: any) => ({
+      user: 'a', params: { id }, body, protocol: 'http', get: (h: string) => (h === 'host' ? 'localhost:7000' : undefined),
+    });
+
+    it('prefers an explicit body.imageUrl', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
+      await c.announce(req(id, { caption: 'Hi', imageUrl: 'https://explicit.example/img.jpg' }), resStub);
+      expect(mp.publishToInstagram).toHaveBeenCalledWith(expect.any(String), 'https://explicit.example/img.jpg');
+      expect(mp.publishToFacebookPage).toHaveBeenCalledWith(expect.any(String), 'https://explicit.example/img.jpg');
+    });
+
+    it('falls back to the gig promoImageUrl when no imageUrl given', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
+      await c.announce(req(id, { caption: 'Hi' }), resStub);
+      expect(mp.publishToInstagram).toHaveBeenCalledWith(expect.any(String), 'https://gig.example/promo.jpg');
+    });
+
+    it('falls back to the default promo image URL when neither is set', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
+      await c.announce(req(id, { caption: 'Hi' }), resStub);
+      expect(mp.publishToInstagram).toHaveBeenCalledWith(expect.any(String), 'http://localhost:7000/gig/promo-default.jpg');
+    });
+  });
+
+  describe('caption conversion', () => {
+    it('converts the TinyMCE HTML caption to plain text before publishing', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.resolve({}));
+      await c.announce({
+        user: 'a', params: { id }, body: { caption: '<p>Big show <a href="https://x.example">tonight</a>!</p>' },
+      }, resStub);
+      expect(mp.publishToInstagram).toHaveBeenCalledWith('Big show https://x.example!', expect.any(String));
+      expect(mp.publishToFacebookPage).toHaveBeenCalledWith('Big show https://x.example!', expect.any(String));
+    });
+  });
+
+  describe('per-leg isolation + announcedAt stamping', () => {
+    it('stamps announcedAt when both legs succeed', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      const upd = vi.fn(() => Promise.resolve({}));
+      c.model.findByIdAndUpdate = upd;
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toEqual({ instagram: { ok: true, id: 'ig-1' }, facebook: { ok: true, id: 'fb-1' } });
+      expect(upd).toHaveBeenCalledWith(id, { announcedAt: expect.any(Date) });
+    });
+
+    it('reports partial failure without failing the request, and still stamps on one success', async () => {
+      mp.publishToInstagram.mockResolvedValue({ ok: false, error: 'token expired' });
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      const upd = vi.fn(() => Promise.resolve({}));
+      c.model.findByIdAndUpdate = upd;
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.instagram).toEqual({ ok: false, error: 'token expired' });
+      expect(payload.facebook).toEqual({ ok: true, id: 'fb-1' });
+      expect(upd).toHaveBeenCalled();
+    });
+
+    it('does not stamp announcedAt when both legs fail', async () => {
+      mp.publishToInstagram.mockResolvedValue({ ok: false, error: 'down' });
+      mp.publishToFacebookPage.mockResolvedValue({ ok: false, error: 'down' });
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      const upd = vi.fn(() => Promise.resolve({}));
+      c.model.findByIdAndUpdate = upd;
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload).toEqual({ instagram: { ok: false, error: 'down' }, facebook: { ok: false, error: 'down' } });
+      expect(upd).not.toHaveBeenCalled();
+    });
+
+    it('never lets a stamping failure mask the publish result', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      c.model.findById = vi.fn(() => Promise.resolve({ _id: id, promoImageUrl: 'https://gig.example/promo.jpg' }));
+      c.model.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('stamp write failed')));
+      await c.announce({ user: 'a', params: { id }, body: { caption: 'Hi' } }, resStub);
+      expect(status).toBe(200);
+      expect(payload.instagram.ok).toBe(true);
+      expect(payload.facebook.ok).toBe(true);
+    });
+  });
+
+  describe('getDefaultPromoImage', () => {
+    it('serves the bundled asset via sendFile', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      const sendFile = vi.fn();
+      await c.getDefaultPromoImage({}, { ...resStub, sendFile });
+      expect(sendFile).toHaveBeenCalled();
+      vi.restoreAllMocks();
+    });
+
+    it('404s when the asset is missing on disk', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      await c.getDefaultPromoImage({}, resStub);
+      expect(status).toBe(404);
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/test/unit/lib/caption-text.spec.ts
+++ b/test/unit/lib/caption-text.spec.ts
@@ -1,0 +1,49 @@
+// Unit tests for the gig-announce caption HTML->text converter (#962).
+import { htmlCaptionToText } from '#src/lib/caption-text.js';
+
+describe('htmlCaptionToText (#962)', () => {
+  it('handles empty/missing input', () => {
+    expect(htmlCaptionToText('')).toBe('');
+    expect(htmlCaptionToText(undefined as unknown as string)).toBe('');
+  });
+
+  it('keeps paragraph breaks between <p> blocks', () => {
+    const html = '<p>First line.</p><p>Second line.</p>';
+    expect(htmlCaptionToText(html)).toBe('First line.\n\nSecond line.');
+  });
+
+  it('turns <br> into a single newline within a paragraph', () => {
+    const html = '<p>Line one<br>Line two</p>';
+    expect(htmlCaptionToText(html)).toBe('Line one\nLine two');
+  });
+
+  it('flattens a link down to its raw href, discarding the link text', () => {
+    const html = '<p>Tickets at <a href="https://example.com/tix" target="_blank" rel="noopener">this link</a>!</p>';
+    expect(htmlCaptionToText(html)).toBe('Tickets at https://example.com/tix!');
+  });
+
+  it('drops inline styling tags without losing the text', () => {
+    const html = '<p><strong>Bold</strong> and <em>italic</em> and <span style="color:red">colored</span> text.</p>';
+    expect(htmlCaptionToText(html)).toBe('Bold and italic and colored text.');
+  });
+
+  it('decodes HTML entities (&amp;, numeric, hex)', () => {
+    const html = "<p>Josh &amp; Maria play at Tom&#39;s Bar &#x2014; come on out!</p>";
+    expect(htmlCaptionToText(html)).toBe("Josh & Maria play at Tom's Bar — come on out!");
+  });
+
+  it('collapses 3+ consecutive breaks down to one paragraph break', () => {
+    const html = '<p>First</p><br><br><p>Second</p>';
+    expect(htmlCaptionToText(html)).toBe('First\n\nSecond');
+  });
+
+  it('handles a list, treating each <li> as its own line', () => {
+    const html = '<ul><li>One</li><li>Two</li></ul>';
+    expect(htmlCaptionToText(html)).toBe('One\n\nTwo');
+  });
+
+  it('trims leading/trailing whitespace from the final result', () => {
+    const html = '  <p>  Padded  </p>  ';
+    expect(htmlCaptionToText(html)).toBe('Padded');
+  });
+});

--- a/test/unit/lib/meta-publish.spec.ts
+++ b/test/unit/lib/meta-publish.spec.ts
@@ -1,0 +1,172 @@
+// Unit tests for the gig-announce Meta Graph API clients (#962). Every test
+// mocks global.fetch — NEVER a real network call to Meta, per the repo's hard
+// safety rule for this feature.
+import {
+  publishToInstagram, publishToFacebookPage, isMetaFullyUnconfigured,
+} from '#src/lib/meta-publish.js';
+
+const ENV_KEYS = ['META_IG_USER_ID', 'META_IG_ACCESS_TOKEN', 'META_FB_PAGE_ID', 'META_FB_PAGE_ACCESS_TOKEN'] as const;
+
+describe('meta-publish (#962)', () => {
+  let original: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    original = {};
+    for (const k of ENV_KEYS) { original[k] = process.env[k]; delete process.env[k]; }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (original[k] === undefined) delete process.env[k];
+      else process.env[k] = original[k];
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe('isMetaFullyUnconfigured', () => {
+    it('is true when no env var is set', () => {
+      expect(isMetaFullyUnconfigured()).toBe(true);
+    });
+
+    it('is false when only the Instagram pair is set', () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      expect(isMetaFullyUnconfigured()).toBe(false);
+    });
+
+    it('is false when only the Facebook pair is set', () => {
+      process.env.META_FB_PAGE_ID = 'page-id';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+      expect(isMetaFullyUnconfigured()).toBe(false);
+    });
+  });
+
+  describe('publishToInstagram', () => {
+    it('errors clearly when not configured, without calling fetch', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch');
+      const result = await publishToInstagram('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: expect.stringContaining('META_IG_USER_ID') });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('creates a media container then publishes it (two calls)', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      const fetchSpy = vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 'container-1' }) } as Response)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 'media-1' }) } as Response);
+
+      const result = await publishToInstagram('Great show tonight!', 'https://example.com/img.jpg');
+
+      expect(result).toEqual({ ok: true, id: 'media-1' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const firstUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(firstUrl).toContain('/ig-user/media');
+      const secondUrl = fetchSpy.mock.calls[1][0] as string;
+      expect(secondUrl).toContain('/ig-user/media_publish');
+    });
+
+    it('surfaces a Graph error on container creation without attempting publish', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      const fetchSpy = vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ error: { message: 'bad image url' } }) } as Response);
+
+      const result = await publishToInstagram('caption', 'not-a-real-url');
+
+      expect(result).toEqual({ ok: false, error: 'bad image url' });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a Graph error on the publish step', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 'container-1' }) } as Response)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ error: { message: 'token expired' } }) } as Response);
+
+      const result = await publishToInstagram('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'token expired' });
+    });
+
+    it('catches a network exception as a leg failure, never throwing', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+      const result = await publishToInstagram('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'network down' });
+    });
+
+    it('falls back to a generic message when the container response has neither error nor id', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce({ json: () => Promise.resolve({}) } as Response);
+
+      const result = await publishToInstagram('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'Instagram media container creation failed' });
+    });
+
+    it('falls back to a generic message when the publish response has neither error nor id', async () => {
+      process.env.META_IG_USER_ID = 'ig-user';
+      process.env.META_IG_ACCESS_TOKEN = 'ig-token';
+      vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 'container-1' }) } as Response)
+        .mockResolvedValueOnce({ json: () => Promise.resolve({}) } as Response);
+
+      const result = await publishToInstagram('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'Instagram publish failed' });
+    });
+  });
+
+  describe('publishToFacebookPage', () => {
+    it('errors clearly when not configured, without calling fetch', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch');
+      const result = await publishToFacebookPage('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: expect.stringContaining('META_FB_PAGE_ID') });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('posts the image + caption to the page photos edge', async () => {
+      process.env.META_FB_PAGE_ID = 'page-id';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+      const fetchSpy = vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 'photo-1' }) } as Response);
+
+      const result = await publishToFacebookPage('Great show tonight!', 'https://example.com/img.jpg');
+
+      expect(result).toEqual({ ok: true, id: 'photo-1' });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/page-id/photos');
+    });
+
+    it('surfaces a Graph error', async () => {
+      process.env.META_FB_PAGE_ID = 'page-id';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+      vi.spyOn(global, 'fetch')
+        .mockResolvedValueOnce({ json: () => Promise.resolve({ error: { message: 'permission denied' } }) } as Response);
+
+      const result = await publishToFacebookPage('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'permission denied' });
+    });
+
+    it('catches a network exception as a leg failure, never throwing', async () => {
+      process.env.META_FB_PAGE_ID = 'page-id';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+      const result = await publishToFacebookPage('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'network down' });
+    });
+
+    it('falls back to a generic message when the response has neither error nor id', async () => {
+      process.env.META_FB_PAGE_ID = 'page-id';
+      process.env.META_FB_PAGE_ACCESS_TOKEN = 'page-token';
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce({ json: () => Promise.resolve({}) } as Response);
+
+      const result = await publishToFacebookPage('caption', 'https://example.com/img.jpg');
+      expect(result).toEqual({ ok: false, error: 'Facebook post failed' });
+    });
+  });
+});

--- a/test/unit/scripts/migrate-gig-venue-id.spec.ts
+++ b/test/unit/scripts/migrate-gig-venue-id.spec.ts
@@ -1,7 +1,12 @@
 // Unit tests for the #958 migration script's pure logic. Importing the module
 // must NOT touch Mongo or process.exit (no top-level side effects beyond
 // dotenv) — run()'s isMain guard is never true under vitest.
-import { isSafeToRun, parseArgs } from '#src/scripts/migrate-gig-venue-id.js';
+import mongoose from 'mongoose';
+import {
+  isSafeToRun, parseArgs, run,
+} from '#src/scripts/migrate-gig-venue-id.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+import gigModel from '#src/model/gig/gig-facade.js';
 
 describe('migrate-gig-venue-id (#958)', () => {
   describe('parseArgs', () => {
@@ -35,6 +40,67 @@ describe('migrate-gig-venue-id (#958)', () => {
 
     it('allows a prod-looking db name when --force is passed', () => {
       expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+
+  // web-jam-back#964 follow-up (Josh-approved, folded into #962's PR) — the
+  // venue fetch must exclude archived venues, so an archived venue can
+  // neither link a gig nor create an ambiguous same-name collision against an
+  // active venue that should have matched cleanly. Everything Mongo-shaped is
+  // mocked via vi.spyOn and fully restored afterEach — this repo's other spec
+  // files share these same facade singletons in the same test process
+  // (fileParallelism: false), so a leaked mock here would break them.
+  describe('run() — archived venue exclusion', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      process.argv = ['node', 'migrate-gig-venue-id.js']; // no --apply, no --force
+      process.env.MONGO_DB_URI = 'mongodb://localhost:27017/web-jam-test';
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    it('excludes an archived venue from matching (no link, no ambiguity vs. the active same-named venue)', async () => {
+      const activeId = new mongoose.Types.ObjectId().toString();
+      const archivedId = new mongoose.Types.ObjectId().toString();
+      const gigId = new mongoose.Types.ObjectId().toString();
+
+      vi.spyOn(mongoose, 'connect').mockResolvedValue(undefined as unknown as typeof mongoose);
+      vi.spyOn(mongoose.connection, 'close').mockResolvedValue(undefined);
+
+      // Stands in for Mongo's own filtering: only excludes the archived venue
+      // when called with the exact status filter the fixed code now passes —
+      // this test would fail against the pre-fix `find({})` call.
+      const findSpy = vi.spyOn(venueModel, 'find').mockImplementation((filter: unknown) => {
+        const all = [
+          { _id: activeId, name: 'The Spot' },
+          { _id: archivedId, name: 'The Spot' },
+        ];
+        const f = filter as { status?: { $ne?: string } } | undefined;
+        if (f?.status?.$ne === 'archived') return Promise.resolve([all[0]]);
+        return Promise.resolve(all);
+      });
+      vi.spyOn(gigModel, 'find').mockResolvedValue([{ _id: gigId, venue: 'The Spot' }]);
+      const updateSpy = vi.spyOn(gigModel, 'findByIdAndUpdate').mockResolvedValue({});
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await run();
+
+      expect(findSpy).toHaveBeenCalledWith({ status: { $ne: 'archived' } });
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('matched exactly one venue'),
+      );
+      expect(summary).toContain('1 matched exactly one venue by name');
+      expect(summary).toContain('0 left unlinked');
+      expect(updateSpy).not.toHaveBeenCalled(); // dry run — no --apply
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `POST /gig/:id/announce`: admin-authed endpoint that publishes an approved caption + image to Instagram and the Web Jam LLC Facebook Page. Auth mirrors `TemplateController`/`VenueController`'s privilege-first, role-fallback (`JaM-admin`/`Developer`) pattern — ensureAuthenticated on the route, a dedicated `authorize()` gate (capability `gig:announce`) in `GigController`.
- New `src/lib/caption-text.ts` converts the TinyMCE `caption` HTML to plain text: keeps paragraph/`<br>` breaks, flattens `<a href>` links to their raw URL, drops all styling. Reuses `decodeHtmlEntities` (now exported) from `src/lib/gig-venue-link.ts` (#964) rather than duplicating entity-decoding.
- New `src/lib/meta-publish.ts`: thin Graph API clients for both legs (`fetch`-based, same convention as `FacebookController`). Each leg never throws — a failure resolves to `{ ok: false, error }` so `Promise.all` lets one leg's failure never block the other. Response shape: `{ instagram: {ok, id|error}, facebook: {ok, id|error} }`.
- Image fallback chain: body `imageUrl` -> gig's `promoImageUrl` -> a new public `GET /gig/promo-default.jpg` route serving the existing `footer-josh-maria.jpg` template asset (registered before the `/:id` param route so it isn't swallowed).
- On any leg success, stamps `announcedAt: Date` on the gig (new optional `gig-schema` field); re-announcing just updates the stamp. A stamping-write failure never masks the publish result already computed.
- Env vars (Heroku config vars on webjamsalem, never committed): `META_IG_USER_ID`, `META_IG_ACCESS_TOKEN` (Instagram leg — `instagram_content_publish`), `META_FB_PAGE_ID`, `META_FB_PAGE_ACCESS_TOKEN` (Facebook leg — `pages_manage_posts`). If NONE of the four are set, the endpoint 500s with a clear message naming all four; partial configuration lets the unconfigured leg fail on its own like any other leg failure.
- **Rider (Josh-approved #964 follow-up, folded into this PR):** `src/scripts/migrate-gig-venue-id.ts`'s venue query now excludes archived venues (`status: { $ne: 'archived' }`), plus a unit test proving an archived venue neither links a gig nor creates ambiguity against an active same-named venue.
- Version bump: `2.3.7` -> `2.4.0` (new feature endpoint), on this PR's first commit only.

Part of #962

## How to test locally
Local (all mocked — no real Meta/network calls, per the issue's hard safety rule):
```sh
npm test
```
Expect: `eslint ./src` clean, `jscpd` unchanged (28 pre-existing clones, none new), `typecheck` clean, and `vitest run --coverage` green (697/697) with coverage above the 90/90/80/80 gate.

Post-deploy (requires Josh's manual Meta app/token setup from the issue body — create a dedicated Meta dev app, add Instagram Graph API + Pages products, confirm the IG account is Business/Creator and Page-linked, generate + save the two long-lived tokens to KeePass, set all four `META_*` Heroku config vars):
```sh
curl -X POST https://webjamsalem.herokuapp.com/gig/GIG_ID_HERE/announce \
  -H 'Authorization: Bearer ADMIN_TOKEN_HERE' \
  -H 'Content-Type: application/json' \
  -d '{"caption": "Big show Friday night, come on out!", "imageUrl": "https://example.com/promo.jpg"}'
```
Expect `200` with both legs reporting success, e.g.:
```json
{ "instagram": { "ok": true, "id": "IG_MEDIA_ID" }, "facebook": { "ok": true, "id": "FB_POST_ID" } }
```
and the gig's `announcedAt` stamped in Mongo. Note: the IG -> joshua.v.sherman personal-FB/Threads auto-share fan-out is intentionally unverifiable until this first real announce — do not attempt to test that part.

## Test evidence
```
> web-jam-back@2.4.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

(eslint ./src: no output — clean)

> web-jam-back@2.4.0 jscpd
> jscpd src
... 28 clones found (260/7080 lines, 3.67%; 2593/48028 tokens, 5.40%) — same pre-existing clones as on dev, none new from this PR's files.

> web-jam-back@2.4.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
(no output — clean)

> web-jam-back@2.4.0 test:unit
> vitest run --coverage
...
 Test Files  46 passed (46)
      Tests  697 passed (697)
   Duration  47.56s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
All files          |   92.93 |    86.79 |   88.22 |   93.65 |
 src/model/gig     |     100 |    86.66 |     100 |     100 |
-------------------|---------|----------|---------|---------|
Statements   : 92.93% ( 2264/2436 )
Branches     : 86.79% ( 1407/1621 )
Functions    : 88.22% ( 352/399 )
Lines        : 93.65% ( 1873/2000 )
```

🤖 Work by Claude Code — Sonnet 5