### PR TITLE
Venue booking lifecycle: outreachEligible as sole STOP/GO, gigInterval spacing, resumeBooking cooldown, derived bookingStatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -23,7 +23,9 @@
     "migrate:target-weekend": "node build/src/scripts/migrate-target-weekend.js",
     "migrate:gig-venue-id": "node build/src/scripts/migrate-gig-venue-id.js",
     "migrate:drop-in-scope": "node build/src/scripts/migrate-drop-in-scope.js",
-  "migrate:drop-contact-verified": "node build/src/scripts/migrate-drop-contact-verified.js",
+    "migrate:drop-contact-verified": "node build/src/scripts/migrate-drop-contact-verified.js",
+    "migrate:drop-do-not-contact": "node build/src/scripts/migrate-drop-do-not-contact.js",
+    "migrate:clean-city": "node build/src/scripts/migrate-clean-city.js",
     "restore:backup": "node scripts/restore-backup.mjs",
     "ts-watch": "tsc -w",
     "ts-start": "DEBUG=web-jam-back:* node --watch --trace-deprecation build/src/index.js",

--- a/src/lib/migration-cli.ts
+++ b/src/lib/migration-cli.ts
@@ -1,0 +1,79 @@
+// src/lib/migration-cli.ts — web-jam-back#980
+//
+// Shared one-time-migration CLI scaffolding: dry-run-by-default `--apply`
+// flag parsing, the local/DEV/TEST-only safety guard (never write to prod
+// without an explicit `--force`), and Mongo URI masking for log output.
+//
+// Every migrate-*.ts script under src/scripts/ hand-rolled an identical copy
+// of this boilerplate (migrate-drop-contact-verified.ts, migrate-drop-in-
+// scope.ts, migrate-gig-venue-id.ts, migrate-target-weekend.ts, all predating
+// #980). #980 adds two MORE one-time migrations (migrate-drop-do-not-
+// contact.ts, migrate-clean-city.ts); copy-pasting the pattern a 5th/6th time
+// pushed jscpd's duplication check over its 5% threshold. Extracted here so
+// #980's two new scripts share ONE implementation instead of adding two more
+// near-identical copies. The pre-existing scripts are left as-is — refactoring
+// them is out of #980's scope.
+import { fileURLToPath } from 'url';
+
+export interface MigrationArgs { apply: boolean; force: boolean }
+
+// `--apply` opts into writing (default: dry run / read-only). `--force`
+// opts into running against a database that doesn't look like local/DEV/TEST
+// (see isSafeToRun below) — a deliberate, reviewed prod run.
+export function parseArgs(argv: string[]): MigrationArgs {
+  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
+}
+
+// Only a db name/host that looks local/DEV/TEST is allowed to run without
+// --force — refuses release/production by default.
+export function isSafeToRun(uri: string, force: boolean): boolean {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+  return isLocal || isDevOrTest || force;
+}
+
+// eslint-disable-next-line sonarjs/slow-regex
+const CREDENTIALS_RE = /\/\/[^@]+@/;
+export function maskMongoUri(uri: string): string {
+  return uri.replace(CREDENTIALS_RE, '//<credentials>@');
+}
+
+// Prints the refusal message when isSafeToRun fails and the caller should
+// process.exit(1). `scriptName` names the script in the error text;
+// `npmScript` is its `npm run migrate:...` name, for the --force example.
+export function logSafetyBlock(scriptName: string, npmScript: string, uri: string, maskedUri: string): void {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  console.error(`ERROR: ${scriptName} only runs against a local, DEV, or TEST database by default — never release/production.`);
+  console.error(`Target MONGO URI: ${maskedUri}`);
+  console.error(`Parsed database name: ${dbName || '(none)'}`);
+  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill), e.g.');
+  console.error(`  heroku run "npm run ${npmScript} -- --force" -a webjamsalem   # dry run against prod`);
+  console.error(`  heroku run "npm run ${npmScript} -- --force --apply" -a webjamsalem   # writes for real`);
+}
+
+// True only when this module is being executed directly (`node script.js`),
+// never when imported by a unit test — gates the auto-run block at the
+// bottom of every migrate-*.ts script. Pass `import.meta.url` from the caller.
+export function isMainModule(importMetaUrl: string): boolean {
+  return Boolean(process.argv[1]) && fileURLToPath(importMetaUrl) === process.argv[1];
+}
+
+export interface MigrationRunContext { apply: boolean; force: boolean; uri: string; maskedUri: string }
+
+// The full "parse argv + env, refuse an unsafe target" preamble every
+// migrate-*.ts script's run() starts with. Calls process.exit(1) (never
+// returns) when isSafeToRun fails; otherwise returns the parsed args + URI
+// info the caller needs to proceed (connect, log the mode, do the work).
+export function guardOrExit(scriptName: string, npmScript: string): MigrationRunContext {
+  const { apply, force } = parseArgs(process.argv.slice(2));
+  const uri = process.env.MONGO_DB_URI || '';
+  const maskedUri = maskMongoUri(uri);
+  if (!isSafeToRun(uri, force)) {
+    logSafetyBlock(scriptName, npmScript, uri, maskedUri);
+    process.exit(1);
+  }
+  return {
+    apply, force, uri, maskedUri,
+  };
+}

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -483,6 +483,33 @@ class OutreachController extends Controller {
     } catch { /* best-effort */ }
   }
 
+  // #980 — append a dated, human-readable line to the venue's free-text
+  // `notes` field (the field the AdminVenues UI's "Notes" textarea reads/
+  // writes — see JaMmusic EditVenueDialog.tsx). APPEND, never overwrite: a
+  // single atomic pipeline update referencing the document's OWN existing
+  // `notes` (no separate read-then-write — same technique as
+  // migrate-drop-do-not-contact.ts's note append) so there's no race with a
+  // concurrent write. Best-effort, same pattern as appendVenueTouch above —
+  // a notes-write hiccup must never fail the outreach status change that's
+  // already committed by the caller.
+  async appendVenueNote(venueId: unknown, line: string): Promise<void> {
+    try {
+      await venueModel.findByIdAndUpdate(String(venueId), [
+        {
+          $set: {
+            notes: {
+              $cond: [
+                { $and: [{ $ne: ['$notes', null] }, { $ne: ['$notes', ''] }] },
+                { $concat: ['$notes', '\n', line] },
+                line,
+              ],
+            },
+          },
+        },
+      ] as unknown as Record<string, unknown>);
+    } catch { /* best-effort */ }
+  }
+
   // Auto-flip every OTHER active (`sent`) record whose targetWeekend overlaps
   // the just-booked record's targetWeekend to `target-filled` (#898/#923): not
   // a rejection, the venue returns to the pool for a future target. Runs ONLY
@@ -532,10 +559,16 @@ class OutreachController extends Controller {
   // (mirrors recordBounce elsewhere in this file): the outreach status change
   // already committed by the caller is the critical write; a venue hiccup
   // here shouldn't undo it.
-  //   - not-interested → venue.doNotContact = true (PERMANENT, per #923).
-  //   - booked → bookedDate + bookingStatus:'booked' on the venue (a judgment
-  //     call: the venue's coarse booking standing should track the specific
-  //     gig date recorded here), plus the target-filled auto-flip.
+  //   - not-interested → venue.outreachEligible = false (PERMANENT — #980
+  //     folded the old doNotContact flag into outreachEligible, now the SOLE
+  //     stop/go gate) + a dated line appended to the venue's notes (never
+  //     overwritten — see appendVenueNote).
+  //   - booked → bookedDate on the venue (the actual gig date this outcome
+  //     recorded). #980: bookingStatus is no longer written here — it's now
+  //     DERIVED purely from actual linked-gig data (computeBookingStatus in
+  //     venue-controller.ts), so a recorded outcome alone no longer flips the
+  //     display badge; the badge only reflects a real gig once one exists.
+  //     The target-filled auto-flip is unaffected by that change.
   // Every outcome also gets a matching timeline touch on the venue.
   async applyOutcomeSideEffects(
     existing: OutreachDoc,
@@ -547,13 +580,15 @@ class OutreachController extends Controller {
   ): Promise<void> {
     const tw = (existing as unknown as { targetWeekend?: TargetWeekend }).targetWeekend;
     if (status === 'not-interested') {
-      try { await venueModel.findByIdAndUpdate(String(existing.venueId), { doNotContact: true, lastModifiedBy: actor }); } catch { /* best-effort */ }
+      try {
+        await venueModel.findByIdAndUpdate(String(existing.venueId), { outreachEligible: false, lastModifiedBy: actor });
+      } catch { /* best-effort */ }
+      const dateStr = outcomeAt.toISOString().slice(0, 10);
+      await this.appendVenueNote(existing.venueId, `[${dateStr}] Marked not-interested via outreach outcome — outreachEligible set to false.`);
     }
     if (status === 'booked') {
       try {
-        await venueModel.findByIdAndUpdate(String(existing.venueId), {
-          bookedDate, bookingStatus: 'booked', lastModifiedBy: actor,
-        });
+        await venueModel.findByIdAndUpdate(String(existing.venueId), { bookedDate, lastModifiedBy: actor });
       } catch { /* best-effort */ }
     }
     await this.appendVenueTouch(existing.venueId, {
@@ -820,20 +855,44 @@ class OutreachController extends Controller {
     return res.status(200).json(result);
   }
 
-  // #958 SAFETY — a venue with an upcoming (datetime >= now) linked gig must
-  // never be offered as an outreach candidate: it's already booked (by phone,
-  // in person, whatever route), so pitching it again is the same failure
-  // class as the 2026-07-08 incident (Durty Bull: booked Nov 16 as a gig
-  // record, yet invisible to venue data and Batch Outreach). Resolution uses
-  // the shared venueId-first/exact-normalized-name rule (never fuzzy — see
-  // src/lib/gig-venue-link.ts). `gigs` is fetched ONCE by the caller (no
-  // per-venue query/N+1).
-  static excludeUpcomingGigVenues(venues: LinkableVenue[], gigs: LinkableGig[]): LinkableVenue[] {
+  // #980 — is `gigDate` within `gigIntervalMonths` of `w` (on EITHER side —
+  // the nearest gig, past or future, is what matters, not just upcoming
+  // ones)? The boundary is inclusive of "exactly gigIntervalMonths away is
+  // fine" (the issue's "≥ gigInterval months from W"), so the excluded
+  // window is OPEN (strictly between the bounds, not touching them).
+  static isTooCloseToWindow(gigDate: Date, w: Date, gigIntervalMonths: number): boolean {
+    const lower = new Date(w); lower.setMonth(lower.getMonth() - gigIntervalMonths);
+    const upper = new Date(w); upper.setMonth(upper.getMonth() + gigIntervalMonths);
+    const t = gigDate.getTime();
+    return t > lower.getTime() && t < upper.getTime();
+  }
+
+  // #980 — generalizes the old #958 SAFETY exclusion (a venue with ANY
+  // upcoming linked gig was dropped forever) into a configurable spacing
+  // rule: `gigInterval` (months on the venue, default 0) is the minimum gap
+  // Josh wants between gigs at that venue. For target window `w`, a venue is
+  // excluded when ANY of its linked gigs (past or future) falls within
+  // `gigInterval` months of `w`. `gigInterval = 0` (every venue's default,
+  // and every venue's value before this migration) disables the check
+  // entirely — BY DESIGN this removes the old blanket exclusion (the
+  // "repeat-venue trap" #980 exists to fix): a venue only gets spaced out
+  // once Josh explicitly opts it in by setting gigInterval > 0. Resolution
+  // uses the shared venueId-first/exact-normalized-name rule (never fuzzy —
+  // see src/lib/gig-venue-link.ts). `gigs` is fetched ONCE by the caller (no
+  // per-venue query/N+1) and the spacing math runs in memory over that one
+  // fetched set, grouped by venueId.
+  static excludeUpcomingGigVenues(
+    venues: (LinkableVenue & { gigInterval?: number })[],
+    gigs: LinkableGig[],
+    w: Date,
+  ): LinkableVenue[] {
     const groups = groupGigsByVenue(gigs, venues);
-    const now = Date.now();
     return venues.filter((v) => {
+      const gigIntervalMonths = Number(v.gigInterval) || 0;
+      if (!gigIntervalMonths) return true;
       const linked = groups.get(String(v._id)) || [];
-      return !linked.some((g) => g.datetime && new Date(g.datetime as string).getTime() >= now);
+      return !linked.some((g) => g.datetime && !Number.isNaN(new Date(g.datetime as string).getTime())
+        && OutreachController.isTooCloseToWindow(new Date(g.datetime as string), w, gigIntervalMonths));
     });
   }
 
@@ -851,45 +910,65 @@ class OutreachController extends Controller {
     });
   }
 
-  // GET /outreach/candidates — propose the target list (#844): vetted
-  // (outreachEligible), non-archived venues with an email, minus any that
-  // already have an active outreach with an OVERLAPPING targetWeekend, AND
-  // (#958) minus any venue with an upcoming linked gig — see
-  // excludeUpcomingGigVenues. #898: the targetWeekend filter is date-range
-  // aware (matching the dedup guard's overlap semantics) rather than the old
-  // targetDates string filter — the note in PR #933 deferred this rekey to
-  // this issue, since #923 already established targetDates no longer
-  // participates in any logic. Read-only.
-  // Optional query: targetWeekend {start, end} (bracket-notation query params
-  // over HTTP, e.g. ?targetWeekend[start]=...&targetWeekend[end]=...). When
-  // given, the response is `{ candidates, weekendGigs }` (weekendGigs = #958's
-  // weekend-awareness surfacing); when omitted, the response stays the plain
-  // candidates array (unchanged, back-compat with existing callers).
+  // GET /outreach/candidates — propose the target list (#844/#980): a venue
+  // is a candidate for target window W iff `outreachEligible = GO` AND a
+  // valid primary email AND not archived AND no active `resumeBooking`
+  // cooldown (unset, or a date already in the past) AND — the
+  // excludeUpcomingGigVenues spacing check below — (`gigInterval = 0` OR
+  // every linked gig at that venue is ≥ `gigInterval` months from W), minus
+  // any venue that already has an active outreach with an OVERLAPPING
+  // targetWeekend. #898: the targetWeekend filter is date-range aware
+  // (matching the dedup guard's overlap semantics) rather than the old
+  // targetDates string filter. Read-only.
+  // Optional query:
+  //   • targetWeekend {start, end} (bracket-notation query params, e.g.
+  //     ?targetWeekend[start]=...&targetWeekend[end]=...) — W for both the
+  //     dedup-overlap check and the gigInterval spacing check. When omitted,
+  //     W defaults to "now" for spacing purposes (matching the pre-#980
+  //     behavior for every venue, since gigInterval=0 is every venue's
+  //     default and disables the check regardless of W) and the response
+  //     stays the plain candidates array (back-compat); when given, the
+  //     response is `{ candidates, weekendGigs }` (weekendGigs = #958's
+  //     weekend-awareness surfacing).
+  //   • cities=City1,City2,... (comma-separated, #980) — AND'd with every
+  //     other criterion; omitted/empty = all cities (back-compat).
   async getCandidates(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
-    let venues: { _id?: unknown }[];
-    try {
-      // #923 — doNotContact is a permanent global exclusion (set by a
-      // not-interested outcome), on top of the existing outreachEligible gate.
-      // #974 — the email clause is now format-checked ($regex EMAIL_RE), not
-      // just non-empty ($nin): a venue with no VALID primary email is not
-      // sendable, so it must never be offered as a candidate either. This is
-      // ADDITIONAL to (never a replacement for) outreachEligible above.
-      venues = await venueModel.find({
-        outreachEligible: true,
-        status: { $ne: 'archived' },
-        email: { $nin: [null, ''], $regex: EMAIL_RE },
-        doNotContact: { $ne: true },
-      });
-    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
 
-    const query = (req.query || {}) as { targetWeekend?: RawTargetWeekend };
+    const query = (req.query || {}) as { targetWeekend?: RawTargetWeekend; cities?: string };
     let tw: TargetWeekend | null = null;
     if (query.targetWeekend !== undefined) {
       tw = parseTargetWeekend(query.targetWeekend);
       if (!tw) return res.status(400).json({ message: 'targetWeekend must include valid start and end' });
     }
+    const now = new Date();
+    const w = tw ? tw.start : now;
+    const cities = (query.cities || '').split(',').map((s) => s.trim()).filter(Boolean);
+
+    let venues: { _id?: unknown }[];
+    try {
+      // #980 — doNotContact is gone (folded into outreachEligible, the SOLE
+      // permanent stop/go gate). #974 — the email clause is format-checked
+      // ($regex EMAIL_RE), not just non-empty ($nin): a venue with no VALID
+      // primary email is not sendable, so it must never be offered as a
+      // candidate. #980 — resumeBooking is an active cooldown only when set
+      // to a date strictly in the future; unset or in the past never blocks.
+      const filter: Record<string, unknown> = {
+        outreachEligible: true,
+        status: { $ne: 'archived' },
+        email: { $nin: [null, ''], $regex: EMAIL_RE },
+        $or: [
+          { resumeBooking: { $exists: false } },
+          { resumeBooking: null },
+          { resumeBooking: { $lte: now } },
+        ],
+      };
+      // #980 — optional city filter, AND'd with everything above.
+      if (cities.length) filter.city = { $in: cities };
+      venues = await venueModel.find(filter);
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+
     let handled = new Set<string>();
     if (tw) {
       let active: { venueId?: unknown }[];
@@ -902,14 +981,18 @@ class OutreachController extends Controller {
     }
     let candidates = venues.filter((v) => !handled.has(String(v._id)));
 
-    // #958 — one extra gig query total (not per-venue): feeds both the SAFETY
-    // exclusion (always applied) and, when a targetWeekend was requested, the
-    // weekendGigs surfacing below.
+    // #958/#980 — one extra gig query total (not per-venue): feeds both the
+    // gigInterval spacing check (always applied) and, when a targetWeekend
+    // was requested, the weekendGigs surfacing below.
     let gigs: LinkableGig[];
     try {
       gigs = await gigModel.find(JOSH_GIGS_FILTER) as unknown as LinkableGig[];
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
-    candidates = OutreachController.excludeUpcomingGigVenues(candidates as unknown as LinkableVenue[], gigs) as unknown as { _id?: unknown }[];
+    candidates = OutreachController.excludeUpcomingGigVenues(
+      candidates as unknown as (LinkableVenue & { gigInterval?: number })[],
+      gigs,
+      w,
+    ) as unknown as { _id?: unknown }[];
 
     if (!tw) return res.status(200).json(candidates);
     const weekendGigs = OutreachController.gigsInWeekend(gigs, tw);

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -55,6 +55,20 @@ type SendResult = { ok: true; record: unknown } | { ok: false; status: number; m
 // left optional) are unaffected.
 interface RawTargetWeekend { start?: string | Date; end?: string | Date }
 
+// #980 — per-candidate qualifying context, attached to every GET
+// /outreach/candidates result so JaMmusic#1238's Find-Eligible UI can show
+// "why did this venue qualify" without re-deriving eligibility client-side.
+// Every returned candidate already passed the outreachEligible/email/
+// archived/resumeBooking query filter and the gigInterval spacing check —
+// this is display context, not a second eligibility test.
+interface CandidateReason {
+  lastGigDate: string | null;
+  gigIntervalMonths: number;
+  nearestGigMonthsAway: number | null;
+  spacingNote: string;
+  resumeBookingExpired: boolean;
+}
+
 interface SendBody {
   venueId?: string;
   templateType?: string;
@@ -896,6 +910,51 @@ class OutreachController extends Controller {
     });
   }
 
+  // #980 — average days/month, used only for the display-only
+  // nearestGigMonthsAway figure in buildCandidateReason below (never for the
+  // isTooCloseToWindow eligibility math above, which uses real
+  // calendar-month arithmetic via setMonth).
+  static readonly MS_PER_MONTH = 30.4368 * 24 * 60 * 60 * 1000;
+
+  // #980 — build the per-venue "why did this qualify" context for JaM#1238.
+  // `linkedGigs` is this one venue's slice of the single batch-fetched gig
+  // set (already grouped by the caller — no extra query). Every candidate
+  // passed here already cleared the eligibility + spacing checks; this is
+  // display context only, never a second gate.
+  static buildCandidateReason(
+    venue: Record<string, unknown> & { gigInterval?: number; resumeBooking?: unknown },
+    linkedGigs: LinkableGig[],
+    w: Date,
+  ): CandidateReason {
+    const validGigs = linkedGigs.filter((g) => g.datetime && !Number.isNaN(new Date(g.datetime as string).getTime()));
+    const now = Date.now();
+    const pastGigs = validGigs.filter((g) => new Date(g.datetime as string).getTime() < now);
+    const lastGig = pastGigs.reduce<LinkableGig | null>((latest, g) => {
+      if (!latest) return g;
+      return new Date(g.datetime as string).getTime() > new Date(latest.datetime as string).getTime() ? g : latest;
+    }, null);
+    const gigIntervalMonths = Number(venue.gigInterval) || 0;
+    const distancesInMonths = validGigs.map(
+      (g) => Math.abs(new Date(g.datetime as string).getTime() - w.getTime()) / OutreachController.MS_PER_MONTH,
+    );
+    const nearestGigMonthsAway = distancesInMonths.length
+      ? Math.round(Math.min(...distancesInMonths) * 10) / 10
+      : null;
+    let spacingNote: string;
+    if (!gigIntervalMonths) spacingNote = 'spacing off (gigInterval=0)';
+    else if (nearestGigMonthsAway === null) spacingNote = 'no gigs yet';
+    else spacingNote = `clear — nearest gig ~${nearestGigMonthsAway} mo away`;
+    const resumeBooking = venue.resumeBooking ? new Date(venue.resumeBooking as string) : null;
+    const resumeBookingExpired = !!(resumeBooking && !Number.isNaN(resumeBooking.getTime()) && resumeBooking.getTime() <= now);
+    return {
+      lastGigDate: lastGig ? new Date(lastGig.datetime as string).toISOString() : null,
+      gigIntervalMonths,
+      nearestGigMonthsAway,
+      spacingNote,
+      resumeBookingExpired,
+    };
+  }
+
   // #958 — weekend awareness: every linked-or-unlinked gig (any venue) whose
   // datetime falls inside the requested target weekend, so the UI can warn
   // "you already have a gig that weekend" while curating a candidate list for
@@ -932,6 +991,11 @@ class OutreachController extends Controller {
   //     weekend-awareness surfacing).
   //   • cities=City1,City2,... (comma-separated, #980) — AND'd with every
   //     other criterion; omitted/empty = all cities (back-compat).
+  // Every returned candidate carries a `reason` object (buildCandidateReason,
+  // #980/JaMmusic#1238) — lastGigDate, gigIntervalMonths,
+  // nearestGigMonthsAway, a human-readable spacingNote, and
+  // resumeBookingExpired — so the Find-Eligible UI can show why each venue
+  // qualified without re-deriving eligibility client-side.
   async getCandidates(req: AuthRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, OUTREACH_ANY_CAPS);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -994,9 +1058,21 @@ class OutreachController extends Controller {
       w,
     ) as unknown as { _id?: unknown }[];
 
-    if (!tw) return res.status(200).json(candidates);
+    // #980 — attach the "why did this qualify" context (JaM#1238) per
+    // candidate, grouped from the same batch-fetched gig set (no extra query).
+    const gigGroups = groupGigsByVenue(gigs, candidates as unknown as LinkableVenue[]);
+    const withReason = candidates.map((v) => ({
+      ...v,
+      reason: OutreachController.buildCandidateReason(
+        v as Record<string, unknown>,
+        gigGroups.get(String(v._id)) || [],
+        w,
+      ),
+    }));
+
+    if (!tw) return res.status(200).json(withReason);
     const weekendGigs = OutreachController.gigsInWeekend(gigs, tw);
-    return res.status(200).json({ candidates, weekendGigs });
+    return res.status(200).json({ candidates: withReason, weekendGigs });
   }
 
   // GET /outreach/preview — render the exact email a venue would get, WITHOUT

--- a/src/model/outreach/outreach-schema.ts
+++ b/src/model/outreach/outreach-schema.ts
@@ -77,9 +77,11 @@ const outreachSchema = new Schema({
   // #923 outcome data model: `interested`/`not-interested`/`booked`/
   // `target-filled` are the new outcome values a human (or, later, #898's
   // auto-flip) records against a pitch. `not-interested` is the permanent
-  // decline (pairs with the venue's `doNotContact` flag); `target-filled`
-  // means a DIFFERENT record for the same weekend got booked, so this one
-  // returns to the pool for a future target rather than being a rejection.
+  // decline (pairs with the venue's `outreachEligible` gate — #980 folded the
+  // old `doNotContact` flag into it, the SOLE permanent stop/go standing
+  // now); `target-filled` means a DIFFERENT record for the same weekend got
+  // booked, so this one returns to the pool for a future target rather than
+  // being a rejection.
   status: {
     type: String,
     required: false,

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -15,7 +15,10 @@ import {
 const COUNTRY_RE = /^[A-Za-z]{2}$/;
 const VENUE_TYPES = ['Originals', 'PubFestivalBrewery', 'MidRangeCafeBar'];
 const STATUS_OPTIONS = ['active', 'archived'];
-const BOOKING_STATUSES = ['booking', 'not-booking', 'booked'];
+// #980 — the derived bookingStatus values, returned on every venue payload by
+// computeBookingStatus below (no settable BOOKING_STATUSES const anymore —
+// bookingStatus is never accepted in a request body).
+type DerivedBookingStatus = 'booked' | 'not-booking' | 'booking';
 // Prospect-ranking enums (#867) — drive the AdminVenues "Prospect Score" sort.
 const ORIGINALS_FIT = ['none', 'some', 'loves'];
 const TRAVEL_BANDS = ['local', 'regional', 'far'];
@@ -61,7 +64,6 @@ interface VenueBody {
   website?: string;
   status?: string;
   outreachEligible?: boolean;
-  bookingStatus?: string;
   interested?: boolean;
   payTier?: string;
   lastVerified?: string;
@@ -72,10 +74,13 @@ interface VenueBody {
   travelBand?: string;
   priority?: number;
   lastContacted?: string;
-  // Global outcome standing (#923) — see venue-schema.ts. Written by the
-  // outcome-recording endpoint (#898); accepted here via the existing
-  // partial-update pass-through like every other venue field.
-  doNotContact?: boolean;
+  // #980 — minimum gig-spacing (months, 0 = off) and the manual "pause until"
+  // cooldown date. See venue-schema.ts. `bookingStatus` is intentionally NOT
+  // in this interface anymore — it's derived/read-only (computeBookingStatus
+  // below); a stray `bookingStatus` in the request body is stripped, never
+  // written (see createVenue/updateVenue).
+  gigInterval?: number;
+  resumeBooking?: string;
   bookedDate?: string;
   actor?: string;
 }
@@ -118,12 +123,11 @@ function resolveActor(req: AuthRequest, body: { actor?: string }): string {
 // `partial` (PUT) only validates the fields that are present.
 // Enum-validated string fields ('' = unset, allowed). Data-driven so adding a
 // field doesn't grow validateBody's cognitive complexity (#867).
-type EnumKey = 'venueType' | 'status' | 'bookingStatus' | 'relationshipStage'
+type EnumKey = 'venueType' | 'status' | 'relationshipStage'
   | 'templateOverride' | 'originalsFit' | 'travelBand';
 const ENUM_FIELDS: { key: EnumKey; allowed: string[] }[] = [
   { key: 'venueType', allowed: VENUE_TYPES },
   { key: 'status', allowed: STATUS_OPTIONS },
-  { key: 'bookingStatus', allowed: BOOKING_STATUSES },
   { key: 'relationshipStage', allowed: ['cold', 'returning'] },
   { key: 'templateOverride', allowed: VENUE_TYPES },
   { key: 'originalsFit', allowed: ORIGINALS_FIT },
@@ -206,11 +210,22 @@ function invalidPriority(priority: number | undefined): boolean {
     && (typeof priority !== 'number' || priority < 0 || priority > 5);
 }
 
+// #980 — gigInterval is a non-negative integer count of months (0 = spacing
+// check off).
+function invalidGigInterval(gigInterval: number | undefined): boolean {
+  return gigInterval !== undefined && gigInterval !== null
+    && (typeof gigInterval !== 'number' || !Number.isInteger(gigInterval) || gigInterval < 0);
+}
+
 function validateBody(body: VenueBody, partial: boolean): string {
   if ((!partial || body.name !== undefined) && (!body.name || !body.name.trim())) return 'Name is required';
   const enumErr = invalidEnum(body);
   if (enumErr) return enumErr;
   if (invalidPriority(body.priority)) return 'priority must be a number 0-5';
+  if (invalidGigInterval(body.gigInterval)) return 'gigInterval must be a non-negative whole number of months';
+  if (body.resumeBooking !== undefined && body.resumeBooking !== '' && Number.isNaN(new Date(body.resumeBooking).getTime())) {
+    return 'resumeBooking must be a valid date';
+  }
   if (body.email !== undefined && body.email !== '' && !isValidEmail(body.email)) {
     return 'A valid email is required';
   }
@@ -223,6 +238,18 @@ function validateBody(body: VenueBody, partial: boolean): string {
     return 'country must be a 2-letter code';
   }
   return '';
+}
+
+// #980 — `bookingStatus` is derived/read-only (computeBookingStatus below)
+// and `doNotContact` was deleted entirely (folded into `outreachEligible`).
+// Neither is in the VenueBody type anymore, but an older/stale client could
+// still send them in the raw JSON body — silently drop both here (mirrors
+// the existing `delete body._id` pattern) rather than erroring, so a
+// round-tripped venue-edit form that still includes the old value is a
+// harmless no-op instead of a 400.
+function stripReadOnlyFields(body: Record<string, unknown>): void {
+  delete body.bookingStatus;
+  delete body.doNotContact;
 }
 
 // Privilege-first, role-fallback gate (mirrors PromoController). Reused for both
@@ -261,12 +288,16 @@ class VenueController extends Controller {
     else filter.status = { $ne: 'archived' };
     if (typeof query.venueType === 'string') filter.venueType = query.venueType;
     // Outreach targeting (#843): ?outreachEligible=true returns only vetted
-    // venues — the pool #844's approval flow proposes from. The vetting tags
-    // below filter the candidate set further (still booking, interested).
+    // venues — the pool #844's approval flow proposes from. The vetting tag
+    // below filters the candidate set further (interested).
     // (`inScope` filter support was dropped with the field itself — #954.)
+    // #980 — `bookingStatus` filter support was dropped with the field's
+    // settable meaning: it's now derived/computed on read (see
+    // computeBookingStatus), so the RAW stored value a Mongo query would
+    // filter on is no longer reliably maintained. Filter on the computed
+    // `bookingStatus` client-side after the list comes back instead.
     if (query.outreachEligible === 'true') filter.outreachEligible = true;
     else if (query.outreachEligible === 'false') filter.outreachEligible = false;
-    if (typeof query.bookingStatus === 'string') filter.bookingStatus = query.bookingStatus;
     if (query.interested === 'true') filter.interested = true;
     else if (query.interested === 'false') filter.interested = false;
     return filter;
@@ -297,6 +328,23 @@ class VenueController extends Controller {
     });
   }
 
+  // #980 — the derived, read-only bookingStatus readout (see venue-schema.ts).
+  // Display precedence when multiple conditions could apply, as decided
+  // during build: `booked` (has an upcoming linked gig) beats `not-booking`
+  // (an active resumeBooking cooldown) beats `booking` (the open/default
+  // state) — a venue can't be actively paused from booking AND already have
+  // a confirmed upcoming gig in any way that matters for the badge; the
+  // confirmed gig is the more useful signal to show. `resumeBooking` is
+  // "active" when set to a date strictly in the future, relative to `now` —
+  // the same instant the caller resolves everything else against (mirrors
+  // the exact wording of #980: "unset or in the past" = no active cooldown).
+  static computeBookingStatus(venue: Record<string, unknown>, hasUpcomingGig: boolean, now: number): DerivedBookingStatus {
+    if (hasUpcomingGig) return 'booked';
+    const resumeBooking = venue.resumeBooking ? new Date(venue.resumeBooking as string) : null;
+    if (resumeBooking && !Number.isNaN(resumeBooking.getTime()) && resumeBooking.getTime() > now) return 'not-booking';
+    return 'booking';
+  }
+
   // #958 — attach computed lastGig/nextGig + locationFallback onto each venue
   // via ONE extra gig query for the whole batch (never a per-venue query — no
   // N+1), scoped to Josh's gigs like filterEligible above. Resolution is the
@@ -307,6 +355,11 @@ class VenueController extends Controller {
   // those two gigs is more relevant — lastGig if there is one, else nextGig,
   // so a venue with only a FUTURE booked gig, like Durty Bull's Nov 16, still
   // gets a location — never written back to the venue record).
+  //
+  // #980 — also attaches the derived `bookingStatus` (computeBookingStatus
+  // above), computed fresh here and OVERWRITING whatever stale value is
+  // still stored on the raw venue doc, so bookingStatus can never go stale on
+  // any read (GET /venue and GET /venue/:id both go through this).
   static async attachGigLinks(venues: Record<string, unknown>[]): Promise<Record<string, unknown>[]> {
     let gigs: LinkableGig[];
     try {
@@ -327,10 +380,34 @@ class VenueController extends Controller {
       const locationFallback = fallbackGig && (fallbackGig.city || fallbackGig.usState)
         ? { city: fallbackGig.city, usState: fallbackGig.usState }
         : null;
+      const bookingStatus = VenueController.computeBookingStatus(v, future.length > 0, now);
       return {
-        ...v, lastGig, nextGig, locationFallback,
+        ...v, lastGig, nextGig, locationFallback, bookingStatus,
       };
     });
+  }
+
+  // GET /venue/cities — distinct non-empty `city` values (#980), so the
+  // AdminVenues city-targeting multi-select (JaMmusic#1238) can offer exactly
+  // the cities that exist in the DB rather than a hardcoded list. Chose a
+  // dedicated endpoint over "derive it client-side from the venues the page
+  // already loaded" because AdminVenues' venue list can be filtered
+  // (status/venueType/etc, see buildListFilter) — a distinct-cities source
+  // that only reflects whatever's currently on screen would silently drop
+  // options depending on which filter happens to be active; this endpoint
+  // always reflects every venue, independent of any list-page filter state.
+  async listCities(req: AuthRequest, res: Response): Promise<unknown> {
+    const guardErr = await this.authorize(req, VENUE_WRITE_CAPS);
+    if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
+    let cities: unknown[];
+    try {
+      cities = await venueModel.Schema.distinct('city', { city: { $nin: [null, ''] } });
+    } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    const distinctCities = (cities as string[])
+      .map((c) => (typeof c === 'string' ? c.trim() : ''))
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+    return res.status(200).json(distinctCities);
   }
 
   // GET /venue — list venues (filters: status, venueType, eligibleFor=<date>).
@@ -387,6 +464,7 @@ class VenueController extends Controller {
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
     const body = (req.body || {}) as VenueBody;
     delete body._id;
+    stripReadOnlyFields(body as unknown as Record<string, unknown>);
     const invalid = validateBody(body, false);
     if (invalid) return res.status(400).json({ message: invalid });
 
@@ -416,6 +494,7 @@ class VenueController extends Controller {
     if (!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) return res.status(400).json({ message: 'Update id is invalid' });
     const body = (req.body || {}) as VenueBody;
     delete body._id;
+    stripReadOnlyFields(body as unknown as Record<string, unknown>);
     const invalid = validateBody(body, true);
     if (invalid) return res.status(400).json({ message: invalid });
     let doc;

--- a/src/model/venue/venue-router.ts
+++ b/src/model/venue/venue-router.ts
@@ -19,6 +19,14 @@ router.route('/')
     void action();
   });
 
+// GET /venue/cities — distinct non-empty city values (#980). Registered
+// BEFORE /:id so Express doesn't swallow it as a :id lookup for "cities".
+router.route('/cities')
+  .get((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'listCities', controller, authUtils);
+    void action();
+  });
+
 router.route('/:id')
   .get((req, res) => {
     const action = routeUtils.makeAction(req, res, 'getVenue', controller, authUtils);

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -132,14 +132,40 @@ const venueSchema = new Schema({
   // `inScope` (was: is this a gig-booking venue at all?) was dropped (#954,
   // 2026-07-16) — it read as a duplicate of `outreachEligible` and Josh only
   // ever used Eligible. A venue that was `inScope: false` is permanently
-  // excluded via `doNotContact` instead (see below) — see migrate-drop-in-
-  // scope.ts for the one-time backfill.
+  // excluded via `outreachEligible: false` instead (the sole stop/go gate as
+  // of #980, below) — see migrate-drop-in-scope.ts for the one-time backfill.
+  //
+  // #980 (2026-07-18) — `bookingStatus` is now a DERIVED, READ-ONLY field:
+  // booked (has an upcoming linked gig) / not-booking (an active
+  // `resumeBooking` cooldown) / booking (otherwise) — computed fresh on every
+  // read (venue-controller.ts's attachGigLinks/computeBookingStatus), never
+  // hand-set. The stored field below is kept only so existing documents don't
+  // need a migration; the app never writes it anymore and every API response
+  // overwrites it with the computed value before the client ever sees it.
   bookingStatus: {
     type: String, required: false, enum: ['booking', 'not-booking', 'booked'], default: 'booking',
   },
   interested: { type: Boolean, required: false, default: true },
   payTier: { type: String, required: false, trim: true },
   lastVerified: { type: Date, required: false },
+  // #980 — minimum spacing (in months) Josh wants between gigs at this venue
+  // before it's offered as a candidate again for a new target window W (the
+  // gigInterval-aware generalization of the old #958 "never re-pitch an
+  // already-booked venue" safety net — see excludeUpcomingGigVenues in
+  // outreach-controller.ts). 0 (the default — every existing venue defaults
+  // here) turns the check off entirely: BY DESIGN this removes the old
+  // blanket "any upcoming linked gig excludes the venue forever" rule (the
+  // "repeat-venue trap" #980 was written to fix), so nothing changes for a
+  // venue until Josh explicitly opts it into spacing by setting this > 0.
+  gigInterval: {
+    type: Number, required: false, default: 0, min: 0,
+  },
+  // #980 — a manual "don't pitch until this date" cooldown, for soft-nos /
+  // deliberate holds (e.g. "nice, but not booking right now — try again in
+  // ~4 months"). Unset, or a date already in the past, means no active
+  // cooldown. Drives both the getCandidates exclusion (outreach-
+  // controller.ts) and the derived bookingStatus:'not-booking' readout above.
+  resumeBooking: { type: Date, required: false },
   notes: { type: String, required: false },
   // Template-selection inputs (#848). `relationshipStage` overrides the
   // auto-derived cold/returning stage when set; left unset = auto-derive
@@ -159,14 +185,19 @@ const venueSchema = new Schema({
   travelBand: { type: String, required: false, enum: ['local', 'regional', 'far'] },
   priority: { type: Number, required: false, min: 0, max: 5 },
   lastContacted: { type: Date, required: false },
-  // Global outcome standing (#923). `doNotContact` is set by a `not-interested`
-  // outreach outcome — permanent, and excluded from /outreach/candidates
-  // FOREVER (in addition to the outreachEligible gate); nothing in this repo
-  // ever flips it back off automatically. `bookedDate` is the actual gig date
-  // once a booking outcome is recorded (bookingStatus:'booked' above already
-  // captures the coarse standing; this is the specific date). Both are written
-  // by the outcome-recording endpoint (#898) — this issue only adds the fields.
-  doNotContact: { type: Boolean, required: false, default: false },
+  // #980 (2026-07-18) — `doNotContact` (#923's permanent global outcome
+  // standing, set by a `not-interested` outreach outcome) is DELETED: folded
+  // into `outreachEligible`, which is now the SOLE permanent stop/go gate (a
+  // `not-interested` outcome sets `outreachEligible=false` instead — see
+  // outreach-controller.ts's applyOutcomeSideEffects). Any venue that still
+  // has `doNotContact:true` in storage is backfilled by the one-time
+  // migrate-drop-do-not-contact.ts script (outreachEligible=false + a dated
+  // note recording the prior exclusion, then $unset doNotContact) — Josh runs
+  // that manually post-merge, same flow as #954/#974.
+  //
+  // `bookedDate` is the actual gig date once a `booked` outreach outcome is
+  // recorded — kept as-is (unrelated to the now-derived `bookingStatus`
+  // above, which only reflects actual linked-gig data, not this outcome log).
   bookedDate: { type: Date, required: false },
   // Per-venue contact timeline (#898) — see touchSchema above.
   touches: { type: [touchSchema], required: false, default: [] },

--- a/src/scripts/migrate-clean-city.ts
+++ b/src/scripts/migrate-clean-city.ts
@@ -1,0 +1,287 @@
+// src/scripts/migrate-clean-city.ts — web-jam-back#980 (city-targeting
+// scope addition, 2026-07-18 comment)
+//
+// One-time cleanup so the AdminVenues city-targeting multi-select (JaMmusic
+// #1238) is trustworthy: `city` is free text today, so "Salem" / "Salem, VA"
+// / "SALEM" all show up as separate, un-mergeable options. This migration:
+//   1. Splits an embedded state off `city` — "Salem, VA" -> city:"Salem" +
+//      usState:"VA" (only when usState is currently empty; when usState is
+//      already set and AGREES with the embedded code, the redundant ", VA"
+//      is still stripped from city; when it DISAGREES, the venue is reported
+//      ambiguous and left untouched — never silently overwritten).
+//   2. Normalizes casing variants of the SAME city name (post state-split)
+//      to a single canonical form: groups venues by lowercased city, and
+//      when exactly one distinct variant in a group is properly title-cased
+//      (e.g. "Salem" among "Salem"/"SALEM"/"salem"), that one wins and every
+//      other variant in the group is rewritten to match it.
+// Going forward, `city` holds the city name ONLY — state lives in `usState`.
+//
+// REPORT, DON'T GUESS (explicit in the issue): anything this script can't
+// confidently resolve is printed in an "AMBIGUOUS — needs manual review"
+// section and left completely untouched (no city/usState write for that
+// venue). Two kinds of ambiguity:
+//   - a `city` containing a comma that ISN'T a clean "City, ST" (2-letter
+//     code) pattern, or whose embedded code conflicts with an existing
+//     usState — can't confidently split.
+//   - a casing group (same name, different case) with either NO clearly
+//     title-cased variant, or MORE THAN ONE disagreeing title-cased variant
+//     (e.g. "DeKalb" vs "Dekalb") — can't confidently pick a canonical form.
+//
+// LESSON FROM #954 (do not repeat — see migrate-drop-contact-verified.ts's
+// header for the full story): writes go through the RAW MongoDB collection
+// (Model.collection.updateOne per venue — city/usState stay in the schema so
+// this isn't strictly the $unset failure mode, but every #980 migration uses
+// the raw collection consistently per the issue's instruction).
+//
+// Idempotent: re-running after a prior --apply only touches venues whose
+// (already-canonical) city would still change — which, once every value in a
+// casing group has been rewritten to the same canonical string, is none.
+// Read-only DRY RUN by default — prints exactly what it would change (and
+// every ambiguous case); pass --apply to write the confident changes.
+//
+// SAFETY GUARD (mirrors the sibling #980/#974/#954 migrations): refuses to
+// run at all against anything that doesn't look like local/DEV/TEST (db name
+// containing 'dev'/'test', or localhost/127.0.0.1) unless --force is passed.
+// Running it for real against prod is a deliberate act, run manually
+// post-merge with Josh's explicit go (e.g. `heroku run "npm run
+// migrate:clean-city -- --force" -a webjamsalem` for the dry run, then
+// `--force --apply` to write) — never wired into build/postinstall/Procfile/CI.
+//
+// Usage:
+//   npm run migrate:clean-city                    # dry run, DEV/local
+//   npm run migrate:clean-city -- --apply          # writes, DEV/local only
+//   npm run migrate:clean-city -- --force --apply  # writes for real (prod)
+
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+config(); // load .env if present
+
+interface Args { apply: boolean; force: boolean }
+export function parseArgs(argv: string[]): Args {
+  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
+}
+
+// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
+export function isSafeToRun(uri: string, force: boolean): boolean {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+  return isLocal || isDevOrTest || force;
+}
+
+interface VenueDoc { _id: unknown; name?: string; city?: string; usState?: string }
+
+// ── Embedded-state split ────────────────────────────────────────────────────
+export type SplitResult =
+  | { kind: 'no-change' }
+  | { kind: 'split'; city: string; state: string }
+  | { kind: 'ambiguous'; reason: string };
+
+// A comma followed by exactly a 2-letter code (optionally trailed by a
+// stray period, e.g. "D.C." style typos don't match — deliberately: that's
+// reported ambiguous, not guessed). Anchored at the END of the string so
+// "Winston-Salem, NC" splits on the LAST comma-code pair only.
+const EMBEDDED_STATE_RE = /^(.*),\s*([A-Za-z]{2})\.?$/;
+
+export function splitEmbeddedState(rawCity: string, existingUsState: string | undefined): SplitResult {
+  const trimmed = rawCity.trim();
+  if (!trimmed.includes(',')) return { kind: 'no-change' };
+  const m = trimmed.match(EMBEDDED_STATE_RE);
+  if (!m) return { kind: 'ambiguous', reason: `contains a comma but isn't a clear "City, ST" pattern: "${trimmed}"` };
+  const cityPart = m[1].trim();
+  const statePart = m[2].toUpperCase();
+  if (!cityPart) return { kind: 'ambiguous', reason: `embedded state with no city text: "${trimmed}"` };
+  const existing = (existingUsState || '').trim().toUpperCase();
+  if (existing && existing !== statePart) {
+    return { kind: 'ambiguous', reason: `embedded state "${statePart}" conflicts with existing usState "${existing}": "${trimmed}"` };
+  }
+  return { kind: 'split', city: cityPart, state: statePart };
+}
+
+// ── Casing canonicalization ─────────────────────────────────────────────────
+// A word is "properly cased" when it starts with an uppercase letter — loose
+// on purpose, so a real embedded-capital city name (McKinney, DeKalb,
+// O'Fallon) still counts as ONE valid candidate casing. Split on whitespace
+// AND hyphens (kept as separate tokens) so "Winston-Salem" and "St. Louis"
+// both check word-by-word. The whole-string isAllOneCase check in
+// isTitleCased below (not here) is what rules out "SALEM" / "salem"; two
+// DIFFERENT mixed-case spellings of the same city (e.g. "DeKalb" vs
+// "Dekalb") both pass this per-word check, so resolveCanonicalCasing's
+// group-level comparison is what catches THAT disagreement and reports it
+// ambiguous instead of guessing.
+const WORD_SPLIT_RE = /([\s-])/;
+function isProperWord(word: string): boolean {
+  if (word === '') return true;
+  return /^[A-Z]/.test(word);
+}
+export function isTitleCased(value: string): boolean {
+  if (value !== value.trim() || !value) return false;
+  const isAllOneCase = value === value.toUpperCase() || value === value.toLowerCase();
+  if (isAllOneCase && value.replace(/[^A-Za-z]/g, '').length > 1) return false; // "SALEM" / "salem" — not properly cased
+  return value.split(WORD_SPLIT_RE).every((token) => (WORD_SPLIT_RE.test(token) ? true : isProperWord(token)));
+}
+
+export interface AmbiguousCasingGroup { key: string; variants: string[] }
+export interface CasingResult {
+  canonicalMap: Map<string, string>;
+  ambiguousGroups: AmbiguousCasingGroup[];
+}
+
+// Groups the given (already state-split, trimmed) city strings by lowercased
+// key; within each multi-variant group, picks the single title-cased variant
+// as canonical (see module header for the ambiguous cases).
+export function resolveCanonicalCasing(cities: string[]): CasingResult {
+  const groups = new Map<string, Set<string>>();
+  for (const c of cities) {
+    const key = c.toLowerCase();
+    if (!groups.has(key)) groups.set(key, new Set());
+    (groups.get(key) as Set<string>).add(c);
+  }
+  const canonicalMap = new Map<string, string>();
+  const ambiguousGroups: AmbiguousCasingGroup[] = [];
+  for (const [key, variantSet] of groups) {
+    const variants = Array.from(variantSet);
+    if (variants.length === 1) { canonicalMap.set(variants[0], variants[0]); continue; }
+    const titleCasedVariants = variants.filter(isTitleCased);
+    if (titleCasedVariants.length === 1) {
+      const canonical = titleCasedVariants[0];
+      for (const v of variants) canonicalMap.set(v, canonical);
+    } else {
+      ambiguousGroups.push({ key, variants: variants.sort() });
+    }
+  }
+  return { canonicalMap, ambiguousGroups };
+}
+
+function logSafetyBlock(uri: string, maskedUri: string): void {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  console.error('ERROR: migrate-clean-city only runs against a local, DEV, or TEST database by default — never release/production.');
+  console.error(`Target MONGO URI: ${maskedUri}`);
+  console.error(`Parsed database name: ${dbName || '(none)'}`);
+  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
+}
+
+interface Plan {
+  venue: VenueDoc;
+  finalCity: string;
+  finalUsState?: string;
+}
+interface AmbiguousVenue { venue: VenueDoc; reason: string }
+
+// Build the per-venue split plan + collect split-level ambiguities. Split
+// out of run() to keep its cognitive complexity down.
+export function buildSplitPlans(venues: VenueDoc[]): { working: { venue: VenueDoc; city: string; state?: string }[]; ambiguous: AmbiguousVenue[] } {
+  const working: { venue: VenueDoc; city: string; state?: string }[] = [];
+  const ambiguous: AmbiguousVenue[] = [];
+  for (const venue of venues) {
+    const result = splitEmbeddedState(venue.city || '', venue.usState);
+    if (result.kind === 'ambiguous') { ambiguous.push({ venue, reason: result.reason }); continue; }
+    if (result.kind === 'split') { working.push({ venue, city: result.city, state: result.state }); continue; }
+    working.push({ venue, city: (venue.city || '').trim() });
+  }
+  return { working, ambiguous };
+}
+
+// Apply the casing pass on top of the split plans, splitting out casing-level
+// ambiguities and building the final per-venue write plan (only venues whose
+// final city/usState actually differs from the stored value are included).
+export function buildFinalPlans(
+  working: { venue: VenueDoc; city: string; state?: string }[],
+): { plans: Plan[]; ambiguous: AmbiguousVenue[] } {
+  const { canonicalMap, ambiguousGroups } = resolveCanonicalCasing(working.map((w) => w.city));
+  const ambiguousKeys = new Set(ambiguousGroups.map((g) => g.key));
+  const plans: Plan[] = [];
+  const ambiguous: AmbiguousVenue[] = [];
+  for (const w of working) {
+    if (ambiguousKeys.has(w.city.toLowerCase())) {
+      const group = ambiguousGroups.find((g) => g.key === w.city.toLowerCase()) as AmbiguousCasingGroup;
+      ambiguous.push({ venue: w.venue, reason: `casing variants disagree, no single title-cased form: ${group.variants.join(' / ')}` });
+      continue;
+    }
+    const finalCity = canonicalMap.get(w.city) || w.city;
+    const cityChanged = finalCity !== (w.venue.city || '').trim();
+    const stateChanged = Boolean(w.state) && !(w.venue.usState || '').trim();
+    if (!cityChanged && !stateChanged) continue; // no-op — nothing to write
+    plans.push({
+      venue: w.venue,
+      finalCity,
+      finalUsState: stateChanged ? w.state : undefined,
+    });
+  }
+  return { plans, ambiguous };
+}
+
+// Print the plan/write line for every venue that would change, then the
+// ambiguous-cases section (if any). Split out of run() to keep its cognitive
+// complexity down.
+function logPlansAndAmbiguous(plans: Plan[], ambiguous: AmbiguousVenue[], apply: boolean): void {
+  for (const { venue, finalCity, finalUsState } of plans) {
+    const verb = apply ? 'WRITE' : 'PLAN';
+    const stateNote = finalUsState ? `, usState -> "${finalUsState}"` : '';
+    console.log(`  ${verb}: venue ${String(venue._id)} "${venue.name}" city "${venue.city}" -> "${finalCity}"${stateNote}`);
+  }
+  if (!ambiguous.length) return;
+  console.log('\nAMBIGUOUS — needs manual review (left untouched):');
+  for (const { venue, reason } of ambiguous) {
+    console.log(`  venue ${String(venue._id)} "${venue.name}": ${reason}`);
+  }
+}
+
+// Write every confirmed (non-ambiguous) plan via the raw collection. Split
+// out of run() to keep its cognitive complexity down.
+async function applyPlans(plans: Plan[]): Promise<number> {
+  let modifiedCount = 0;
+  for (const { venue, finalCity, finalUsState } of plans) {
+    const update: Record<string, unknown> = { $set: { city: finalCity, ...(finalUsState ? { usState: finalUsState } : {}) } };
+    const filter = { _id: new mongoose.Types.ObjectId(String(venue._id)) };
+    // eslint-disable-next-line no-await-in-loop
+    const res = await venueModel.Schema.collection.updateOne(filter, update);
+    modifiedCount += res.modifiedCount || 0;
+  }
+  return modifiedCount;
+}
+
+async function run(): Promise<void> {
+  const { apply, force } = parseArgs(process.argv.slice(2));
+  const uri = process.env.MONGO_DB_URI || '';
+  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
+  if (!isSafeToRun(uri, force)) {
+    logSafetyBlock(uri, maskedUri);
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
+  console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
+
+  const venues = (await venueModel.find({ city: { $exists: true, $ne: '' } })) as unknown as VenueDoc[];
+  const { working, ambiguous: splitAmbiguous } = buildSplitPlans(venues);
+  const { plans, ambiguous: casingAmbiguous } = buildFinalPlans(working);
+  const ambiguous = [...splitAmbiguous, ...casingAmbiguous];
+
+  logPlansAndAmbiguous(plans, ambiguous, apply);
+
+  const modifiedCount = apply ? await applyPlans(plans) : 0;
+
+  console.log(`\n${venues.length} venue(s) scanned; ${plans.length} would change; ${ambiguous.length} ambiguous (needs Josh).`);
+  console.log(apply
+    ? `${modifiedCount} venue(s) updated.`
+    : `Dry run — ${plans.length} venue(s) WOULD be updated. Re-run with --apply to write for real.`);
+
+  await mongoose.connection.close();
+}
+
+// Only auto-execute when run directly — NOT when imported by a unit test.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+/* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
+if (isMain) {
+  run().catch((err) => {
+    console.error('Migration failed:', (err as Error).message);
+    process.exit(1);
+  });
+}
+
+export { run };

--- a/src/scripts/migrate-clean-city.ts
+++ b/src/scripts/migrate-clean-city.ts
@@ -52,25 +52,12 @@
 //   npm run migrate:clean-city -- --apply          # writes, DEV/local only
 //   npm run migrate:clean-city -- --force --apply  # writes for real (prod)
 
-import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import mongoose from 'mongoose';
 import venueModel from '#src/model/venue/venue-facade.js';
+import { guardOrExit, isMainModule } from '#src/lib/migration-cli.js';
 
 config(); // load .env if present
-
-interface Args { apply: boolean; force: boolean }
-export function parseArgs(argv: string[]): Args {
-  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
-}
-
-// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
-export function isSafeToRun(uri: string, force: boolean): boolean {
-  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
-  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
-  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
-  return isLocal || isDevOrTest || force;
-}
 
 interface VenueDoc { _id: unknown; name?: string; city?: string; usState?: string }
 
@@ -156,14 +143,6 @@ export function resolveCanonicalCasing(cities: string[]): CasingResult {
   return { canonicalMap, ambiguousGroups };
 }
 
-function logSafetyBlock(uri: string, maskedUri: string): void {
-  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
-  console.error('ERROR: migrate-clean-city only runs against a local, DEV, or TEST database by default — never release/production.');
-  console.error(`Target MONGO URI: ${maskedUri}`);
-  console.error(`Parsed database name: ${dbName || '(none)'}`);
-  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
-}
-
 interface Plan {
   venue: VenueDoc;
   finalCity: string;
@@ -245,13 +224,7 @@ async function applyPlans(plans: Plan[]): Promise<number> {
 }
 
 async function run(): Promise<void> {
-  const { apply, force } = parseArgs(process.argv.slice(2));
-  const uri = process.env.MONGO_DB_URI || '';
-  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
-  if (!isSafeToRun(uri, force)) {
-    logSafetyBlock(uri, maskedUri);
-    process.exit(1);
-  }
+  const { apply, uri, maskedUri } = guardOrExit('migrate-clean-city', 'migrate:clean-city');
 
   await mongoose.connect(uri);
   console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
@@ -275,9 +248,8 @@ async function run(): Promise<void> {
 }
 
 // Only auto-execute when run directly — NOT when imported by a unit test.
-const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 /* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
-if (isMain) {
+if (isMainModule(import.meta.url)) {
   run().catch((err) => {
     console.error('Migration failed:', (err as Error).message);
     process.exit(1);

--- a/src/scripts/migrate-drop-do-not-contact.ts
+++ b/src/scripts/migrate-drop-do-not-contact.ts
@@ -1,0 +1,179 @@
+// src/scripts/migrate-drop-do-not-contact.ts — web-jam-back#980
+//
+// One-time backfill: `doNotContact` is deleted entirely (folded into
+// `outreachEligible`, now the SOLE permanent stop/go gate). For every venue
+// that still has `doNotContact: true`:
+//   - set `outreachEligible: false` (the permanent exclusion moves here)
+//   - APPEND a dated line to `notes` recording the prior exclusion (never
+//     overwrite existing notes — same append rule as the live not-interested
+//     outcome handler in outreach-controller.ts)
+//   - `$unset doNotContact`
+// A venue that has `doNotContact` set to anything OTHER than `true` (e.g.
+// `false`, stored by a stray earlier write) just has the field removed —
+// there is no prior exclusion to carry forward.
+//
+// LESSON FROM #954 (do not repeat — see migrate-drop-contact-verified.ts's
+// header for the full story): a schema-bound mongoose update method ($unset
+// via Model.findByIdAndUpdate / Model.updateMany) silently DROPS an
+// unknown-field write instruction once that field is removed from the
+// schema (strict mode casts it away before the write ever reaches Mongo).
+// This migration writes via the RAW MongoDB collection
+// (Model.collection.updateMany with an aggregation-pipeline update) instead,
+// which bypasses mongoose's schema casting entirely, AND lets the notes
+// append reference each document's OWN existing `notes` value in one atomic
+// per-document write (no separate read-then-write race).
+//
+// Idempotent: only venues where `doNotContact` still exists are candidates,
+// so a re-run after a prior --apply is a no-op (the field is gone). Read-only
+// DRY RUN by default — prints exactly what it would change; pass --apply to
+// write.
+//
+// SAFETY GUARD (mirrors migrate-drop-in-scope.ts / migrate-drop-contact-
+// verified.ts): this migration permanently flips outreachEligible on real
+// venue records, so it refuses to run at all against anything that doesn't
+// look like local/DEV/TEST (db name containing 'dev'/'test', or
+// localhost/127.0.0.1) unless --force is passed. Running it for real against
+// prod is a deliberate act, run manually post-merge with Josh's explicit go
+// (e.g. `heroku run "npm run migrate:drop-do-not-contact -- --force" -a
+// webjamsalem` for the dry run, then `--force --apply` to write) — never
+// wired into build/postinstall/Procfile/CI.
+//
+// Usage:
+//   npm run migrate:drop-do-not-contact                    # dry run, DEV/local
+//   npm run migrate:drop-do-not-contact -- --apply          # writes, DEV/local only
+//   npm run migrate:drop-do-not-contact -- --force --apply  # writes for real (prod)
+
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+config(); // load .env if present
+
+interface Args { apply: boolean; force: boolean }
+export function parseArgs(argv: string[]): Args {
+  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
+}
+
+// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
+// Mirrors the sibling migrations' guard exactly: only db names/hosts that
+// look local/DEV/TEST are allowed without --force. Pure predicate (no
+// process.exit) so it's unit-testable; run() below is what actually exits.
+export function isSafeToRun(uri: string, force: boolean): boolean {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
+  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
+  return isLocal || isDevOrTest || force;
+}
+
+interface VenueDoc { _id: unknown; name?: string; doNotContact?: boolean; notes?: string }
+
+const DNC_FILTER = { doNotContact: { $exists: true } };
+
+// The dated note line appended for every venue that was doNotContact:true.
+// Built once per run (same date for the whole batch, which is fine — it's a
+// single migration run producing one dated record per venue).
+export function buildNoteLine(now: Date): string {
+  const dateStr = now.toISOString().slice(0, 10);
+  return `[${dateStr}] Previously doNotContact:true (permanent exclusion) — migrated to outreachEligible:false (#980).`;
+}
+
+function logSafetyBlock(uri: string, maskedUri: string): void {
+  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
+  console.error('ERROR: migrate-drop-do-not-contact only runs against a local, DEV, or TEST database by default — never release/production.');
+  console.error(`Target MONGO URI: ${maskedUri}`);
+  console.error(`Parsed database name: ${dbName || '(none)'}`);
+  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
+}
+
+async function run(): Promise<void> {
+  const { apply, force } = parseArgs(process.argv.slice(2));
+  const uri = process.env.MONGO_DB_URI || '';
+  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
+  if (!isSafeToRun(uri, force)) {
+    logSafetyBlock(uri, maskedUri);
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
+  console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
+
+  // Idempotent: only venues that still carry the field are candidates.
+  // Deliberately NOT scoped to status != archived — an archived venue may be
+  // unarchived later and should come back permanently excluded
+  // (outreachEligible:false), not silently back in play.
+  const candidates = (await venueModel.find(DNC_FILTER)) as unknown as VenueDoc[];
+  const wasDoNotContactTrue = candidates.filter((v) => v.doNotContact === true);
+  const fieldOnlyRemoved = candidates.length - wasDoNotContactTrue.length;
+  const now = new Date();
+  const noteLine = buildNoteLine(now);
+
+  for (const venue of candidates) {
+    const verb = apply ? 'WRITE' : 'PLAN';
+    if (venue.doNotContact === true) {
+      console.log(`  ${verb}: venue ${String(venue._id)} "${venue.name}" doNotContact:true -> outreachEligible:false `
+        + `(note appended, doNotContact removed)`);
+    } else {
+      console.log(`  ${verb}: venue ${String(venue._id)} "${venue.name}" doNotContact removed (was not true — no other change)`);
+    }
+  }
+
+  let modifiedCount = 0;
+  if (apply && candidates.length) {
+    // RAW COLLECTION WRITE — see the #954 lesson in the header comment above.
+    // Two separate pipeline updateMany calls (one per prior-value branch) so
+    // the "was true" group gets the outreachEligible flip + note append, and
+    // the "was something else" group just loses the field — a single
+    // pipeline can't conditionally add the note ONLY for a subset the same
+    // way two scoped calls can, and keeps each call's intent simple to read.
+    if (wasDoNotContactTrue.length) {
+      const res = await venueModel.Schema.collection.updateMany(
+        { doNotContact: true },
+        [
+          {
+            $set: {
+              outreachEligible: false,
+              notes: {
+                $cond: [
+                  { $and: [{ $ne: ['$notes', null] }, { $ne: ['$notes', ''] }] },
+                  { $concat: ['$notes', '\n', noteLine] },
+                  noteLine,
+                ],
+              },
+            },
+          },
+          { $unset: 'doNotContact' },
+        ],
+      );
+      modifiedCount += res.modifiedCount || 0;
+    }
+    if (fieldOnlyRemoved) {
+      const res = await venueModel.Schema.collection.updateMany(
+        { doNotContact: { $exists: true, $ne: true } },
+        { $unset: { doNotContact: '' } },
+      );
+      modifiedCount += res.modifiedCount || 0;
+    }
+  }
+
+  console.log(`\n${candidates.length} venue(s) scanned (still had doNotContact); `
+    + `${wasDoNotContactTrue.length} were doNotContact:true (-> outreachEligible:false + note); ${fieldOnlyRemoved} just lose the field.`);
+  console.log(apply
+    ? `${modifiedCount} venue(s) updated.`
+    : `Dry run — ${candidates.length} venue(s) WOULD be updated. Re-run with --apply to write for real.`);
+
+  await mongoose.connection.close();
+}
+
+// Only auto-execute when run directly — NOT when imported by a unit test.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+/* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
+if (isMain) {
+  run().catch((err) => {
+    console.error('Migration failed:', (err as Error).message);
+    process.exit(1);
+  });
+}
+
+export { run };

--- a/src/scripts/migrate-drop-do-not-contact.ts
+++ b/src/scripts/migrate-drop-do-not-contact.ts
@@ -43,28 +43,12 @@
 //   npm run migrate:drop-do-not-contact -- --apply          # writes, DEV/local only
 //   npm run migrate:drop-do-not-contact -- --force --apply  # writes for real (prod)
 
-import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import mongoose from 'mongoose';
 import venueModel from '#src/model/venue/venue-facade.js';
+import { guardOrExit, isMainModule } from '#src/lib/migration-cli.js';
 
 config(); // load .env if present
-
-interface Args { apply: boolean; force: boolean }
-export function parseArgs(argv: string[]): Args {
-  return { apply: argv.includes('--apply'), force: argv.includes('--force') };
-}
-
-// ── SAFETY GUARD ─────────────────────────────────────────────────────────────
-// Mirrors the sibling migrations' guard exactly: only db names/hosts that
-// look local/DEV/TEST are allowed without --force. Pure predicate (no
-// process.exit) so it's unit-testable; run() below is what actually exits.
-export function isSafeToRun(uri: string, force: boolean): boolean {
-  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
-  const isLocal = uri.includes('localhost') || uri.includes('127.0.0.1');
-  const isDevOrTest = dbName.includes('dev') || dbName.includes('test');
-  return isLocal || isDevOrTest || force;
-}
 
 interface VenueDoc { _id: unknown; name?: string; doNotContact?: boolean; notes?: string }
 
@@ -78,22 +62,8 @@ export function buildNoteLine(now: Date): string {
   return `[${dateStr}] Previously doNotContact:true (permanent exclusion) — migrated to outreachEligible:false (#980).`;
 }
 
-function logSafetyBlock(uri: string, maskedUri: string): void {
-  const dbName = (uri.split('?')[0].split('/').pop() || '').toLowerCase();
-  console.error('ERROR: migrate-drop-do-not-contact only runs against a local, DEV, or TEST database by default — never release/production.');
-  console.error(`Target MONGO URI: ${maskedUri}`);
-  console.error(`Parsed database name: ${dbName || '(none)'}`);
-  console.error('Pass --force to run against a different database anyway (a deliberate, reviewed prod backfill).');
-}
-
 async function run(): Promise<void> {
-  const { apply, force } = parseArgs(process.argv.slice(2));
-  const uri = process.env.MONGO_DB_URI || '';
-  const maskedUri = uri.replace(/\/\/[^@]+@/, '//<credentials>@'); // eslint-disable-line sonarjs/slow-regex
-  if (!isSafeToRun(uri, force)) {
-    logSafetyBlock(uri, maskedUri);
-    process.exit(1);
-  }
+  const { apply, uri, maskedUri } = guardOrExit('migrate-drop-do-not-contact', 'migrate:drop-do-not-contact');
 
   await mongoose.connect(uri);
   console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
@@ -167,9 +137,8 @@ async function run(): Promise<void> {
 }
 
 // Only auto-execute when run directly — NOT when imported by a unit test.
-const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 /* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
-if (isMain) {
+if (isMainModule(import.meta.url)) {
   run().catch((err) => {
     console.error('Migration failed:', (err as Error).message);
     process.exit(1);

--- a/test/unit/lib/migration-cli.spec.ts
+++ b/test/unit/lib/migration-cli.spec.ts
@@ -1,0 +1,128 @@
+// Unit tests for the shared one-time-migration CLI scaffolding (#980) —
+// extracted out of migrate-drop-do-not-contact.ts / migrate-clean-city.ts
+// (and duplicated no further into any pre-existing migrate-*.ts script) so
+// jscpd's duplication check stays under threshold. See src/lib/migration-cli.ts
+// header for the full story.
+import {
+  parseArgs, isSafeToRun, maskMongoUri, logSafetyBlock, isMainModule, guardOrExit,
+} from '#src/lib/migration-cli.js';
+
+describe('migration-cli (#980)', () => {
+  describe('parseArgs', () => {
+    it('reads --apply and --force flags', () => {
+      expect(parseArgs([])).toEqual({ apply: false, force: false });
+      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
+      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
+    });
+  });
+
+  describe('isSafeToRun', () => {
+    it('allows a localhost URI', () => {
+      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a 127.0.0.1 URI', () => {
+      expect(isSafeToRun('mongodb://127.0.0.1:27017/anything', false)).toBe(true);
+    });
+
+    it('allows a DEV Atlas db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a TEST db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-test', false)).toBe(true);
+    });
+
+    it('blocks a prod-looking (release) db name without --force', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
+    });
+
+    it('allows a prod-looking db name when --force is passed', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+
+  describe('maskMongoUri', () => {
+    it('masks embedded credentials', () => {
+      expect(maskMongoUri('mongodb+srv://user:pass@cluster.mongodb.net/release')).toBe('mongodb+srv://<credentials>@cluster.mongodb.net/release');
+    });
+
+    it('leaves a credential-free URI untouched', () => {
+      expect(maskMongoUri('mongodb://localhost:27017/web-jam-dev')).toBe('mongodb://localhost:27017/web-jam-dev');
+    });
+  });
+
+  describe('logSafetyBlock', () => {
+    it('logs the refusal message including the script name, npm script, and parsed db name', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      logSafetyBlock('migrate-example', 'migrate:example', 'mongodb+srv://user:pass@cluster.mongodb.net/release', 'mongodb+srv://<credentials>@cluster.mongodb.net/release');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('migrate-example only runs against a local, DEV, or TEST database'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('release'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('migrate:example -- --force'));
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('isMainModule', () => {
+    let originalArgv: string[];
+    beforeEach(() => { originalArgv = process.argv; });
+    afterEach(() => { process.argv = originalArgv; });
+
+    it('true when argv[1] matches the given module URL', () => {
+      process.argv = ['node', '/path/to/script.js'];
+      expect(isMainModule('file:///path/to/script.js')).toBe(true);
+    });
+
+    it('false when argv[1] does not match (imported by a test runner)', () => {
+      process.argv = ['node', '/path/to/vitest.js'];
+      expect(isMainModule('file:///path/to/script.js')).toBe(false);
+    });
+
+    it('false when argv[1] is empty', () => {
+      process.argv = ['node'];
+      expect(isMainModule('file:///path/to/script.js')).toBe(false);
+    });
+  });
+
+  describe('guardOrExit', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    it('returns the parsed args + masked URI for a safe (DEV) target', () => {
+      process.argv = ['node', 'migrate-example.js', '--apply'];
+      process.env.MONGO_DB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev';
+      const ctx = guardOrExit('migrate-example', 'migrate:example');
+      expect(ctx).toEqual({
+        apply: true,
+        force: false,
+        uri: 'mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev',
+        maskedUri: 'mongodb+srv://<credentials>@cluster.mongodb.net/web-jam-dev',
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('exits and logs the safety block for an unsafe target without --force', () => {
+      process.argv = ['node', 'migrate-example.js', '--apply'];
+      process.env.MONGO_DB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/release';
+      expect(() => guardOrExit('migrate-example', 'migrate:example')).toThrow('exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('migrate-example only runs against a local, DEV, or TEST database'));
+    });
+  });
+});

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -585,14 +585,63 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect((venueModel as any).find).toHaveBeenCalledWith(expect.objectContaining({ outreachEligible: true }));
     });
 
-    // #923 — doNotContact is a permanent global exclusion, on top of the
-    // existing outreachEligible gate; the query itself excludes it (the venue
-    // never comes back from Mongo in the first place).
-    it('excludes doNotContact venues from the query (#923)', async () => {
+    // #980 — doNotContact is gone entirely (folded into outreachEligible,
+    // the SOLE permanent stop/go gate now) — the query must never reference
+    // it anymore.
+    it('no longer references doNotContact in the query (#980)', async () => {
       (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
       await c.getCandidates({ user: 'a', query: {} }, resStub);
       expect(status).toBe(200);
-      expect((venueModel as any).find).toHaveBeenCalledWith(expect.objectContaining({ doNotContact: { $ne: true } }));
+      const callArg = (venueModel as any).find.mock.calls[0][0];
+      expect(callArg).not.toHaveProperty('doNotContact');
+    });
+
+    // #980 — no active resumeBooking cooldown: unset, null, or already in
+    // the past are all fine; only a future date blocks. Enforced at the
+    // query level (ADDITIONAL to outreachEligible, never a replacement).
+    it('excludes an active resumeBooking cooldown via the query (#980)', async () => {
+      (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+      await c.getCandidates({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(200);
+      const callArg = (venueModel as any).find.mock.calls[0][0];
+      expect(callArg.$or).toEqual(expect.arrayContaining([
+        { resumeBooking: { $exists: false } },
+        { resumeBooking: null },
+        { resumeBooking: { $lte: expect.any(Date) } },
+      ]));
+    });
+
+    // #980 — optional cities filter, AND'd with every other criterion;
+    // omitted/empty = all cities (back-compat).
+    describe('cities filter (#980)', () => {
+      it('adds a city $in clause when cities is given', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: { cities: 'Salem,Roanoke' } }, resStub);
+        expect(status).toBe(200);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg.city).toEqual({ $in: ['Salem', 'Roanoke'] });
+      });
+
+      it('trims whitespace and drops empty entries from a comma-separated cities list', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: { cities: ' Salem , , Roanoke ' } }, resStub);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg.city).toEqual({ $in: ['Salem', 'Roanoke'] });
+      });
+
+      it('omits the city clause entirely when cities is absent — all cities (back-compat)', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg).not.toHaveProperty('city');
+      });
+
+      it('omits the city clause when cities is an empty string', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: { cities: '' } }, resStub);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg).not.toHaveProperty('city');
+      });
     });
 
     // #974 — the sendability precondition (no VALID primary email = not
@@ -627,22 +676,45 @@ describe('Outreach Controller (#844 batch model)', () => {
       }));
     });
 
-    // #958 SAFETY — the core motivation for this issue: a venue booked
-    // outside the pitch flow (phone/in-person) must never be re-suggested.
-    describe('excludes venues with an upcoming linked gig (#958 SAFETY)', () => {
-      it('drops a venue matched by venueId with a future gig', async () => {
-        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }, { _id: 'b' }]));
+    // #980 — the gigInterval-aware generalization of the old #958 SAFETY
+    // blanket exclusion. gigInterval=0 (every venue's default, and every
+    // venue's value before the #980 migration) now means NO spacing check at
+    // all — the old "any upcoming linked gig excludes forever" rule (the
+    // "repeat-venue trap" #980 fixes) is gone by design. A venue only gets
+    // spaced out once it's explicitly opted in via gigInterval > 0.
+    describe('gigInterval spacing (#980)', () => {
+      it('does NOT drop a venue with an upcoming gig when gigInterval is 0 (the default) — the repeat-venue trap is fixed', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 0 }]));
         (gigModel as any).find = vi.fn(() => Promise.resolve([
           { venueId: 'a', datetime: new Date(Date.now() + 86400000).toISOString() },
         ]));
         await c.getCandidates({ user: 'a', query: {} }, resStub);
         expect(status).toBe(200);
         expect(payload).toHaveLength(1);
-        expect(payload[0]._id).toBe('b');
       });
 
-      it('drops a venue matched by exact normalized name with a future gig', async () => {
-        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', name: 'Durty Bull' }]));
+      it('does NOT drop a venue with an upcoming gig when gigInterval is unset (default) either', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: new Date(Date.now() + 86400000).toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        expect(payload).toHaveLength(1);
+      });
+
+      it('drops a venue (matched by venueId) whose linked gig is within gigInterval months of the target window', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 3 }, { _id: 'b', gigInterval: 3 }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: VALID_WEEKEND.start }, // exactly the target window
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.candidates.map((v: any) => v._id)).toEqual(['b']);
+      });
+
+      it('drops a venue matched by exact normalized name whose gig is too close', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', name: 'Durty Bull', gigInterval: 6 }]));
         (gigModel as any).find = vi.fn(() => Promise.resolve([
           { venue: 'DURTY, BULL!', datetime: new Date(Date.now() + 86400000).toISOString() },
         ]));
@@ -651,14 +723,68 @@ describe('Outreach Controller (#844 batch model)', () => {
         expect(payload).toHaveLength(0);
       });
 
-      it('does NOT drop a venue whose linked gig is in the past', async () => {
-        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+      it('does NOT drop when the linked gig is exactly gigInterval months away (boundary is inclusive of "ok")', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 2 }]));
+        const w = new Date(VALID_WEEKEND.start);
+        const exactlyTwoMonthsOut = new Date(w); exactlyTwoMonthsOut.setMonth(exactlyTwoMonthsOut.getMonth() + 2);
         (gigModel as any).find = vi.fn(() => Promise.resolve([
-          { venueId: 'a', datetime: new Date(Date.now() - 86400000).toISOString() },
+          { venueId: 'a', datetime: exactlyTwoMonthsOut.toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.candidates).toHaveLength(1);
+      });
+
+      it('checks the NEAREST gig on EITHER side of the target window (a past gig can be too close too)', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 3 }]));
+        const w = new Date(VALID_WEEKEND.start);
+        const oneMonthBefore = new Date(w); oneMonthBefore.setMonth(oneMonthBefore.getMonth() - 1);
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: oneMonthBefore.toISOString() }, // in the past, but only 1 month from W
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.candidates).toHaveLength(0);
+      });
+
+      it('with multiple linked gigs, drops the venue if ANY one of them is too close', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 2 }]));
+        const w = new Date(VALID_WEEKEND.start);
+        const farBefore = new Date(w); farBefore.setFullYear(farBefore.getFullYear() - 1);
+        const farAfter = new Date(w); farAfter.setFullYear(farAfter.getFullYear() + 1);
+        const closeAfter = new Date(w); closeAfter.setDate(closeAfter.getDate() + 10);
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: farBefore.toISOString() },
+          { venueId: 'a', datetime: closeAfter.toISOString() },
+          { venueId: 'a', datetime: farAfter.toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.candidates).toHaveLength(0);
+      });
+
+      it('with multiple linked gigs, keeps the venue when EVERY one of them clears the spacing', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 2 }]));
+        const w = new Date(VALID_WEEKEND.start);
+        const farBefore = new Date(w); farBefore.setFullYear(farBefore.getFullYear() - 1);
+        const farAfter = new Date(w); farAfter.setFullYear(farAfter.getFullYear() + 1);
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: farBefore.toISOString() },
+          { venueId: 'a', datetime: farAfter.toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        expect(payload.candidates).toHaveLength(1);
+      });
+
+      it('uses "now" as the target window when no targetWeekend is given', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 3 }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: new Date(Date.now() + 86400000).toISOString() }, // ~tomorrow, well within 3 months of now
         ]));
         await c.getCandidates({ user: 'a', query: {} }, resStub);
         expect(status).toBe(200);
-        expect(payload).toHaveLength(1);
+        expect(payload).toHaveLength(0);
       });
 
       it('500s when the gig query throws', async () => {
@@ -1840,17 +1966,29 @@ describe('Outreach Controller (#844 batch model)', () => {
       }));
     });
 
-    it('not-interested sets venue.doNotContact permanently', async () => {
+    // #980 — doNotContact is gone; not-interested now sets outreachEligible
+    // false (the SOLE permanent stop/go gate) and appends a dated note.
+    it('not-interested sets venue.outreachEligible false permanently and appends a dated note (#980)', async () => {
       const rec = outreachRec();
       c.model.findById = vi.fn(() => Promise.resolve(rec));
       const venueUpd = vi.fn(() => Promise.resolve({}));
       (venueModel as any).findByIdAndUpdate = venueUpd;
       await c.recordOutcome({ user: 'a', params: { id: String(rec._id) }, body: { status: 'not-interested' } }, resStub);
       expect(status).toBe(200);
-      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({ doNotContact: true }));
+      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({ outreachEligible: false }));
+      // The note-append call: a single pipeline update (array), never a
+      // separate read-then-write — see appendVenueNote's header comment.
+      const noteCall = venueUpd.mock.calls.find((call: any) => Array.isArray(call[1]));
+      expect(noteCall).toBeTruthy();
+      const pipeline = (noteCall as any)[1][0];
+      const line = pipeline.$set.notes.$cond[2];
+      expect(line).toContain('not-interested');
+      expect(line).toContain('outreachEligible set to false');
     });
 
-    it('booked stamps bookedDate on the record + venue, and marks venue.bookingStatus booked', async () => {
+    // #980 — bookingStatus is no longer written here (it's derived purely
+    // from actual linked-gig data now); bookedDate is unaffected.
+    it('booked stamps bookedDate on the record + venue, WITHOUT touching bookingStatus (#980)', async () => {
       const rec = outreachRec();
       c.model.findById = vi.fn(() => Promise.resolve(rec));
       const outreachUpd = vi.fn((id: string, u: any) => Promise.resolve({ _id: id, ...u }));
@@ -1863,9 +2001,10 @@ describe('Outreach Controller (#844 batch model)', () => {
       }, resStub);
       expect(status).toBe(200);
       expect((outreachUpd.mock.calls[0] as any)[1].bookedDate).toEqual(new Date('2026-09-26'));
-      expect(venueUpd).toHaveBeenCalledWith(String(rec.venueId), expect.objectContaining({
-        bookedDate: new Date('2026-09-26'), bookingStatus: 'booked',
-      }));
+      const bookedDateCall = venueUpd.mock.calls.find((call: any) => call[1] && call[1].bookedDate);
+      expect(bookedDateCall).toBeTruthy();
+      expect((bookedDateCall as any)[1]).not.toHaveProperty('bookingStatus');
+      expect((bookedDateCall as any)[1].bookedDate).toEqual(new Date('2026-09-26'));
     });
 
     it('booked auto-flips every OTHER sent+overlapping record to target-filled (+ nextTouchDue null)', async () => {

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -795,6 +795,68 @@ describe('Outreach Controller (#844 batch model)', () => {
       });
     });
 
+    // #980/JaMmusic#1238 — every candidate carries a `reason` object so the
+    // Find-Eligible UI can show why it qualified without re-deriving
+    // eligibility client-side (buildCandidateReason).
+    describe('candidate reason (#980)', () => {
+      it('reports spacing off when gigInterval is 0 (the default)', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 0 }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(payload[0].reason).toMatchObject({
+          gigIntervalMonths: 0, spacingNote: 'spacing off (gigInterval=0)', nearestGigMonthsAway: null, lastGigDate: null,
+        });
+      });
+
+      it('reports "no gigs yet" when gigInterval is set but the venue has no linked gigs', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 3 }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(payload[0].reason).toMatchObject({ gigIntervalMonths: 3, spacingNote: 'no gigs yet', nearestGigMonthsAway: null });
+      });
+
+      it('reports the nearest-gig distance (months) when the venue clears spacing', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 2 }]));
+        const w = new Date(VALID_WEEKEND.start);
+        const sixMonthsOut = new Date(w); sixMonthsOut.setMonth(sixMonthsOut.getMonth() + 6);
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: sixMonthsOut.toISOString() },
+        ]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(payload.candidates[0].reason.gigIntervalMonths).toBe(2);
+        expect(payload.candidates[0].reason.nearestGigMonthsAway).toBeCloseTo(6, 0);
+        expect(payload.candidates[0].reason.spacingNote).toContain('clear — nearest gig');
+      });
+
+      it('reports lastGigDate as the most recent PAST linked gig, picking the latest among several', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a', gigInterval: 0 }]));
+        const older = new Date(Date.now() - 200 * 86400000).toISOString();
+        const mostRecent = new Date(Date.now() - 10 * 86400000).toISOString();
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: 'a', datetime: older },
+          { venueId: 'a', datetime: mostRecent },
+        ]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(payload[0].reason.lastGigDate).toBe(new Date(mostRecent).toISOString());
+      });
+
+      it('reports resumeBookingExpired true for a past resumeBooking date', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([
+          { _id: 'a', resumeBooking: new Date(Date.now() - 86400000).toISOString() },
+        ]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(payload[0].reason.resumeBookingExpired).toBe(true);
+      });
+
+      it('reports resumeBookingExpired false when resumeBooking is unset', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(payload[0].reason.resumeBookingExpired).toBe(false);
+      });
+    });
+
     // #958 — weekend awareness: surfaces Josh's whole gig schedule for the
     // requested weekend (any venue), independent of the per-venue safety
     // exclusion above.

--- a/test/unit/scripts/migrate-clean-city.spec.ts
+++ b/test/unit/scripts/migrate-clean-city.spec.ts
@@ -1,0 +1,320 @@
+// Unit tests for the #980 city-cleanup migration script's logic. Importing
+// the module must NOT touch Mongo or process.exit (no top-level side effects
+// beyond dotenv) — run()'s isMain guard is never true under vitest.
+import mongoose from 'mongoose';
+import {
+  isSafeToRun, parseArgs, run,
+  splitEmbeddedState, isTitleCased, resolveCanonicalCasing,
+  buildSplitPlans, buildFinalPlans,
+} from '#src/scripts/migrate-clean-city.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+describe('migrate-clean-city (#980)', () => {
+  describe('parseArgs', () => {
+    it('reads --apply and --force flags', () => {
+      expect(parseArgs([])).toEqual({ apply: false, force: false });
+      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
+      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
+    });
+  });
+
+  describe('isSafeToRun', () => {
+    it('allows a localhost URI', () => {
+      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
+    });
+
+    it('blocks a prod-looking (release) db name without --force', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
+    });
+
+    it('allows a prod-looking db name when --force is passed', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+
+  describe('splitEmbeddedState', () => {
+    it('no-change when there is no comma at all', () => {
+      expect(splitEmbeddedState('Salem', undefined)).toEqual({ kind: 'no-change' });
+    });
+
+    it('splits a clean "City, ST" pattern when usState is empty', () => {
+      expect(splitEmbeddedState('Salem, VA', undefined)).toEqual({ kind: 'split', city: 'Salem', state: 'VA' });
+    });
+
+    it('splits a multi-word city with an embedded state', () => {
+      expect(splitEmbeddedState('Winston-Salem, NC', '')).toEqual({ kind: 'split', city: 'Winston-Salem', state: 'NC' });
+    });
+
+    it('still splits (redundantly) when usState already agrees', () => {
+      expect(splitEmbeddedState('Salem, VA', 'VA')).toEqual({ kind: 'split', city: 'Salem', state: 'VA' });
+    });
+
+    it('is case-insensitive against an existing usState', () => {
+      expect(splitEmbeddedState('Salem, va', 'VA')).toEqual({ kind: 'split', city: 'Salem', state: 'VA' });
+    });
+
+    it('ambiguous when the embedded state conflicts with an existing usState', () => {
+      const result = splitEmbeddedState('Salem, VA', 'NC');
+      expect(result.kind).toBe('ambiguous');
+      expect((result as { reason: string }).reason).toContain('conflicts');
+    });
+
+    it('ambiguous when the comma is present but not a clean 2-letter-code pattern (full state name)', () => {
+      const result = splitEmbeddedState('Salem, Virginia', undefined);
+      expect(result.kind).toBe('ambiguous');
+    });
+
+    it('ambiguous when there is no city text before the comma', () => {
+      const result = splitEmbeddedState(', VA', undefined);
+      expect(result.kind).toBe('ambiguous');
+    });
+  });
+
+  describe('isTitleCased', () => {
+    it('accepts a simple properly-cased single word', () => {
+      expect(isTitleCased('Salem')).toBe(true);
+    });
+
+    it('accepts a multi-word properly-cased city', () => {
+      expect(isTitleCased('Winston-Salem')).toBe(true);
+      expect(isTitleCased('St. Louis')).toBe(true);
+    });
+
+    it('rejects ALL CAPS', () => {
+      expect(isTitleCased('SALEM')).toBe(false);
+    });
+
+    it('rejects all lowercase', () => {
+      expect(isTitleCased('salem')).toBe(false);
+    });
+
+    it('rejects untrimmed input', () => {
+      expect(isTitleCased(' Salem ')).toBe(false);
+    });
+  });
+
+  describe('resolveCanonicalCasing', () => {
+    it('a single variant needs no canonicalization', () => {
+      const { canonicalMap, ambiguousGroups } = resolveCanonicalCasing(['Salem']);
+      expect(canonicalMap.get('Salem')).toBe('Salem');
+      expect(ambiguousGroups).toHaveLength(0);
+    });
+
+    it('picks the single title-cased variant as canonical for a casing group', () => {
+      const { canonicalMap } = resolveCanonicalCasing(['Salem', 'SALEM', 'salem']);
+      expect(canonicalMap.get('Salem')).toBe('Salem');
+      expect(canonicalMap.get('SALEM')).toBe('Salem');
+      expect(canonicalMap.get('salem')).toBe('Salem');
+    });
+
+    it('reports ambiguous when no variant in the group is title-cased', () => {
+      const { ambiguousGroups, canonicalMap } = resolveCanonicalCasing(['SALEM', 'salem']);
+      expect(ambiguousGroups).toHaveLength(1);
+      expect(ambiguousGroups[0].variants.sort()).toEqual(['SALEM', 'salem']);
+      expect(canonicalMap.has('SALEM')).toBe(false);
+    });
+
+    it('reports ambiguous when two DIFFERENT title-cased variants disagree (e.g. DeKalb vs Dekalb)', () => {
+      const { ambiguousGroups } = resolveCanonicalCasing(['DeKalb', 'Dekalb']);
+      expect(ambiguousGroups).toHaveLength(1);
+      expect(ambiguousGroups[0].variants.sort()).toEqual(['DeKalb', 'Dekalb']);
+    });
+
+    it('different cities do not interfere with each other', () => {
+      const { canonicalMap } = resolveCanonicalCasing(['Salem', 'SALEM', 'Roanoke']);
+      expect(canonicalMap.get('Roanoke')).toBe('Roanoke');
+      expect(canonicalMap.get('SALEM')).toBe('Salem');
+    });
+  });
+
+  describe('buildSplitPlans', () => {
+    it('separates split-ambiguous venues from working (split or no-change) ones', () => {
+      const venues = [
+        { _id: 'a', name: 'A', city: 'Salem, VA' },
+        { _id: 'b', name: 'B', city: 'Salem, Virginia' }, // ambiguous
+        { _id: 'c', name: 'C', city: 'Roanoke' },
+      ];
+      const { working, ambiguous } = buildSplitPlans(venues);
+      expect(working.map((w) => w.venue._id)).toEqual(['a', 'c']);
+      expect(ambiguous.map((a) => a.venue._id)).toEqual(['b']);
+      expect(working[0]).toMatchObject({ city: 'Salem', state: 'VA' });
+      expect(working[1]).toMatchObject({ city: 'Roanoke' });
+    });
+  });
+
+  describe('buildFinalPlans', () => {
+    it('plans a city rewrite for a casing variant with a confident canonical form', () => {
+      const working = [
+        { venue: { _id: 'a', name: 'A', city: 'SALEM' }, city: 'SALEM' },
+        { venue: { _id: 'b', name: 'B', city: 'Salem' }, city: 'Salem' },
+      ];
+      const { plans, ambiguous } = buildFinalPlans(working);
+      expect(ambiguous).toHaveLength(0);
+      const planA = plans.find((p) => p.venue._id === 'a');
+      expect(planA).toMatchObject({ finalCity: 'Salem' });
+      // 'b' is already canonical — no-op, not in the plan list.
+      expect(plans.find((p) => p.venue._id === 'b')).toBeUndefined();
+    });
+
+    it('plans a usState set only when usState was empty', () => {
+      const working = [{ venue: { _id: 'a', name: 'A', city: 'Salem, VA', usState: '' }, city: 'Salem', state: 'VA' }];
+      const { plans } = buildFinalPlans(working);
+      expect(plans[0]).toMatchObject({ finalCity: 'Salem', finalUsState: 'VA' });
+    });
+
+    it('does not overwrite an existing usState even when the split state agrees', () => {
+      const working = [{ venue: { _id: 'a', name: 'A', city: 'Salem, VA', usState: 'VA' }, city: 'Salem', state: 'VA' }];
+      const { plans } = buildFinalPlans(working);
+      expect(plans[0].finalUsState).toBeUndefined();
+      expect(plans[0].finalCity).toBe('Salem'); // city itself still gets the redundant ", VA" stripped
+    });
+
+    it('reports a casing-ambiguous group and leaves those venues out of plans', () => {
+      const working = [
+        { venue: { _id: 'a', name: 'A', city: 'SALEM' }, city: 'SALEM' },
+        { venue: { _id: 'b', name: 'B', city: 'salem' }, city: 'salem' },
+      ];
+      const { plans, ambiguous } = buildFinalPlans(working);
+      expect(plans).toHaveLength(0);
+      expect(ambiguous.map((a) => a.venue._id).sort()).toEqual(['a', 'b']);
+      expect(ambiguous[0].reason).toContain('casing variants disagree');
+    });
+
+    it('a venue whose city is already canonical produces no plan (idempotent)', () => {
+      const working = [{ venue: { _id: 'a', name: 'A', city: 'Salem' }, city: 'Salem' }];
+      const { plans, ambiguous } = buildFinalPlans(working);
+      expect(plans).toHaveLength(0);
+      expect(ambiguous).toHaveLength(0);
+    });
+  });
+
+  describe('run()', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      process.env.MONGO_DB_URI = 'mongodb://localhost:27017/web-jam-test';
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    function stubMongo(venues: { _id: string; name: string; city?: string; usState?: string }[]) {
+      vi.spyOn(mongoose, 'connect').mockResolvedValue(undefined as unknown as typeof mongoose);
+      vi.spyOn(mongoose.connection, 'close').mockResolvedValue(undefined);
+      const findSpy = vi.spyOn(venueModel, 'find').mockImplementation((filter: unknown) => {
+        const f = filter as { city?: { $exists?: boolean } } | undefined;
+        if (f?.city?.$exists === true) return Promise.resolve(venues);
+        return Promise.resolve([]);
+      });
+      const fakeResult = { acknowledged: true, matchedCount: 1, modifiedCount: 1, upsertedCount: 0, upsertedId: null };
+      const updateOneSpy = vi.spyOn(venueModel.Schema.collection, 'updateOne')
+        .mockImplementation(() => Promise.resolve(fakeResult) as unknown as ReturnType<typeof venueModel.Schema.collection.updateOne>);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      return {
+        findSpy, updateOneSpy, logSpy,
+      };
+    }
+
+    it('dry run: plans confident rewrites and reports ambiguous cases, writes nothing', async () => {
+      process.argv = ['node', 'migrate-clean-city.js']; // no --apply
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const id2 = new mongoose.Types.ObjectId().toString();
+      const id3 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy, logSpy } = stubMongo([
+        { _id: id1, name: 'A', city: 'SALEM' },
+        { _id: id2, name: 'B', city: 'Salem' },
+        { _id: id3, name: 'C', city: 'Salem, Virginia' }, // split-ambiguous
+      ]);
+
+      await run();
+
+      expect(updateOneSpy).not.toHaveBeenCalled();
+      const planLines = logSpy.mock.calls.map((c) => c[0]).filter(
+        (l): l is string => typeof l === 'string' && l.includes('PLAN'),
+      );
+      expect(planLines).toHaveLength(1); // only "SALEM" -> "Salem" changes
+      expect(planLines[0]).toContain('"SALEM" -> "Salem"');
+      const ambiguousHeader = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('AMBIGUOUS'),
+      );
+      expect(ambiguousHeader).toBeTruthy();
+    });
+
+    it('apply: writes confident plans via the raw collection updateOne, never for ambiguous venues', async () => {
+      process.argv = ['node', 'migrate-clean-city.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const id2 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy } = stubMongo([{ _id: id1, name: 'A', city: 'SALEM' }, { _id: id2, name: 'B', city: 'Salem' }]);
+      await run();
+      // Only "SALEM" (venue A) needs a write; "Salem" (venue B) is already canonical.
+      expect(updateOneSpy).toHaveBeenCalledTimes(1);
+      expect(updateOneSpy).toHaveBeenCalledWith(
+        { _id: new mongoose.Types.ObjectId(id1) },
+        { $set: { city: 'Salem' } },
+      );
+    });
+
+    it('apply: a single clean venue writes city + usState in one $set', async () => {
+      process.argv = ['node', 'migrate-clean-city.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy } = stubMongo([{ _id: id1, name: 'A', city: 'Salem, VA', usState: '' }]);
+
+      await run();
+
+      expect(updateOneSpy).toHaveBeenCalledWith(
+        { _id: new mongoose.Types.ObjectId(id1) },
+        { $set: { city: 'Salem', usState: 'VA' } },
+      );
+    });
+
+    it('is a no-op on re-run once every city is already canonical (idempotent)', async () => {
+      process.argv = ['node', 'migrate-clean-city.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy, logSpy } = stubMongo([{ _id: id1, name: 'A', city: 'Salem' }]);
+
+      await run();
+
+      expect(updateOneSpy).not.toHaveBeenCalled();
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('0 would change');
+    });
+  });
+
+  describe('SAFETY GUARD', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    it('refuses to run against a prod-looking db without --force', async () => {
+      process.argv = ['node', 'migrate-clean-city.js', '--apply'];
+      process.env.MONGO_DB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/release';
+      await expect(run()).rejects.toThrow('exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('only runs against a local, DEV, or TEST database'));
+    });
+  });
+});

--- a/test/unit/scripts/migrate-clean-city.spec.ts
+++ b/test/unit/scripts/migrate-clean-city.spec.ts
@@ -1,37 +1,19 @@
 // Unit tests for the #980 city-cleanup migration script's logic. Importing
 // the module must NOT touch Mongo or process.exit (no top-level side effects
 // beyond dotenv) — run()'s isMain guard is never true under vitest.
+//
+// parseArgs/isSafeToRun/logSafetyBlock are shared (src/lib/migration-cli.ts,
+// #980) and covered by their own test/unit/lib/migration-cli.spec.ts — not
+// re-tested here to avoid duplicating that coverage.
 import mongoose from 'mongoose';
 import {
-  isSafeToRun, parseArgs, run,
+  run,
   splitEmbeddedState, isTitleCased, resolveCanonicalCasing,
   buildSplitPlans, buildFinalPlans,
 } from '#src/scripts/migrate-clean-city.js';
 import venueModel from '#src/model/venue/venue-facade.js';
 
 describe('migrate-clean-city (#980)', () => {
-  describe('parseArgs', () => {
-    it('reads --apply and --force flags', () => {
-      expect(parseArgs([])).toEqual({ apply: false, force: false });
-      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
-      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
-    });
-  });
-
-  describe('isSafeToRun', () => {
-    it('allows a localhost URI', () => {
-      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
-    });
-
-    it('blocks a prod-looking (release) db name without --force', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
-    });
-
-    it('allows a prod-looking db name when --force is passed', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
-    });
-  });
-
   describe('splitEmbeddedState', () => {
     it('no-change when there is no comma at all', () => {
       expect(splitEmbeddedState('Salem', undefined)).toEqual({ kind: 'no-change' });

--- a/test/unit/scripts/migrate-drop-do-not-contact.spec.ts
+++ b/test/unit/scripts/migrate-drop-do-not-contact.spec.ts
@@ -1,0 +1,203 @@
+// Unit tests for the #980 migration script's logic. Importing the module
+// must NOT touch Mongo or process.exit (no top-level side effects beyond
+// dotenv) — run()'s isMain guard is never true under vitest.
+import mongoose from 'mongoose';
+import {
+  isSafeToRun, parseArgs, run, buildNoteLine,
+} from '#src/scripts/migrate-drop-do-not-contact.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+describe('migrate-drop-do-not-contact (#980)', () => {
+  describe('parseArgs', () => {
+    it('reads --apply and --force flags', () => {
+      expect(parseArgs([])).toEqual({ apply: false, force: false });
+      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
+      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
+    });
+  });
+
+  describe('isSafeToRun', () => {
+    it('allows a localhost URI', () => {
+      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a 127.0.0.1 URI', () => {
+      expect(isSafeToRun('mongodb://127.0.0.1:27017/anything', false)).toBe(true);
+    });
+
+    it('allows a DEV Atlas db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev', false)).toBe(true);
+    });
+
+    it('allows a TEST db name', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-test', false)).toBe(true);
+    });
+
+    it('blocks a prod-looking (release) db name without --force', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
+    });
+
+    it('allows a prod-looking db name when --force is passed', () => {
+      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
+    });
+  });
+
+  describe('buildNoteLine', () => {
+    it('produces a dated line recording the prior exclusion', () => {
+      const line = buildNoteLine(new Date('2026-07-18T12:00:00Z'));
+      expect(line).toContain('[2026-07-18]');
+      expect(line).toContain('doNotContact:true');
+      expect(line).toContain('outreachEligible:false');
+    });
+  });
+
+  describe('run()', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      process.env.MONGO_DB_URI = 'mongodb://localhost:27017/web-jam-test';
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    function stubMongo(venues: { _id: string; name: string; doNotContact?: boolean; notes?: string }[], modifiedCount?: number) {
+      vi.spyOn(mongoose, 'connect').mockResolvedValue(undefined as unknown as typeof mongoose);
+      vi.spyOn(mongoose.connection, 'close').mockResolvedValue(undefined);
+      const findSpy = vi.spyOn(venueModel, 'find').mockImplementation((filter: unknown) => {
+        const f = filter as { doNotContact?: { $exists?: boolean } } | undefined;
+        if (f?.doNotContact?.$exists === true) return Promise.resolve(venues);
+        return Promise.resolve([]);
+      });
+      const fakeResult = {
+        acknowledged: true, matchedCount: venues.length, modifiedCount: modifiedCount ?? venues.length, upsertedCount: 0, upsertedId: null,
+      };
+      const updateManySpy = vi.spyOn(venueModel.Schema.collection, 'updateMany')
+        .mockImplementation(() => Promise.resolve(fakeResult) as unknown as ReturnType<typeof venueModel.Schema.collection.updateMany>);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      return {
+        findSpy, updateManySpy, logSpy,
+      };
+    }
+
+    it('dry run: plans the flip for doNotContact:true venues, writes nothing', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js']; // no --apply
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const id2 = new mongoose.Types.ObjectId().toString();
+      const { findSpy, updateManySpy, logSpy } = stubMongo([
+        { _id: id1, name: 'Salem Red Sox', doNotContact: true },
+        { _id: id2, name: 'ODAC Tournament', doNotContact: true, notes: 'existing note' },
+      ]);
+
+      await run();
+
+      expect(findSpy).toHaveBeenCalledWith({ doNotContact: { $exists: true } });
+      expect(updateManySpy).not.toHaveBeenCalled(); // dry run — no --apply
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('2 venue(s) scanned');
+      expect(summary).toContain('2 were doNotContact:true');
+      const planLines = logSpy.mock.calls.map((c) => c[0]).filter(
+        (l): l is string => typeof l === 'string' && l.includes('PLAN'),
+      );
+      expect(planLines).toHaveLength(2);
+      expect(planLines[0]).toContain('outreachEligible:false');
+    });
+
+    it('a venue with doNotContact set to something other than true just loses the field (no flip)', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { logSpy } = stubMongo([{ _id: id1, name: 'Stray Field', doNotContact: false }]);
+
+      await run();
+
+      const planLines = logSpy.mock.calls.map((c) => c[0]).filter(
+        (l): l is string => typeof l === 'string' && l.includes('PLAN'),
+      );
+      expect(planLines).toHaveLength(1);
+      expect(planLines[0]).toContain('was not true');
+      expect(planLines[0]).not.toContain('outreachEligible:false');
+    });
+
+    it('apply: flips doNotContact:true venues via a RAW pipeline updateMany (outreachEligible false + note appended + field unset)', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { updateManySpy } = stubMongo([{ _id: id1, name: 'Salem Red Sox', doNotContact: true }]);
+
+      await run();
+
+      expect(updateManySpy).toHaveBeenCalledWith(
+        { doNotContact: true },
+        expect.arrayContaining([
+          expect.objectContaining({
+            $set: expect.objectContaining({ outreachEligible: false, notes: expect.anything() }),
+          }),
+          { $unset: 'doNotContact' },
+        ]),
+      );
+    });
+
+    it('apply: a venue with doNotContact != true is $unset via a separate RAW call, no outreachEligible/notes touch', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { updateManySpy } = stubMongo([{ _id: id1, name: 'Stray Field', doNotContact: false }]);
+
+      await run();
+
+      expect(updateManySpy).toHaveBeenCalledWith(
+        { doNotContact: { $exists: true, $ne: true } },
+        { $unset: { doNotContact: '' } },
+      );
+    });
+
+    it('is a no-op on re-run once no venues still carry doNotContact (idempotent)', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js', '--apply'];
+      const { updateManySpy, logSpy } = stubMongo([]);
+
+      await run();
+
+      expect(updateManySpy).not.toHaveBeenCalled();
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('0 venue(s) scanned');
+    });
+  });
+
+  describe('SAFETY GUARD', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    it('refuses to run against a prod-looking db without --force', async () => {
+      process.argv = ['node', 'migrate-drop-do-not-contact.js', '--apply'];
+      process.env.MONGO_DB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/release';
+      await expect(run()).rejects.toThrow('exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('only runs against a local, DEV, or TEST database'));
+    });
+  });
+});

--- a/test/unit/scripts/migrate-drop-do-not-contact.spec.ts
+++ b/test/unit/scripts/migrate-drop-do-not-contact.spec.ts
@@ -1,47 +1,15 @@
 // Unit tests for the #980 migration script's logic. Importing the module
 // must NOT touch Mongo or process.exit (no top-level side effects beyond
 // dotenv) — run()'s isMain guard is never true under vitest.
+//
+// parseArgs/isSafeToRun/logSafetyBlock are shared (src/lib/migration-cli.ts,
+// #980) and covered by their own test/unit/lib/migration-cli.spec.ts — not
+// re-tested here to avoid duplicating that coverage.
 import mongoose from 'mongoose';
-import {
-  isSafeToRun, parseArgs, run, buildNoteLine,
-} from '#src/scripts/migrate-drop-do-not-contact.js';
+import { run, buildNoteLine } from '#src/scripts/migrate-drop-do-not-contact.js';
 import venueModel from '#src/model/venue/venue-facade.js';
 
 describe('migrate-drop-do-not-contact (#980)', () => {
-  describe('parseArgs', () => {
-    it('reads --apply and --force flags', () => {
-      expect(parseArgs([])).toEqual({ apply: false, force: false });
-      expect(parseArgs(['--apply'])).toEqual({ apply: true, force: false });
-      expect(parseArgs(['--force', '--apply'])).toEqual({ apply: true, force: true });
-    });
-  });
-
-  describe('isSafeToRun', () => {
-    it('allows a localhost URI', () => {
-      expect(isSafeToRun('mongodb://localhost:27017/web-jam-dev', false)).toBe(true);
-    });
-
-    it('allows a 127.0.0.1 URI', () => {
-      expect(isSafeToRun('mongodb://127.0.0.1:27017/anything', false)).toBe(true);
-    });
-
-    it('allows a DEV Atlas db name', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-dev', false)).toBe(true);
-    });
-
-    it('allows a TEST db name', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/web-jam-test', false)).toBe(true);
-    });
-
-    it('blocks a prod-looking (release) db name without --force', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', false)).toBe(false);
-    });
-
-    it('allows a prod-looking db name when --force is passed', () => {
-      expect(isSafeToRun('mongodb+srv://user:pass@cluster.mongodb.net/release', true)).toBe(true);
-    });
-  });
-
   describe('buildNoteLine', () => {
     it('produces a dated line recording the prior exclusion', () => {
       const line = buildNoteLine(new Date('2026-07-18T12:00:00Z'));

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import controller from '#src/model/venue/venue-controller.js';
 import userModel from '#src/model/user/user-facade.js';
 import gigModel from '#src/model/gig/gig-facade.js';
+import venueModel from '#src/model/venue/venue-facade.js';
 
 const c = controller as any;
 
@@ -252,18 +253,91 @@ describe('Venue Controller', () => {
       expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ country: 'CA', region: 'Quebec' }));
     });
 
-    // #923 — global outcome standing: doNotContact (permanent exclusion) + the
-    // actual booked gig date, both written by the future outcome-recording
-    // endpoint (#898) but pass through updateVenue like any other field today.
-    it('accepts doNotContact + bookedDate (#923)', async () => {
+    // #923 — bookedDate (the actual booked gig date, written by the outcome-
+    // recording endpoint #898) passes through updateVenue like any other field.
+    it('accepts bookedDate (#923)', async () => {
       const id = new mongoose.Types.ObjectId().toString();
       const upd = vi.fn(() => Promise.resolve({ _id: id }));
       c.model.findByIdAndUpdate = upd;
       await c.updateVenue({
-        user: 'agent', params: { id }, body: { doNotContact: true, bookedDate: '2026-09-26' },
+        user: 'agent', params: { id }, body: { bookedDate: '2026-09-26' },
       }, resStub);
       expect(status).toBe(200);
-      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ doNotContact: true, bookedDate: '2026-09-26' }));
+      expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ bookedDate: '2026-09-26' }));
+    });
+
+    // #980 — doNotContact was deleted entirely (folded into outreachEligible).
+    // A stale client that still sends it must not error and must not have it
+    // written — silently stripped, like _id.
+    it('strips a stray doNotContact from the body instead of writing or erroring (#980)', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateVenue({
+        user: 'agent', params: { id }, body: { doNotContact: true, outreachEligible: false },
+      }, resStub);
+      expect(status).toBe(200);
+      const written = (upd.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+      expect(written).not.toHaveProperty('doNotContact');
+      expect(written).toMatchObject({ outreachEligible: false });
+    });
+
+    // #980 — bookingStatus is derived/read-only now: a stray value in the
+    // body must be stripped (never written, never validated/rejected).
+    it('strips a stray bookingStatus from the body instead of writing or erroring (#980)', async () => {
+      const id = new mongoose.Types.ObjectId().toString();
+      const upd = vi.fn(() => Promise.resolve({ _id: id }));
+      c.model.findByIdAndUpdate = upd;
+      await c.updateVenue({
+        user: 'agent', params: { id }, body: { bookingStatus: 'booked', notes: 'x' },
+      }, resStub);
+      expect(status).toBe(200);
+      const written = (upd.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+      expect(written).not.toHaveProperty('bookingStatus');
+      expect(written).toMatchObject({ notes: 'x' });
+    });
+
+    // #980 — gigInterval (spacing, months) + resumeBooking (cooldown date).
+    describe('gigInterval / resumeBooking (#980)', () => {
+      it('accepts gigInterval + resumeBooking on update', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({
+          user: 'agent', params: { id }, body: { gigInterval: 4, resumeBooking: '2026-11-01' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ gigInterval: 4, resumeBooking: '2026-11-01' }));
+      });
+
+      it('rejects a negative gigInterval', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        await c.updateVenue({ user: 'agent', params: { id }, body: { gigInterval: -1 } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('gigInterval');
+      });
+
+      it('rejects a non-integer gigInterval', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        await c.updateVenue({ user: 'agent', params: { id }, body: { gigInterval: 2.5 } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('gigInterval');
+      });
+
+      it('accepts gigInterval: 0 (spacing off, the default)', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { gigInterval: 0 } }, resStub);
+        expect(status).toBe(200);
+      });
+
+      it('rejects an invalid resumeBooking date', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        await c.updateVenue({ user: 'agent', params: { id }, body: { resumeBooking: 'not-a-date' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('resumeBooking');
+      });
     });
   });
 
@@ -442,6 +516,110 @@ describe('Venue Controller', () => {
         expect(status).toBe(500);
       });
     });
+
+    // #980 — derived, read-only bookingStatus: booked (upcoming linked gig) >
+    // not-booking (active resumeBooking cooldown) > booking (otherwise).
+    // Unit-tests the static helper directly (each branch + the precedence),
+    // then confirms it's actually wired into the listVenues/getVenue payload.
+    describe('computeBookingStatus (#980)', () => {
+      const compute = (venue: any, hasUpcomingGig: boolean, now: number) => (
+        (controller as any).constructor.computeBookingStatus(venue, hasUpcomingGig, now));
+
+      it('booked — has an upcoming linked gig, regardless of anything else', () => {
+        const now = Date.now();
+        expect(compute({ resumeBooking: new Date(now + 1e9) }, true, now)).toBe('booked');
+      });
+
+      it('not-booking — an active (future) resumeBooking cooldown, no upcoming gig', () => {
+        const now = Date.now();
+        expect(compute({ resumeBooking: new Date(now + 1e9).toISOString() }, false, now)).toBe('not-booking');
+      });
+
+      it('booking — no upcoming gig, no active cooldown (default/open)', () => {
+        const now = Date.now();
+        expect(compute({}, false, now)).toBe('booking');
+      });
+
+      it('booking — resumeBooking already in the past does not count as active', () => {
+        const now = Date.now();
+        expect(compute({ resumeBooking: new Date(now - 1e9).toISOString() }, false, now)).toBe('booking');
+      });
+
+      it('booking — an invalid resumeBooking value is ignored, not treated as active', () => {
+        const now = Date.now();
+        expect(compute({ resumeBooking: 'not-a-date' }, false, now)).toBe('booking');
+      });
+
+      it('precedence: booked wins over an active resumeBooking cooldown', () => {
+        const now = Date.now();
+        expect(compute({ resumeBooking: new Date(now + 1e9) }, true, now)).toBe('booked');
+      });
+
+      it('is wired into listVenues: booked when there is an upcoming linked gig', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'Booked Venue' }]));
+        (gigModel as any).find = vi.fn(() => Promise.resolve([
+          { venueId: idA, datetime: new Date(Date.now() + 86400000).toISOString() },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('booked');
+      });
+
+      it('is wired into listVenues: not-booking with an active resumeBooking, no upcoming gig', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: idA, name: 'Paused Venue', resumeBooking: new Date(Date.now() + 1e10).toISOString() },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('not-booking');
+      });
+
+      it('is wired into listVenues: booking otherwise', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'Open Venue' }]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('booking');
+      });
+
+      it('overrides a stale stored bookingStatus with the computed value', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: idA, name: 'Stale Venue', bookingStatus: 'booked' }]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('booking');
+      });
+    });
+  });
+
+  describe('listCities — GET /venue/cities (#980)', () => {
+    // Reassign just `Schema.distinct` (not the whole Schema object — the
+    // real Model also carries `.collection`, which the migration scripts'
+    // tests rely on and which this repo's other spec files share via the
+    // same facade singleton, fileParallelism:false) and restore it after
+    // each test so nothing leaks into other spec files.
+    let originalDistinct: typeof venueModel.Schema.distinct;
+    beforeEach(() => { originalDistinct = venueModel.Schema.distinct; });
+    afterEach(() => { venueModel.Schema.distinct = originalDistinct; });
+
+    it('403s without a venue capability', async () => {
+      asAgent([]);
+      await c.listCities({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(403);
+    });
+
+    it('returns distinct non-empty cities, sorted', async () => {
+      const distinctSpy = vi.fn(() => Promise.resolve(['Roanoke', '', 'Salem', null, 'Blacksburg']));
+      (venueModel.Schema as any).distinct = distinctSpy;
+      await c.listCities({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(200);
+      expect(distinctSpy).toHaveBeenCalledWith('city', { city: { $nin: [null, ''] } });
+      expect(payload).toEqual(['Blacksburg', 'Roanoke', 'Salem']);
+    });
+
+    it('500s when the distinct query throws', async () => {
+      (venueModel.Schema as any).distinct = vi.fn(() => Promise.reject(new Error('db down')));
+      await c.listCities({ user: 'a', query: {} }, resStub);
+      expect(status).toBe(500);
+    });
   });
 
   describe('buildListFilter', () => {
@@ -461,9 +639,9 @@ describe('Venue Controller', () => {
       expect(g).toMatchObject({ outreachEligible: false });
     });
 
-    it('filters by the vetting tags bookingStatus / interested (#843)', () => {
-      const f = (controller as any).constructor.buildListFilter({ bookingStatus: 'booking', interested: 'true' });
-      expect(f).toMatchObject({ bookingStatus: 'booking', interested: true });
+    it('filters by the vetting tag interested (#843)', () => {
+      const f = (controller as any).constructor.buildListFilter({ interested: 'true' });
+      expect(f).toMatchObject({ interested: true });
       const g = (controller as any).constructor.buildListFilter({ interested: 'false' });
       expect(g).toMatchObject({ interested: false });
     });
@@ -474,13 +652,26 @@ describe('Venue Controller', () => {
       const f = (controller as any).constructor.buildListFilter({ inScope: 'true' });
       expect(f).not.toHaveProperty('inScope');
     });
+
+    // #980 — bookingStatus is derived/read-only now; a stored-field Mongo
+    // filter is no longer reliable, so it's no longer built into the query.
+    it('no longer supports a bookingStatus filter (#980)', () => {
+      const f = (controller as any).constructor.buildListFilter({ bookingStatus: 'booking' });
+      expect(f).not.toHaveProperty('bookingStatus');
+    });
   });
 
   describe('vetting tags (#843)', () => {
-    it('rejects an invalid bookingStatus', async () => {
+    // #980 — bookingStatus is no longer validated (it's derived/read-only —
+    // stripped before validateBody ever sees it), so an invalid value is
+    // silently ignored rather than rejected.
+    it('silently strips an invalid bookingStatus instead of rejecting it (#980)', async () => {
+      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      const create = vi.fn(() => Promise.resolve({ _id: 'v11' }));
+      c.model.create = create;
       await c.createVenue({ user: 'a', body: { name: 'X', bookingStatus: 'bogus' } }, resStub);
-      expect(status).toBe(400);
-      expect(payload.message).toContain('bookingStatus');
+      expect(status).toBe(201);
+      expect((create.mock.calls[0] as unknown[])[0]).not.toHaveProperty('bookingStatus');
     });
 
     it('persists the vetting tags on create', async () => {
@@ -490,11 +681,11 @@ describe('Venue Controller', () => {
       await c.createVenue({
         user: 'a',
         body: {
-          name: 'Olde Salem', bookingStatus: 'booked', interested: false, payTier: 'low',
+          name: 'Olde Salem', interested: false, payTier: 'low',
         },
       }, resStub);
       expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({
-        bookingStatus: 'booked', interested: false, payTier: 'low',
+        interested: false, payTier: 'low',
       });
     });
 


### PR DESCRIPTION
## Summary
- Implements #980's venue booking-lifecycle model: `outreachEligible` is now the SOLE permanent stop/go gate (absorbs the deleted `doNotContact`); `gigInterval` (months, default 0=off) is a new min-spacing lever; `resumeBooking` is a new optional "pause until" cooldown date.
- `bookingStatus` is now DERIVED/read-only (`computeBookingStatus` in venue-controller.ts), computed fresh on every GET /venue and GET /venue/:id response — never hand-set.
- `GET /outreach/candidates` rewrites the pitch rule around the new levers: `outreachEligible=true` AND valid email AND not archived AND no active `resumeBooking` cooldown AND (`gigInterval=0` OR every linked gig is ≥ `gigInterval` months from the target window W). Generalizes the old #958 blanket "any upcoming gig excludes forever" exclusion.
- Adds an optional `cities` multi-select filter to `getCandidates`, AND'd with every other criterion, plus `GET /venue/cities` (distinct non-empty city values) as the frontend's source list.
- Every candidate now carries a `reason` object (`buildCandidateReason`) — `lastGigDate`, `gigIntervalMonths`, `nearestGigMonthsAway`, a human-readable `spacingNote`, `resumeBookingExpired` — so JaMmusic#1238's Find-Eligible UI can show why a venue qualified. This was missing from the original WIP and has been added in this session.
- A recorded `not-interested` outreach outcome now sets `outreachEligible=false` + appends a dated note (never overwrites) instead of the old `doNotContact` flag.
- Two new one-time migrations, both dry-run-by-default and writing via the RAW MongoDB collection (never a schema-bound mongoose method, per the #954 `$unset`-strip lesson): `migrate-drop-do-not-contact` (backfills `doNotContact:true` venues to `outreachEligible:false` + a dated note, then `$unset`s the field) and `migrate-clean-city` (normalizes `city` casing + splits an embedded "City, ST" into `city`/`usState`, reporting anything ambiguous for manual review instead of guessing).
- Extracted the shared migration-script safety-guard boilerplate (arg parsing, the local/DEV/TEST-only safety check, URI masking) into a new `src/lib/migration-cli.ts` so the two new migrations don't re-duplicate it a 5th/6th time — this was needed to get jscpd back under its 5% threshold (the original WIP was at 5.7%, over the gate).
- **Manual step for Josh (why this PR is `--part-of #980`, not closing it):** neither migration is run by this PR or wired into build/postinstall/CI. After merge, Josh runs `npm run migrate:drop-do-not-contact` and `npm run migrate:clean-city` by hand (dry run first, then `--apply`; `--force` needed for prod) — same flow as #954/#974. #980 stays open until that's done.

Part of #980

## How to test locally
Run the full gate:
```sh
npm test
```
Expect: lint clean, jscpd under 5%, typecheck clean, 833/833 vitest tests green, coverage well above the 90/90/80/80 (stmts/lines vs branches/funcs) floor.

Exercise the changed API surface directly (after `npm run dev` against a local/DEV Mongo with a couple of seeded venues):

```sh
# distinct cities for the frontend multi-select
curl -s -H "Authorization: Bearer $TOKEN" \
  "http://localhost:8081/venue/cities"
# expect: 200, a sorted array of distinct non-empty city strings

# candidates for a target window, filtered to one city, with the new reason context
curl -s -H "Authorization: Bearer $TOKEN" \
  "http://localhost:8081/outreach/candidates?targetWeekend[start]=2026-09-25&targetWeekend[end]=2026-09-27&cities=Salem"
# expect: 200, { candidates: [...], weekendGigs: [...] } — each candidate has a
# `reason: { lastGigDate, gigIntervalMonths, nearestGigMonthsAway, spacingNote, resumeBookingExpired }`
# object, and every candidate's city is "Salem"

# a venue with a future resumeBooking date reads bookingStatus:"not-booking"
curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:8081/venue/$VENUE_ID"
# expect: 200, bookingStatus computed fresh (booked > not-booking > booking precedence),
# never the raw stored value
```

Dry-run the two new migrations locally (never against prod — Josh applies those manually, see the note in Test evidence below):
```sh
npm run build
npm run migrate:drop-do-not-contact
npm run migrate:clean-city
```
Expect: both print a PLAN for anything they'd change (or "0 venue(s) scanned") and make zero writes — they refuse to run against a non-local/DEV/TEST `MONGO_DB_URI` without `--force`.

## Test evidence
```

> web-jam-back@2.6.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit


> web-jam-back@2.6.0 jscpd
> jscpd src

Using config from .jscpd.json
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/lib/artist-controller.ts[39m[22m [68:26 - 74:18] (7 lines, 87 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/lib/artist-controller.ts [77:26 - 83:18]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/lib/controller.ts[39m[22m [104:5 - 110:28] (7 lines, 88 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [667:5 - 678:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/lib/migration-cli.ts[39m[22m [23:58 - 34:2] (12 lines, 110 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts [47:49 - 60:2]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/admin-user/admin-user-router.ts[39m[22m [2:52 - 18:48] (17 lines, 108 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/subscriber/admin-subscriber-router.ts [2:52 - 21:48]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [16:42 - 21:52] (6 lines, 59 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [40:66 - 45:52]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [16:43 - 24:10] (9 lines, 68 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [38:36 - 46:10]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [31:16 - 44:35] (14 lines, 109 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [175:66 - 187:35]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [31:25 - 44:35] (14 lines, 106 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [252:27 - 266:35]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [32:1 - 44:35] (13 lines, 105 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [81:1 - 93:35]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [74:46 - 90:8] (17 lines, 99 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [394:45 - 406:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [78:77 - 83:66] (6 lines, 71 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/promo/promo-controller.ts [36:88 - 41:66]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/gig/gig-controller.ts[39m[22m [102:65 - 116:33] (15 lines, 150 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [190:67 - 202:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/inquiry/format-inquiry.ts[39m[22m [31:77 - 44:9] (14 lines, 67 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [221:121 - 240:9]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [145:79 - 159:9] (15 lines, 96 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [150:92 - 163:9]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [394:26 - 402:4] (9 lines, 100 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [154:26 - 164:4]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [394:26 - 407:108] (14 lines, 138 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [271:23 - 287:22]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [461:23 - 467:37] (7 lines, 111 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [624:22 - 630:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [462:64 - 467:37] (6 lines, 84 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [1450:61 - 1455:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [462:64 - 467:49] (6 lines, 86 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [536:63 - 539:56]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [636:95 - 641:10] (6 lines, 53 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts [274:62 - 276:20]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [808:74 - 821:10] (14 lines, 105 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [838:87 - 850:10]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [1108:32 - 1115:11] (8 lines, 59 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts [1127:92 - 1134:7]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [1449:24 - 1455:33] (7 lines, 109 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [491:20 - 495:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/outreach/outreach-controller.ts[39m[22m [1449:24 - 1455:33] (7 lines, 109 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [514:17 - 518:37]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/subscriber/subscriber-controller.ts[39m[22m [64:47 - 70:8] (7 lines, 84 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/subscriber/subscriber-controller.ts [129:20 - 134:7]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [230:20 - 237:20] (8 lines, 101 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [467:68 - 474:20]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [242:74 - 248:10] (7 lines, 52 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [478:51 - 483:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/model/template/template-controller.ts[39m[22m [276:98 - 288:8] (13 lines, 104 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/model/venue/venue-controller.ts [499:66 - 514:8]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-clean-city.ts[39m[22m [245:27 - 259:16] (15 lines, 69 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-do-not-contact.ts [134:32 - 148:16]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [39:1 - 62:49] (24 lines, 172 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-in-scope.ts [37:1 - 60:49]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [47:8 - 60:2] (14 lines, 121 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-gig-venue-id.ts [45:1 - 59:2]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [71:115 - 90:45] (20 lines, 124 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-in-scope.ts [87:4 - 107:45]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [71:115 - 78:34] (8 lines, 66 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-gig-venue-id.ts [58:41 - 65:34]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [109:23 - 125:16] (17 lines, 92 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-in-scope.ts [128:17 - 144:16]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [110:107 - 125:9] (16 lines, 82 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-gig-venue-id.ts [110:95 - 125:9]
[1mClone found (typescript)[22m
 - [1m[32m/home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-drop-contact-verified.ts[39m[22m [110:107 - 123:2] (14 lines, 80 tokens)
   /home/joshua/WebJamApps/web-jam-back/src/scripts/migrate-target-weekend.ts [112:98 - 127:2]
[90m┌────────────┬────────────────┬─────────────┬──────────────┬──────────────┬──────────────────┬───────────────────┐[39m
[90m│[39m[31m Format     [39m[90m│[39m[31m Files analyzed [39m[90m│[39m[31m Total lines [39m[90m│[39m[31m Total tokens [39m[90m│[39m[31m Clones found [39m[90m│[39m[31m Duplicated lines [39m[90m│[39m[31m Duplicated tokens [39m[90m│[39m
[90m├────────────┼────────────────┼─────────────┼──────────────┼──────────────┼──────────────────┼───────────────────┤[39m
[90m│[39m typescript [90m│[39m 77             [90m│[39m 8211        [90m│[39m 53512        [90m│[39m 36           [90m│[39m 377 (4.59%)      [90m│[39m 3424 (6.40%)      [90m│[39m
[90m├────────────┼────────────────┼─────────────┼──────────────┼──────────────┼──────────────────┼───────────────────┤[39m
[90m│[39m [1mTotal:[22m     [90m│[39m 77             [90m│[39m 8211        [90m│[39m 53512        [90m│[39m 36           [90m│[39m 377 (4.59%)      [90m│[39m 3424 (6.40%)      [90m│[39m
[90m└────────────┴────────────────┴─────────────┴──────────────┴──────────────┴──────────────────┴───────────────────┘[39m
[90mFound 36 clones.[39m
[90mtime: 12.637ms[39m

[90m💡 Auto-refactor with AI: [1m[39mnpx skills add https://github.com/kucherenko/jscpd --skill dry-refactoring[90m[22m
[90m🎩 New: Gangsta Agents — discipline your AI coding → gangsta.page[39m
[90m💖 Support jscpd project → https://opencollective.com/jscpd[39m

> web-jam-back@2.6.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit


> web-jam-back@2.6.0 test:unit
> vitest run --coverage


 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back
      Coverage enabled with v8

GET /gig?artist=tim 200 172 - 20.157 ms
GET /gig 200 334 - 16.722 ms
POST /gig 201 173 - 36.310 ms
POST /gig 201 170 - 35.984 ms
POST /gig 201 179 - 148.280 ms
PUT /gig/6a5c0a4cf2d33aed97769e49 200 164 - 156.802 ms
PUT /gig/6a5c0a4cf2d33aed97769e4a 403 44 - 136.860 ms
PUT /gig/6a5c0a4df2d33aed97769e4b 403 44 - 26.715 ms
DELETE /gig/6a5c0a4df2d33aed97769e4c 403 44 - 28.333 ms
DELETE /gig/6a5c0a4df2d33aed97769e4d 200 42 - 41.743 ms
GET /book/one?type=bio&artist=tim 200 194 - 13.848 ms
PUT /book/one?type=bio 200 185 - 39.705 ms
PUT /book/one?type=bio 200 189 - 28.107 ms
GET /setlist 200 149 - 22.711 ms
GET /setlist/6a5c0a520d626f1ede08889f 200 209 - 16.223 ms
GET /setlist/not-an-id 400 32 - 0.249 ms
GET /setlist/6a53da5b8c4f9aa55d290d99 400 44 - 16.391 ms
POST /setlist 201 172 - 33.751 ms
POST /setlist 401 63 - 0.240 ms
POST /setlist 500 71 - 18.363 ms
POST /setlist 500 96 - 16.981 ms
POST /setlist 201 158 - 28.656 ms
PUT /setlist/6a5c0a520d626f1ede0888aa 200 188 - 35.445 ms
PUT /setlist/6a5c0a520d626f1ede0888ae 400 30 - 15.795 ms
DELETE /setlist/6a5c0a530d626f1ede0888af 200 46 - 34.480 ms
DELETE /setlist?name=Bulk+Set 200 47 - 28.405 ms
GET /setlist/6a5c0a530d626f1ede0888b2 200 307 - 27.446 ms
GET /setlist/6a5c0a530d626f1ede0888b4 200 414 - 26.836 ms
GET /setlist 200 416 - 26.856 ms
GET /gig 200 202 - 21.707 ms
GET /gig/6a5c0a576499836774c6038b 200 200 - 33.184 ms
POST /gig 201 222 - 32.626 ms
PUT /gig/6a5c0a576499836774c6038d 200 155 - 36.580 ms
DELETE /gig/6a5c0a586499836774c6038e 200 42 - 33.723 ms
DELETE /gig?city=Salem 200 43 - 30.509 ms
GET /gig/promo-default.jpg 200 57600 - 1.970 ms
POST /gig/6a5c0a586499836774c60390/announce 401 63 - 0.221 ms
POST /gig/6a5c0a586499836774c60391/announce 403 45 - 28.312 ms
POST /gig/6a5c0a586499836774c60392/announce 200 78 - 55.695 ms
POST /gig/6a5c0a586499836774c60393/announce 500 132 - 38.212 ms
GET /book/one?type=paperback 200 171 - 19.682 ms
GET /book/one?type=magazine 400 29 - 14.996 ms
PUT /book/one?type=paperback 200 160 - 38.196 ms
PUT /book/one?type=stewardshipPageContent 200 191 - 168.032 ms
DELETE /book/6a5c0a5df6cb9549f8981b5e 200 43 - 32.322 ms
GET /book/findcheckedout/33333 200 196 - 29.063 ms
PUT /book/6a5c0a5df6cb9549f8981b60 200 189 - 32.116 ms
GET /book/6a5c0a5df6cb9549f8981b61 200 194 - 26.168 ms
GET /book 200 173 - 13.705 ms
POST /book 201 191 - 29.476 ms
DELETE /book?type=paperback 200 44 - 27.885 ms
GET /facebook/feed 200 31 - 2.193 ms
PUT /facebook/token 401 63 - 0.583 ms
PUT /facebook/token 400 35 - 17.407 ms
PUT /facebook/token 200 69 - 50.162 ms
GET /facebook/feed 200 152 - 0.178 ms
PUT /facebook/token 400 37 - 14.958 ms
PUT /facebook/token 400 23 - 14.685 ms
PUT /facebook/token 200 69 - 49.782 ms
GET /facebook/feed?pageId=111111111111111 200 88 - 0.295 ms
GET /facebook/feed 200 31 - 0.301 ms
POST /inquiry 200 24 - 2.623 ms
GET /user?name=tester 200 2 - 396.697 ms
GET /user?name=tester 401 28 - 0.257 ms
POST /user 401 63 - 0.287 ms
POST /user 400 25 - 167.248 ms
POST /user/auth/google 500 73 - 0.643 ms
GET /livestream/current 200 32 - 2.430 ms
GET /livestream/current 200 74 - 0.717 ms
GET /livestream/current 200 79 - 0.230 ms
GET /livestream/current 200 32 - 0.298 ms
GET /livestream/current 200 32 - 0.235 ms
GET /livestream/current 200 37 - 0.171 ms
GET /livestream/current 200 37 - 0.120 ms
POST /admin/backup 401 63 - 2.688 ms
POST /admin/backup 401 51 - 0.673 ms
POST /admin/backup 202 28 - 0.543 ms

 Test Files  52 passed (52)
      Tests  833 passed (833)
   Start at  19:20:41
   Duration  50.38s (transform 754ms, setup 0ms, import 8.39s, tests 34.36s, environment 6ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   93.17 |    87.21 |   88.65 |   93.86 |                   
 src               |   95.83 |      100 |      60 |   97.82 |                   
  index.ts         |    93.1 |      100 |      50 |   96.29 | 74                
 src/auth          |    98.8 |       80 |    90.9 |     100 |                   
  authUtils.ts     |     100 |    70.27 |     100 |     100 | ...47,50-76,83-88 
  google.ts        |   96.66 |     87.5 |   66.66 |     100 | 22,63             
 src/lib           |   95.15 |     86.3 |   95.08 |   96.54 |                   
  ...controller.ts |    87.5 |    97.14 |      80 |   91.66 | 45,54,97          
  artist.ts        |     100 |       90 |     100 |     100 | 25,44             
  backup-export.ts |   85.71 |    72.72 |   77.77 |   88.88 | 90-94             
  ...sify-reply.ts |      96 |    92.59 |     100 |     100 | 38-48             
  controller.ts    |   94.87 |    80.95 |     100 |   92.59 | 45-48,57          
  dropbox.ts       |   96.15 |    76.66 |     100 |     100 | 32-34,43,73-84    
  ...venue-link.ts |     100 |       95 |     100 |     100 | 69                
  imap-replies.ts  |   96.09 |    83.89 |   94.73 |   97.95 | 271-272           
  mailer.ts        |   78.94 |    52.94 |      80 |   83.33 | 13-22             
  migration-cli.ts |     100 |    78.94 |     100 |     100 | 30,46-49,70       
  utils.ts         |     100 |    83.33 |     100 |     100 | 5                 
 ...del/admin-user |   92.85 |      100 |      70 |   91.04 |                   
  ...ser-router.ts |      40 |      100 |       0 |      40 | 10-15,22-23       
 src/model/backup  |   79.16 |    63.63 |     100 |   79.16 |                   
  ...controller.ts |      75 |    63.63 |     100 |      75 | 39-41,46,54       
 ...model/facebook |   98.95 |    78.78 |     100 |    98.8 |                   
  ...Controller.ts |   98.83 |    78.12 |     100 |   98.66 | 41                
 src/model/gig     |     100 |    86.66 |     100 |     100 |                   
  ...controller.ts |     100 |    86.04 |     100 |     100 | 36,43-54,80,106   
 src/model/inquiry |   93.05 |    90.19 |   91.66 |    93.1 |                   
  ...Controller.ts |      84 |    73.68 |      75 |      85 | 34-43             
  index.ts         |   83.33 |      100 |     100 |   83.33 | 13                
 ...del/livestream |   97.36 |       90 |     100 |   96.96 |                   
  ...Controller.ts |     100 |       90 |     100 |     100 | 30-31             
  index.ts         |   83.33 |      100 |     100 |   83.33 | 13                
 ...model/outreach |   94.11 |    87.28 |   84.21 |   94.09 |                   
  ...controller.ts |   98.37 |    86.95 |     100 |   99.58 | 187,1460          
  ...ach-router.ts |   30.23 |      100 |       0 |   30.23 | ...06-107,112-121 
 src/model/promo   |   86.04 |    78.57 |      80 |   87.17 |                   
  ...controller.ts |   89.74 |    78.57 |     100 |   91.42 | 40,68,79          
  promo-router.ts  |      50 |      100 |       0 |      50 | 12-13             
 ...del/subscriber |      80 |    82.08 |   57.14 |    81.7 |                   
  ...ber-router.ts |   42.85 |      100 |       0 |   42.85 | 12-17             
  ...controller.ts |   84.52 |    81.53 |   88.88 |   87.87 | ...19,145,158-160 
  ...ber-router.ts |   57.14 |      100 |       0 |   57.14 | 9,12,15           
 ...model/template |   84.83 |    82.14 |      75 |   86.33 |                   
  ...controller.ts |    90.5 |    81.81 |     100 |   94.11 | ...44,256,281,296 
  ...ate-router.ts |      25 |      100 |       0 |      25 | 14-19,24-25,30-39 
 src/model/venue   |   89.43 |    90.98 |   84.78 |   90.26 |                   
  ...controller.ts |   93.84 |     90.9 |     100 |   96.03 | ...80,486,503,543 
  venue-router.ts  |   26.31 |      100 |       0 |   26.31 | ...27,32-41,48-49 
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 93.17% ( 2361/2534 )
Branches     : 87.21% ( 1494/1713 )
Functions    : 88.65% ( 375/423 )
Lines        : 93.86% ( 1960/2088 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5