### PR TITLE
Venue schema: add country (default US) + optional region for non-US venues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -10,6 +10,9 @@ import {
 } from '#src/lib/gig-venue-link.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s.@]+$/;
+// #972 — country is a 2-letter code (ISO 3166-1 alpha-2 style, e.g. 'US',
+// 'CA'); case-insensitive here since the schema uppercase-normalizes on save.
+const COUNTRY_RE = /^[A-Za-z]{2}$/;
 const VENUE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'];
 const STATUS_OPTIONS = ['active', 'archived'];
 const BOOKING_STATUSES = ['booking', 'not-booking', 'booked'];
@@ -42,6 +45,11 @@ interface VenueBody {
   name?: string;
   city?: string;
   usState?: string;
+  // #972 — country (2-letter code, default 'US' at the schema level) + region
+  // (free-text state/province, for non-US venues). usState is kept as-is for
+  // US venues; region is its non-US counterpart.
+  country?: string;
+  region?: string;
   venueType?: string;
   contactName?: string;
   email?: string;
@@ -202,6 +210,9 @@ function validateBody(body: VenueBody, partial: boolean): string {
   if (invalidPriority(body.priority)) return 'priority must be a number 0-5';
   if (body.email !== undefined && body.email !== '' && !EMAIL_RE.test(String(body.email).trim().toLowerCase())) {
     return 'A valid email is required';
+  }
+  if (body.country !== undefined && body.country !== '' && !COUNTRY_RE.test(String(body.country).trim())) {
+    return 'country must be a 2-letter code';
   }
   return '';
 }

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -73,6 +73,14 @@ const venueSchema = new Schema({
   name: { type: String, required: true, trim: true },
   city: { type: String, required: false, trim: true },
   usState: { type: String, required: false, trim: true },
+  // #972 — 2-letter country code (validated in venue-controller.ts), defaulting
+  // to 'US' since every venue on record today is US-based. `region` is optional
+  // free-text state/province for non-US venues; US venues keep using `usState`
+  // as-is (no migration of existing records — they all default cleanly).
+  country: {
+    type: String, required: false, trim: true, uppercase: true, default: 'US',
+  },
+  region: { type: String, required: false, trim: true },
   venueType: {
     type: String,
     required: false,

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -125,6 +125,30 @@ describe('Venue Controller', () => {
       expect(payload.message).toContain('valid email');
     });
 
+    // #972 — country (2-letter code, default 'US' at the schema level) + region
+    // (free-text, non-US state/province).
+    it('rejects an invalid country', async () => {
+      await c.createVenue({ user: 'a', body: { name: 'X', country: 'USA' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('country');
+      await c.createVenue({ user: 'a', body: { name: 'X', country: '1' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('country');
+    });
+
+    it('accepts + passes through country + region (#972)', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      const create = vi.fn(() => Promise.resolve({ _id: 'n2' }));
+      c.model.create = create;
+      await c.createVenue({
+        user: 'a', body: { name: 'The North Spot', country: 'ca', region: 'Ontario' },
+      }, resStub);
+      expect(status).toBe(201);
+      const arg = (create.mock.calls[0] as unknown[])[0] as any;
+      expect(arg.country).toBe('ca');
+      expect(arg.region).toBe('Ontario');
+    });
+
     it('creates a new venue when there is no duplicate', async () => {
       c.model.findOne = vi.fn(() => Promise.resolve(null));
       const create = vi.fn(() => Promise.resolve({ _id: 'new' }));
@@ -178,6 +202,25 @@ describe('Venue Controller', () => {
       await c.updateVenue({ user: 'agent', params: { id }, body: { notes: 'called them' } }, resStub);
       expect(status).toBe(200);
       expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ notes: 'called them', lastModifiedBy: 'agent' }));
+    });
+
+    // #972 — country/region accepted through the partial-merge PUT path too.
+    it('rejects an invalid country on update', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      await c.updateVenue({ user: 'a', params: { id }, body: { country: 'usa' } }, resStub);
+      expect(status).toBe(400);
+      expect(payload.message).toContain('country');
+    });
+
+    it('accepts country + region on update (#972)', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateVenue({
+        user: 'agent', params: { id }, body: { country: 'CA', region: 'Quebec' },
+      }, resStub);
+      expect(status).toBe(200);
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ country: 'CA', region: 'Quebec' }));
     });
 
     // #923 — global outcome standing: doNotContact (permanent exclusion) + the


### PR DESCRIPTION
## Summary
- venue-schema: add `country` (2-letter code, uppercase-normalized, default 'US') and optional `region` (free-text, non-US state/province); `usState` is unchanged for US venues
- venue-controller: accept both new fields through the existing `POST /venue` create path and `PUT /venue/:id` partial-merge path
- venue-controller: validate `country` is a 2-letter code (`/^[A-Za-z]{2}$/`), mirroring the existing email/enum validation style — rejects e.g. `'USA'` or `'1'` with a 400
- Unit tests covering the new fields on create + update, and both country-validation rejection cases

Closes #972

## How to test locally
Run the full gated suite:
```sh
npm test
```
Expect: eslint clean, jscpd report (no new gate), typecheck clean, 713 vitest tests passing, coverage above the 90/90/80/80 gate.

Exercise the change directly (replace `YOUR_TOKEN` with a valid bearer token for a user holding `venue:create`/`venue:edit`, and `VENUE_ID` with a real venue id):

```sh
# 1. POST /venue — create with country + region accepted
curl -s -X POST http://localhost:3000/venue \
  -H 'Authorization: Bearer YOUR_TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"The North Spot","country":"ca","region":"Ontario"}'
# Expect: 201, body includes "country":"CA" (schema uppercase-normalizes on save), "region":"Ontario"

# 2. PUT /venue/:id — partial merge accepts country + region
curl -s -X PUT http://localhost:3000/venue/VENUE_ID \
  -H 'Authorization: Bearer YOUR_TOKEN' -H 'Content-Type: application/json' \
  -d '{"country":"CA","region":"Quebec"}'
# Expect: 200, body includes "country":"CA", "region":"Quebec"

# 3. Validation rejection — country must be a 2-letter code
curl -s -X POST http://localhost:3000/venue \
  -H 'Authorization: Bearer YOUR_TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"Bad Country Venue","country":"USA"}'
# Expect: 400, body {"message":"country must be a 2-letter code"}
```

## Test evidence
```
> web-jam-back@2.4.2 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

(eslint: clean, no output)

> web-jam-back@2.4.2 jscpd
> jscpd src
... (pre-existing clones only, 31 clones / 5.86% duplicated tokens, unrelated to this change)

> web-jam-back@2.4.2 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit
(clean, no output)

> web-jam-back@2.4.2 test:unit
> vitest run --coverage

 Test Files  47 passed (47)
      Tests  713 passed (713)
   Start at  15:30:10
   Duration  50.90s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
All files          |   92.93 |     86.8 |   88.22 |   93.65 |
 src/model/venue   |   88.71 |    88.78 |   84.61 |    89.6 |
  venue-controller.ts |  92.79 |    88.66 |     100 |   95.02 |
-------------------|---------|----------|---------|---------|

Statements   : 92.93% ( 2263/2435 )
Branches     : 86.8% ( 1408/1622 )
Functions    : 88.22% ( 352/399 )
Lines        : 93.65% ( 1874/2001 )
Exit code: 0
```

🤖 Work by Claude Code — Sonnet 5