### PR TITLE
Remove inScope from the venue model (consolidated into outreachEligible + doNotContact)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -22,6 +22,7 @@
     "seed:outreach": "node scripts/seed-outreach.mjs",
     "migrate:target-weekend": "node build/src/scripts/migrate-target-weekend.js",
     "migrate:gig-venue-id": "node build/src/scripts/migrate-gig-venue-id.js",
+    "migrate:drop-in-scope": "node build/src/scripts/migrate-drop-in-scope.js",
     "restore:backup": "node scripts/restore-backup.mjs",
     "ts-watch": "tsc -w",
     "ts-start": "DEBUG=web-jam-back:* node --watch --trace-deprecation build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -49,7 +49,6 @@ interface VenueBody {
   website?: string;
   status?: string;
   outreachEligible?: boolean;
-  inScope?: boolean;
   bookingStatus?: string;
   interested?: boolean;
   payTier?: string;
@@ -244,11 +243,10 @@ class VenueController extends Controller {
     if (typeof query.venueType === 'string') filter.venueType = query.venueType;
     // Outreach targeting (#843): ?outreachEligible=true returns only vetted
     // venues — the pool #844's approval flow proposes from. The vetting tags
-    // below filter the candidate set further (in-scope, still booking, interested).
+    // below filter the candidate set further (still booking, interested).
+    // (`inScope` filter support was dropped with the field itself — #954.)
     if (query.outreachEligible === 'true') filter.outreachEligible = true;
     else if (query.outreachEligible === 'false') filter.outreachEligible = false;
-    if (query.inScope === 'true') filter.inScope = true;
-    else if (query.inScope === 'false') filter.inScope = false;
     if (typeof query.bookingStatus === 'string') filter.bookingStatus = query.bookingStatus;
     if (query.interested === 'true') filter.interested = true;
     else if (query.interested === 'false') filter.interested = false;

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -96,15 +96,18 @@ const venueSchema = new Schema({
   // Vetting/disqualification tags (#843) — the data a human uses to decide
   // outreachEligible, and that the selection logic (#844) checks. Derived from
   // the criteria review of the 5 mis-sent venues:
-  // - inScope: is this a gig-booking venue at all? false = anthem/other (Salem
-  //   Red Sox, ODAC Tournament) — never a target.
   // - bookingStatus: `booking` = open to booking; `not-booking` = closed / new
   //   management that stopped (Radford); `booked` = currently full (Olde Salem).
   // - interested: false = not worth pursuing (pay too low / declined — Harrisonburg).
   // - payTier: free-text pay note. lastVerified: when the info was last checked
   //   (stale venues get re-verified). contactVerified: is the contact confirmed
   //   correct (Olde Salem went to the wrong person).
-  inScope: { type: Boolean, required: false, default: true },
+  //
+  // `inScope` (was: is this a gig-booking venue at all?) was dropped (#954,
+  // 2026-07-16) — it read as a duplicate of `outreachEligible` and Josh only
+  // ever used Eligible. A venue that was `inScope: false` is permanently
+  // excluded via `doNotContact` instead (see below) — see migrate-drop-in-
+  // scope.ts for the one-time backfill.
   bookingStatus: {
     type: String, required: false, enum: ['booking', 'not-booking', 'booked'], default: 'booking',
   },

--- a/src/scripts/migrate-drop-in-scope.ts
+++ b/src/scripts/migrate-drop-in-scope.ts
@@ -1,0 +1,144 @@
+// src/scripts/migrate-drop-in-scope.ts — web-jam-back#954
+//
+// One-time backfill for dropping the `inScope` venue field entirely (it read
+// as a duplicate of `outreachEligible` — Josh only ever used Eligible, #954).
+// For every venue that still has an `inScope` field:
+//   - `inScope: false` (the ballpark/farmer's-market crowd, e.g. Salem Red
+//     Sox, ODAC Tournament) -> `doNotContact: true` (PERMANENT exclusion from
+//     /outreach/candidates, #923) AND the `inScope` field is removed. The
+//     venue stays visible/active — this is NOT an archive.
+//   - `inScope: true` (or missing) -> just has the `inScope` field removed;
+//     `doNotContact` is left untouched.
+//
+// Archived venues ARE included in this sweep (deliberately, unlike
+// migrate-gig-venue-id.ts's venue query, which excludes archived venues for a
+// DIFFERENT reason — avoiding ambiguous gig-name matches). An archived venue
+// may be unarchived later, and if it was `inScope: false` it should come back
+// permanently excluded via `doNotContact`, not silently back in scope.
+//
+// Idempotent: only venues where `inScope` still exists are candidates, so a
+// re-run after a prior --apply is a no-op (the field is gone). Read-only DRY
+// RUN by default — prints exactly what it would change; pass --apply to write.
+//
+// SAFETY GUARD (mirrors migrate-gig-venue-id.ts): this migration permanently
+// flips doNotContact on real venue records, so it refuses to run at all
+// against anything that doesn't look like local/DEV/TEST (db name containing
+// 'dev'/'test', or localhost/127.0.0.1) unless --force is passed. Running it
+// for real against prod is a deliberate act, run manually post-merge with
+// Josh's explicit go (e.g. `heroku run "npm run migrate:drop-in-scope --
+// --force" -a webjamsalem` for the dry run, then `--force --apply` to write)
+// — never wired into build/postinstall/Procfile/CI.
+//
+// Usage:
+//   npm run migrate:drop-in-scope                    # dry run against DEV/local
+//   npm run migrate:drop-in-scope -- --apply          # writes, DEV/local only
+//   npm run migrate:drop-in-scope -- --force --apply  # writes for real (prod)
+
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+config(); // load .env if present
+
+interface Args { apply: boolean; force: boolean }
+export function parseArgs(argv: string[]): Args {
+  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
+}
+
+// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
+// Mirrors migrate-gig-venue-id.ts's guard exactly: only db names/hosts that
+// look local/DEV/TEST are allowed without --force. Pure predicate (no
+// process.exit) so it's unit-testable; run() below is what actually exits.
+export function isSafeToRun(uri: string, force: boolean): boolean {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+  return isLocal || isDevOrTest || force;
+}
+
+interface VenueDoc { _id: unknown; name?: string; inScope?: boolean }
+
+function logSafetyBlock(uri: string, maskedUri: string): void {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  console.error('ERROR: migrate-drop-in-scope only runs against a local, DEV, or TEST database by default — never release/production.');
+  console.error(`Target MONGO URI: ${maskedUri}`);
+  console.error(`Parsed database name: ${dbName || '(none)'}`);
+  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
+}
+
+// Build the Mongo update for one venue + a human-readable plan/write label.
+// `inScope: false` permanently flips doNotContact (and the field is always
+// unset); `inScope: true` (or missing) just loses the field.
+function buildVenueUpdate(venue: VenueDoc, apply: boolean): { update: Record<string, unknown>; label: string; wasOutOfScope: boolean } {
+  const wasOutOfScope = venue.inScope === false;
+  const verb = apply ? 'WRITE' : 'PLAN';
+  if (wasOutOfScope) {
+    return {
+      update: { $unset: { inScope: '' }, $set: { doNotContact: true } },
+      label: `${verb}: venue ${String(venue._id)} "${venue.name}" inScope:false -> doNotContact:true (inScope removed)`,
+      wasOutOfScope: true,
+    };
+  }
+  return {
+    update: { $unset: { inScope: '' } },
+    label: `${verb}: venue ${String(venue._id)} "${venue.name}" inScope removed (no other change)`,
+    wasOutOfScope: false,
+  };
+}
+
+async function run(): Promise<void> {
+  const { apply, force } = parseArgs(process.argv.slice(2));
+  const uri = process.env.MONGO_DB_URI || '';
+  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
+  if (!isSafeToRun(uri, force)) {
+    logSafetyBlock(uri, maskedUri);
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
+  console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
+
+  // Idempotent: only venues that still carry the field are candidates. Deliberately
+  // NOT scoped to status != archived — an archived venue may be unarchived later
+  // and should come back permanently excluded (doNotContact), not silently
+  // back in scope (#954).
+  const candidates = (await venueModel.find({
+    inScope: { $exists: true },
+  })) as unknown as VenueDoc[];
+
+  let flippedToDoNotContact = 0;
+  let applied = 0;
+  for (const venue of candidates) {
+    const { update, label, wasOutOfScope } = buildVenueUpdate(venue, apply);
+    if (wasOutOfScope) flippedToDoNotContact += 1;
+    console.log(`  ${label}`);
+    if (apply) {
+      // eslint-disable-next-line no-await-in-loop
+      await venueModel.findByIdAndUpdate(String(venue._id), update);
+      applied += 1;
+    }
+  }
+  const fieldOnlyRemoved = candidates.length - flippedToDoNotContact;
+
+  console.log(`\n${candidates.length} venue(s) scanned (still had inScope); `
+    + `${flippedToDoNotContact} were inScope:false (-> doNotContact:true); ${fieldOnlyRemoved} just lose the field.`);
+  console.log(apply
+    ? `${applied} venue(s) updated.`
+    : `Dry run — ${candidates.length} venue(s) WOULD be updated. Re-run with --apply to write for real.`);
+
+  await mongoose.connection.close();
+}
+
+// Only auto-execute when run directly — NOT when imported by a unit test.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+/* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
+if (isMain) {
+  run().catch((err) => {
+    console.error('Migration failed:', (err as Error).message);
+    process.exit(1);
+  });
+}
+
+export { run };

--- a/test/unit/scripts/migrate-drop-in-scope.spec.ts
+++ b/test/unit/scripts/migrate-drop-in-scope.spec.ts
@@ -1,0 +1,149 @@
+// Unit tests for the #954 migration script's logic. Importing the module
+// must NOT touch Mongo or process.exit (no top-level side effects beyond
+// dotenv) — run()'s isMain guard is never true under vitest.
+import mongoose from 'mongoose';
+import {
+  isSafeToRun, parseArgs, run,
+} from '#src/scripts/migrate-drop-in-scope.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+describe('migrate-drop-in-scope (#954)', () => {
+  describe('parseArgs', () => {
+    it('reads --apply and --force flags', () => {
+      expect(parseArgs([])).toEqual({ apply: false, force: false });
+      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
+      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
+    });
+  });
+
+  describe('isSafeToRun', () => {
+    it('allows a localhost URI', () => {
+      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a 127.0.0.1 URI', () => {
+      expect(isSafeToRun('mongodb://127.0.0.1:27017/anything', false)).toBe(true);
+    });
+
+    it('allows a DEV Atlas db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a TEST db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-test', false)).toBe(true);
+    });
+
+    it('blocks a prod-looking (release) db name without --force', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
+    });
+
+    it('allows a prod-looking db name when --force is passed', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+
+  describe('run()', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      process.env.MONGO_DB_URI = 'mongodb://localhost:27017/web-jam-test';
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    // Everything Mongo-shaped is mocked via vi.spyOn and fully restored
+    // afterEach — this repo's other spec files share these same facade
+    // singletons in the same test process (fileParallelism: false), so a
+    // leaked mock here would break them.
+    function stubMongo(venues: { _id: string; name: string; inScope?: boolean }[]) {
+      vi.spyOn(mongoose, 'connect').mockResolvedValue(undefined as unknown as typeof mongoose);
+      vi.spyOn(mongoose.connection, 'close').mockResolvedValue(undefined);
+      const findSpy = vi.spyOn(venueModel, 'find').mockImplementation((filter: unknown) => {
+        const f = filter as { inScope?: { $exists?: boolean } } | undefined;
+        if (f?.inScope?.$exists === true) return Promise.resolve(venues);
+        return Promise.resolve([]);
+      });
+      const updateSpy = vi.spyOn(venueModel, 'findByIdAndUpdate').mockResolvedValue({});
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      return {
+        findSpy, updateSpy, logSpy,
+      };
+    }
+
+    it('dry run: plans doNotContact for inScope:false, plans field-only removal for inScope:true, writes nothing', async () => {
+      process.argv = ['node', 'migrate-drop-in-scope.js']; // no --apply
+      const outOfScopeId = new mongoose.Types.ObjectId().toString();
+      const inScopeId = new mongoose.Types.ObjectId().toString();
+      const { findSpy, updateSpy, logSpy } = stubMongo([
+        { _id: outOfScopeId, name: 'Salem Red Sox', inScope: false },
+        { _id: inScopeId, name: 'The Spot', inScope: true },
+      ]);
+
+      await run();
+
+      expect(findSpy).toHaveBeenCalledWith({ inScope: { $exists: true } });
+      expect(updateSpy).not.toHaveBeenCalled(); // dry run — no --apply
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('2 venue(s) scanned');
+      expect(summary).toContain('1 were inScope:false');
+      expect(summary).toContain('1 just lose the field');
+    });
+
+    it('apply: flips inScope:false venues to doNotContact:true and unsets inScope on both', async () => {
+      process.argv = ['node', 'migrate-drop-in-scope.js', '--apply'];
+      const outOfScopeId = new mongoose.Types.ObjectId().toString();
+      const inScopeId = new mongoose.Types.ObjectId().toString();
+      const { updateSpy } = stubMongo([
+        { _id: outOfScopeId, name: 'Salem Red Sox', inScope: false },
+        { _id: inScopeId, name: 'The Spot', inScope: true },
+      ]);
+
+      await run();
+
+      expect(updateSpy).toHaveBeenCalledWith(outOfScopeId, {
+        $unset: { inScope: '' }, $set: { doNotContact: true },
+      });
+      expect(updateSpy).toHaveBeenCalledWith(inScopeId, { $unset: { inScope: '' } });
+      expect(updateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('apply: also flips an archived inScope:false venue (deliberate — #954)', async () => {
+      process.argv = ['node', 'migrate-drop-in-scope.js', '--apply'];
+      const archivedId = new mongoose.Types.ObjectId().toString();
+      const { updateSpy } = stubMongo([
+        {
+          _id: archivedId, name: 'ODAC Tournament', inScope: false, status: 'archived',
+        } as unknown as { _id: string; name: string; inScope?: boolean },
+      ]);
+
+      await run();
+
+      expect(updateSpy).toHaveBeenCalledWith(archivedId, {
+        $unset: { inScope: '' }, $set: { doNotContact: true },
+      });
+    });
+
+    it('is a no-op on re-run once no venues still carry inScope (idempotent)', async () => {
+      process.argv = ['node', 'migrate-drop-in-scope.js', '--apply'];
+      const { updateSpy, logSpy } = stubMongo([]);
+
+      await run();
+
+      expect(updateSpy).not.toHaveBeenCalled();
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('0 venue(s) scanned');
+    });
+  });
+});

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -389,11 +389,18 @@ describe('Venue Controller', () => {
       expect(g).toMatchObject({ outreachEligible: false });
     });
 
-    it('filters by the vetting tags inScope / bookingStatus / interested (#843)', () => {
-      const f = (controller as any).constructor.buildListFilter({ inScope: 'true', bookingStatus: 'booking', interested: 'true' });
-      expect(f).toMatchObject({ inScope: true, bookingStatus: 'booking', interested: true });
-      const g = (controller as any).constructor.buildListFilter({ inScope: 'false', interested: 'false' });
-      expect(g).toMatchObject({ inScope: false, interested: false });
+    it('filters by the vetting tags bookingStatus / interested (#843)', () => {
+      const f = (controller as any).constructor.buildListFilter({ bookingStatus: 'booking', interested: 'true' });
+      expect(f).toMatchObject({ bookingStatus: 'booking', interested: true });
+      const g = (controller as any).constructor.buildListFilter({ interested: 'false' });
+      expect(g).toMatchObject({ interested: false });
+    });
+
+    // #954 — inScope was dropped entirely; ?inScope=... must no longer surface
+    // in the built filter (it's just an unrecognized query param now).
+    it('no longer supports an inScope filter (#954)', () => {
+      const f = (controller as any).constructor.buildListFilter({ inScope: 'true' });
+      expect(f).not.toHaveProperty('inScope');
     });
   });
 
@@ -411,11 +418,11 @@ describe('Venue Controller', () => {
       await c.createVenue({
         user: 'a',
         body: {
-          name: 'Olde Salem', inScope: true, bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
+          name: 'Olde Salem', bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
         },
       }, resStub);
       expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({
-        inScope: true, bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
+        bookingStatus: 'booked', interested: false, payTier: 'low', contactVerified: true,
       });
     });
 
@@ -423,8 +430,8 @@ describe('Venue Controller', () => {
       const id = new mongoose.Types.ObjectId().toString();
       const upd = vi.fn(() => Promise.resolve({ _id: id }));
       c.model.findByIdAndUpdate = upd;
-      await c.updateVenue({ user: 'a', params: { id }, body: { inScope: false, interested: false } }, resStub);
-      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ inScope: false, interested: false }));
+      await c.updateVenue({ user: 'a', params: { id }, body: { interested: false } }, resStub);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ interested: false }));
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove `inScope` from the venue schema (`src/model/venue/venue-schema.ts`) — it read as a duplicate of `outreachEligible`; Josh only ever used Eligible
- Remove `inScope` from `VenueBody` validation and drop the `?inScope=` filter support from `GET /venue` (`buildListFilter` in `src/model/venue/venue-controller.ts`)
- Swept the whole codebase for other `inScope` references — the candidates/eligibility logic in `GET /outreach/candidates` (`outreach-controller.ts`) never referenced `inScope` in the first place; it already gates on `outreachEligible: true` + `doNotContact: { $ne: true }` + non-archived + has-email, so no changes were needed there (confirmed by existing passing tests)
- Updated `test/unit/venue/venue-controller.spec.ts` to drop `inScope` from its vetting-tag fixtures/assertions and added a case confirming `?inScope=` is no longer a recognized filter
- Added a new idempotent migration, `src/scripts/migrate-drop-in-scope.ts` (`npm run migrate:drop-in-scope`), following the `migrate-gig-venue-id.ts` pattern: dry-run by default (prints the plan), `--apply` to write, and the same local/DEV/TEST-only safety guard requiring `--force` to target anything else. For every venue that still has an `inScope` field: `inScope: false` -> `$set: { doNotContact: true }` + `$unset: { inScope: '' }` (stays visible, never archived); `inScope: true`/missing -> just `$unset: { inScope: '' }`
- **Archived-venues decision**: unlike `migrate-gig-venue-id.ts` (which excludes archived venues from its query for gig-name-matching reasons), this migration deliberately INCLUDES archived venues — an archived venue may be unarchived later, and if it was `inScope: false` it should come back permanently excluded via `doNotContact`, not silently back in scope
- Added `test/unit/scripts/migrate-drop-in-scope.spec.ts` covering `parseArgs`, `isSafeToRun`, dry-run planning, `--apply` writes (both the doNotContact-flip and field-only-removal paths), the archived-venue inclusion, and idempotency (no-op once no venue still carries `inScope`)
- Bumped `package.json` to 2.4.1 (patch)

Part of #954

## How to test locally
Local commands run in this repo (all local — no Heroku, no prod Atlas, no `--apply` run anywhere):
```sh
npm test
```
Expected: eslint clean, jscpd under threshold, typecheck clean, 47/47 test files and 709/709 tests passing, coverage above the 90/90/80/80 gate (actual: 92.92% stmts / 86.76% branches / 88.22% funcs / 93.64% lines — `src/scripts/**` is excluded from the coverage gate by existing vitest.config.ts convention, same as the other migration scripts).

Post-merge prod steps (NOT run in this task — gated on Josh's explicit go):
1. Dry run against prod (safe — prints the plan, writes nothing):
```sh
heroku run "npm run migrate:drop-in-scope -- --force" -a webjamsalem
```
   Expected output shape:
```
Connected to "`<dbname>`" (`<masked uri>`)
Mode: DRY RUN — no writes (pass --apply to write).
  PLAN: venue `<id>` "`<name>`" inScope:false -> doNotContact:true (inScope removed)
  PLAN: venue `<id>` "`<name>`" inScope removed (no other change)
  ...
N venue(s) scanned (still had inScope); X were inScope:false (-> doNotContact:true); Y just lose the field.
Dry run — N venue(s) WOULD be updated. Re-run with --apply to write for real.
```
2. Once Josh reviews the printed plan and gives explicit go, the actual write (requires Josh's explicit go — not run as part of this PR):
```sh
heroku run "npm run migrate:drop-in-scope -- --force --apply" -a webjamsalem
```

## Test evidence
```
> web-jam-back@2.4.1 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

(eslint: 0 errors)
(jscpd: 31 clones, 4.08% duplicated lines — under the 5% threshold, exit 0)
(typecheck: 0 errors)

 Test Files  47 passed (47)
      Tests  709 passed (709)
   Duration  48.69s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
All files          |   92.92 |    86.76 |   88.22 |   93.64 |
-------------------|---------|----------|---------|---------|

=============================== Coverage summary ===============================
Statements   : 92.92% ( 2260/2432 )
Branches     : 86.76% ( 1403/1617 )
Functions    : 88.22% ( 352/399 )
Lines        : 93.64% ( 1871/1998 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5