### PR TITLE
Venue identity: add address field, dedup on name+city(+address), drop email as dedup key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -485,12 +485,33 @@ class VenueController extends Controller {
   // #983 — email is plain contact data now: the same address (a shared chain
   // inbox) may legitimately exist on multiple venues, and finding it
   // elsewhere must never block or overwrite a create. This is a cheap,
-  // best-effort, non-blocking lookup purely to log an informational notice;
-  // any failure here is swallowed so it can never fail the actual write.
+  // best-effort, non-blocking lookup purely to surface an informational
+  // notice; any failure here is swallowed so it can never fail the actual
+  // write. #985 — when more than one other venue shares the email, only the
+  // FIRST match found is named (kept simple, per #985's own call-it-your-way
+  // acceptance criterion) rather than enumerating every match.
   async findEmailElsewhere(email: string, excludeId?: string): Promise<Record<string, unknown> | null> {
     const query: Record<string, unknown> = { email };
     if (excludeId) query._id = { $ne: excludeId };
     return this.model.findOne(query);
+  }
+
+  // #985 — build the dated notice line persisted to a newly-created venue's
+  // `notes` when its email is already on another venue (e.g. Starr Hill's
+  // shared info@starrhill.com). Same `[YYYY-MM-DD] ...` dated-line format as
+  // the not-interested outcome handler / #980 migration notes.
+  static buildEmailElsewhereNote(email: string, otherName: unknown): string {
+    const dateStr = new Date().toISOString().slice(0, 10);
+    return `[${dateStr}] Email ${email} also used by venue '${String(otherName || '')}'.`;
+  }
+
+  // #985 — append (never overwrite) a note line onto a create payload's own
+  // `notes` value. Only used on the fresh-insert path (findDuplicate found no
+  // match) — an upsert onto an existing venue is intentionally left alone,
+  // since #985 only annotates the NEWLY CREATED record, never another venue.
+  static appendNote(existingNotes: unknown, line: string): string {
+    const trimmed = typeof existingNotes === 'string' ? existingNotes.trim() : '';
+    return trimmed ? `${trimmed}\n${line}` : line;
   }
 
   // POST /venue — create a venue, or upsert onto an existing match (dedupe), so
@@ -509,14 +530,22 @@ class VenueController extends Controller {
     let existing: Record<string, unknown> | null;
     try { existing = await this.findDuplicate(body); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
 
-    // #983 — non-blocking "email also on '<venueName>'" notice: never awaited
-    // in a way that could fail the create, and never used to find/overwrite
-    // a record (that's findDuplicate's job, above, and it never looks at email).
+    // #983/#985 — non-blocking "email also on '<venueName>'" notice: never
+    // awaited in a way that could fail the create, and never used to
+    // find/overwrite a record (that's findDuplicate's job, above, and it
+    // never looks at email). #985 — only a fresh insert (no name+city match)
+    // gets the notice persisted to ITS OWN `notes`; an upsert onto an
+    // existing venue is untouched (not a "newly created" record), and the
+    // OTHER venue that shares the email is never modified either way.
     const email = (body.email || '').trim().toLowerCase();
+    let emailNote = '';
     if (email) {
       try {
         const elsewhere = await this.findEmailElsewhere(email, existing ? String(existing._id) : undefined);
-        if (elsewhere) console.log(`[venue] email '${email}' also on '${elsewhere.name}'`); // eslint-disable-line no-console
+        if (elsewhere) {
+          emailNote = VenueController.buildEmailElsewhereNote(email, elsewhere.name);
+          console.log(`[venue] ${emailNote}`); // eslint-disable-line no-console
+        }
       } catch { /* notice lookup is best-effort only — never blocks the write */ }
     }
 
@@ -529,9 +558,11 @@ class VenueController extends Controller {
       } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
       return res.status(200).json(updated);
     }
+    const createBody: Record<string, unknown> = { ...body, status: body.status || 'active', lastModifiedBy: actor };
+    if (emailNote) createBody.notes = VenueController.appendNote(body.notes, emailNote);
     let doc;
     try {
-      doc = await this.model.create({ ...body, status: body.status || 'active', lastModifiedBy: actor });
+      doc = await this.model.create(createBody);
     } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
     return res.status(201).json(doc);
   }

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -47,6 +47,10 @@ interface VenueBody {
   _id?: string;
   name?: string;
   city?: string;
+  // #983 — street address, the disambiguator for same-name/same-city
+  // locations. Optional; refines POST /venue dedup (see findDuplicate below)
+  // but is never required.
+  address?: string;
   usState?: string;
   // #972 — country (2-letter code, default 'US' at the schema level) + region
   // (free-text state/province, for non-US venues). usState is kept as-is for
@@ -445,14 +449,47 @@ class VenueController extends Controller {
     return res.status(200).json(withLinks[0]);
   }
 
-  // Find an existing venue for dedupe: by email when given (strongest key),
-  // otherwise by case-insensitive name (+ city when present).
+  // Find an existing venue for dedupe (#983). Email is NOT part of this
+  // match anymore — a shared chain inbox (e.g. Starr Hill's info@starrhill
+  // .com) is not unique per location, and matching on it silently overwrote
+  // a different venue's record (the Starr Hill incident this issue fixes).
+  //
+  // Match key is name + city (case-insensitive, as before #983), refined by
+  // `address` ONLY when BOTH the incoming body and a given candidate have a
+  // non-empty address — records without one keep falling back to name+city,
+  // same as before #983 (no back-migration; address fills in on next edit).
+  // When address IS supplied and matches a candidate's address exactly,
+  // that candidate wins outright (two Macado's in Roanoke, disambiguated).
+  // When address is supplied but matches no candidate, only fall back to
+  // name+city when there is exactly one address-less candidate to fall back
+  // to — never guess between two already address-differentiated locations.
   async findDuplicate(body: VenueBody): Promise<Record<string, unknown> | null> {
-    const email = (body.email || '').trim().toLowerCase();
-    if (email) return this.model.findOne({ email });
-    const query: Record<string, unknown> = { name: new RegExp(`^${escapeRegExp((body.name || '').trim())}$`, 'i') };
+    const name = (body.name || '').trim();
+    if (!name) return null;
+    const query: Record<string, unknown> = { name: new RegExp(`^${escapeRegExp(name)}$`, 'i') };
     const city = (body.city || '').trim();
     if (city) query.city = new RegExp(`^${escapeRegExp(city)}$`, 'i');
+    const candidates = await this.model.find(query) as unknown as Record<string, unknown>[];
+    if (!candidates.length) return null;
+    const incomingAddress = (body.address || '').trim().toLowerCase();
+    if (incomingAddress) {
+      const addressMatch = candidates.find(
+        (c) => String(c.address || '').trim().toLowerCase() === incomingAddress,
+      );
+      if (addressMatch) return addressMatch;
+    }
+    const noAddressCandidates = candidates.filter((c) => !String(c.address || '').trim());
+    return noAddressCandidates.length === 1 ? noAddressCandidates[0] : null;
+  }
+
+  // #983 — email is plain contact data now: the same address (a shared chain
+  // inbox) may legitimately exist on multiple venues, and finding it
+  // elsewhere must never block or overwrite a create. This is a cheap,
+  // best-effort, non-blocking lookup purely to log an informational notice;
+  // any failure here is swallowed so it can never fail the actual write.
+  async findEmailElsewhere(email: string, excludeId?: string): Promise<Record<string, unknown> | null> {
+    const query: Record<string, unknown> = { email };
+    if (excludeId) query._id = { $ne: excludeId };
     return this.model.findOne(query);
   }
 
@@ -471,6 +508,18 @@ class VenueController extends Controller {
     const actor = resolveActor(req, body);
     let existing: Record<string, unknown> | null;
     try { existing = await this.findDuplicate(body); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+
+    // #983 — non-blocking "email also on '<venueName>'" notice: never awaited
+    // in a way that could fail the create, and never used to find/overwrite
+    // a record (that's findDuplicate's job, above, and it never looks at email).
+    const email = (body.email || '').trim().toLowerCase();
+    if (email) {
+      try {
+        const elsewhere = await this.findEmailElsewhere(email, existing ? String(existing._id) : undefined);
+        if (elsewhere) console.log(`[venue] email '${email}' also on '${elsewhere.name}'`); // eslint-disable-line no-console
+      } catch { /* notice lookup is best-effort only — never blocks the write */ }
+    }
+
     if (existing) {
       let updated;
       try {

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -72,6 +72,12 @@ const touchSchema = new Schema({
 const venueSchema = new Schema({
   name: { type: String, required: true, trim: true },
   city: { type: String, required: false, trim: true },
+  // #983 — street address, the disambiguator for same-name/same-city
+  // locations (e.g. two Macado's in Roanoke). Optional: not back-migrated
+  // onto existing records (see #983 non-goals) — it's filled in the next
+  // time a venue is created/edited. See venue-controller.ts's findDuplicate
+  // for how this refines the POST /venue dedup match.
+  address: { type: String, required: false, trim: true },
   usState: { type: String, required: false, trim: true },
   // #972 — 2-letter country code (validated in venue-controller.ts), defaulting
   // to 'US' since every venue on record today is US-based. `region` is optional

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -304,7 +304,7 @@ describe('Venue Controller', () => {
           user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', email: 'info@starrhill.com' },
         }, resStub);
         expect(status).toBe(201);
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("also on 'Starr Hill On Main'"));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("also used by venue 'Starr Hill On Main'"));
         logSpy.mockRestore();
       });
 
@@ -317,6 +317,70 @@ describe('Venue Controller', () => {
           user: 'a', body: { name: 'Some Venue', email: 'info@starrhill.com' },
         }, resStub);
         expect(status).toBe(201);
+      });
+
+      // #985 — persist the duplicate-email notice to the NEW venue's own
+      // notes field (append, never overwrite), since a server-log-only notice
+      // was never visible to a human in AdminVenues.
+      describe('duplicate-email note append (#985)', () => {
+        it('appends a dated note to the new venue when its email is found on another venue', async () => {
+          c.model.find = vi.fn(() => Promise.resolve([]));
+          c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'other-venue', name: 'Starr Hill Pilot Brewery' }));
+          const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
+          c.model.create = create;
+          await c.createVenue({
+            user: 'a', body: { name: 'Starr Hill On Main', city: 'Lynchburg', email: 'info@starrhill.com' },
+          }, resStub);
+          expect(status).toBe(201);
+          const arg = (create.mock.calls[0] as unknown[])[0] as any;
+          const today = new Date().toISOString().slice(0, 10);
+          expect(arg.notes).toBe(`[${today}] Email info@starrhill.com also used by venue 'Starr Hill Pilot Brewery'.`);
+        });
+
+        it('preserves pre-existing notes on the new venue (appended, not overwritten)', async () => {
+          c.model.find = vi.fn(() => Promise.resolve([]));
+          c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'other-venue', name: 'Starr Hill Pilot Brewery' }));
+          const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
+          c.model.create = create;
+          await c.createVenue({
+            user: 'a',
+            body: {
+              name: 'Starr Hill On Main', city: 'Lynchburg', email: 'info@starrhill.com', notes: 'Great patio.',
+            },
+          }, resStub);
+          expect(status).toBe(201);
+          const arg = (create.mock.calls[0] as unknown[])[0] as any;
+          expect(arg.notes).toMatch(/^Great patio\.\n\[\d{4}-\d{2}-\d{2}] Email info@starrhill\.com also used by venue 'Starr Hill Pilot Brewery'\.$/);
+        });
+
+        it('adds no note when the email is unique (not found elsewhere)', async () => {
+          c.model.find = vi.fn(() => Promise.resolve([]));
+          c.model.findOne = vi.fn(() => Promise.resolve(null));
+          const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
+          c.model.create = create;
+          await c.createVenue({
+            user: 'a', body: { name: 'Unique Venue', email: 'nobody-else@x.com' },
+          }, resStub);
+          expect(status).toBe(201);
+          const arg = (create.mock.calls[0] as unknown[])[0] as any;
+          expect(arg).not.toHaveProperty('notes');
+        });
+
+        it('does not annotate notes on the upsert-onto-existing-match path (only a newly-created record is annotated)', async () => {
+          c.model.find = vi.fn(() => Promise.resolve([{ _id: 'dup5', name: 'The Spot', city: 'Salem' }]));
+          c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'other-venue', name: 'Some Other Venue' }));
+          const upd = vi.fn(() => Promise.resolve({ _id: 'dup5' }));
+          c.model.findByIdAndUpdate = upd;
+          const create = vi.fn();
+          c.model.create = create;
+          await c.createVenue({
+            user: 'a', body: { name: 'The Spot', city: 'Salem', email: 'shared@x.com' },
+          }, resStub);
+          expect(status).toBe(200);
+          expect(create).not.toHaveBeenCalled();
+          const written = (upd.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+          expect(written).not.toHaveProperty('notes');
+        });
       });
 
       it('findDuplicate: no candidates at all resolves null', async () => {

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -30,6 +30,10 @@ describe('Venue Controller', () => {
     // attachGigLinks); default it to empty so tests that don't care about gig
     // linkage never hit the real DB. Tests exercising the linkage override this.
     (gigModel as any).find = vi.fn(() => Promise.resolve([]));
+    // #983 — createVenue's non-blocking email-elsewhere notice calls
+    // model.findOne whenever the body has an email; default it to null so a
+    // test that doesn't care about the notice never hits the real DB.
+    (venueModel as any).findOne = vi.fn(() => Promise.resolve(null));
   });
 
   describe('authorize', () => {
@@ -104,7 +108,7 @@ describe('Venue Controller', () => {
     });
 
     it('accepts + passes through the ranking fields (#867)', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'n' }));
       c.model.create = create;
       await c.createVenue({
@@ -135,6 +139,7 @@ describe('Venue Controller', () => {
     });
 
     it('accepts + passes through a valid secondaryEmail alongside the primary (#974)', async () => {
+      c.model.find = vi.fn(() => Promise.resolve([]));
       c.model.findOne = vi.fn(() => Promise.resolve(null));
       const create = vi.fn(() => Promise.resolve({ _id: 'n3' }));
       c.model.create = create;
@@ -148,7 +153,7 @@ describe('Venue Controller', () => {
     });
 
     it('allows an empty-string secondaryEmail (unset, not an error)', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'n4' }));
       c.model.create = create;
       await c.createVenue({ user: 'a', body: { name: 'X', secondaryEmail: '' } }, resStub);
@@ -167,7 +172,7 @@ describe('Venue Controller', () => {
     });
 
     it('accepts + passes through country + region (#972)', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'n2' }));
       c.model.create = create;
       await c.createVenue({
@@ -180,7 +185,7 @@ describe('Venue Controller', () => {
     });
 
     it('creates a new venue when there is no duplicate', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'new' }));
       c.model.create = create;
       await c.createVenue({ user: 'agent', body: { name: 'The Spot', city: 'Salem', actor: 'sonnet' } }, resStub);
@@ -191,7 +196,7 @@ describe('Venue Controller', () => {
     });
 
     it('upserts onto an existing duplicate instead of inserting', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'dup1' }));
+      c.model.find = vi.fn(() => Promise.resolve([{ _id: 'dup1', name: 'The Spot' }]));
       const upd = vi.fn(() => Promise.resolve({ _id: 'dup1' }));
       c.model.findByIdAndUpdate = upd;
       const create = vi.fn();
@@ -202,12 +207,136 @@ describe('Venue Controller', () => {
       expect(upd).toHaveBeenCalledWith('dup1', expect.objectContaining({ status: 'active' }));
     });
 
-    it('dedupes by email when an email is provided', async () => {
-      const findOne = vi.fn(() => Promise.resolve(null));
-      c.model.findOne = findOne;
-      c.model.create = vi.fn(() => Promise.resolve({ _id: 'n' }));
-      await c.createVenue({ user: 'a', body: { name: 'X', email: 'A@B.com' } }, resStub);
-      expect(findOne).toHaveBeenCalledWith({ email: 'a@b.com' });
+    // #983 — dedup logic. Email is entirely out of the match key now; only
+    // name+city (refined by address when both sides have one) is used.
+    describe('dedup (#983)', () => {
+      it('matches by name+city (case-insensitive), no address involved', async () => {
+        const find = vi.fn(() => Promise.resolve([{ _id: 'dup2', name: 'The Spot', city: 'Salem' }]));
+        c.model.find = find;
+        const upd = vi.fn(() => Promise.resolve({ _id: 'dup2' }));
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({ user: 'a', body: { name: 'the spot', city: 'SALEM' } }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith('dup2', expect.objectContaining({ status: 'active' }));
+      });
+
+      it('same name+city, no address on either side, dedupes as today', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'dup3', name: "Macado's", city: 'Roanoke' }]));
+        const upd = vi.fn(() => Promise.resolve({ _id: 'dup3' }));
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({ user: 'a', body: { name: "Macado's", city: 'Roanoke' } }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith('dup3', expect.objectContaining({ status: 'active' }));
+      });
+
+      it('same name+city, different (both non-empty) address ⇒ creates a new record, not an overwrite', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          {
+            _id: 'macados-1', name: "Macado's", city: 'Roanoke', address: '1 Electric Rd',
+          },
+        ]));
+        const create = vi.fn(() => Promise.resolve({ _id: 'macados-2' }));
+        c.model.create = create;
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({
+          user: 'a', body: { name: "Macado's", city: 'Roanoke', address: '2 Franklin Rd' },
+        }, resStub);
+        expect(status).toBe(201);
+        expect(upd).not.toHaveBeenCalled();
+        expect(create).toHaveBeenCalled();
+      });
+
+      it('same name+city+same address (case-insensitive) ⇒ matches the right location', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          {
+            _id: 'macados-1', name: "Macado's", city: 'Roanoke', address: '1 Electric Rd',
+          },
+          {
+            _id: 'macados-2', name: "Macado's", city: 'Roanoke', address: '2 Franklin Rd',
+          },
+        ]));
+        const upd = vi.fn(() => Promise.resolve({ _id: 'macados-2' }));
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({
+          user: 'a', body: { name: "Macado's", city: 'Roanoke', address: '2 franklin rd' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith('macados-2', expect.objectContaining({ status: 'active' }));
+      });
+
+      it('incoming has an address, existing candidate has none ⇒ still matches (falls back to name+city, fills the address in)', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'dup4', name: 'Starr Hill Pilot Brewery', city: 'Roanoke' }]));
+        const upd = vi.fn(() => Promise.resolve({ _id: 'dup4' }));
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({
+          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', address: '5 Points' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith('dup4', expect.objectContaining({ address: '5 Points' }));
+      });
+
+      it('shared email across two differently-named venues ⇒ two records, no overwrite (the Starr Hill fix)', async () => {
+        // findDuplicate matches on name+city only — a different name never
+        // returns a match, regardless of a shared email, so no findOne-by-
+        // email path exists anymore to accidentally overwrite the other venue.
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'starr-hill-on-main', name: 'Starr Hill On Main' }));
+        const create = vi.fn(() => Promise.resolve({ _id: 'starr-hill-pilot-brewery', name: 'Starr Hill Pilot Brewery' }));
+        c.model.create = create;
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({
+          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', email: 'info@starrhill.com' },
+        }, resStub);
+        expect(status).toBe(201);
+        expect(upd).not.toHaveBeenCalled();
+        expect(create).toHaveBeenCalled();
+      });
+
+      it('logs a non-blocking notice when the email is found elsewhere, without blocking or overwriting', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        c.model.findOne = vi.fn(() => Promise.resolve({ _id: 'other-venue', name: 'Starr Hill On Main' }));
+        const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
+        c.model.create = create;
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        await c.createVenue({
+          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', email: 'info@starrhill.com' },
+        }, resStub);
+        expect(status).toBe(201);
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("also on 'Starr Hill On Main'"));
+        logSpy.mockRestore();
+      });
+
+      it('the email-notice lookup failing never blocks the create', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        c.model.findOne = vi.fn(() => Promise.reject(new Error('db down')));
+        const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
+        c.model.create = create;
+        await c.createVenue({
+          user: 'a', body: { name: 'Some Venue', email: 'info@starrhill.com' },
+        }, resStub);
+        expect(status).toBe(201);
+      });
+
+      it('findDuplicate: no candidates at all resolves null', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        const result = await c.findDuplicate({ name: 'Nobody Here' });
+        expect(result).toBeNull();
+      });
+
+      it('findDuplicate: an address supplied with no matching candidate and no unambiguous address-less fallback resolves null', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          {
+            _id: 'a1', name: "Macado's", city: 'Roanoke', address: '1 Electric Rd',
+          },
+          {
+            _id: 'a2', name: "Macado's", city: 'Roanoke', address: '2 Franklin Rd',
+          },
+        ]));
+        const result = await c.findDuplicate({ name: "Macado's", city: 'Roanoke', address: '3 Brand New Rd' });
+        expect(result).toBeNull();
+      });
     });
   });
 
@@ -666,7 +795,7 @@ describe('Venue Controller', () => {
     // stripped before validateBody ever sees it), so an invalid value is
     // silently ignored rather than rejected.
     it('silently strips an invalid bookingStatus instead of rejecting it (#980)', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'v11' }));
       c.model.create = create;
       await c.createVenue({ user: 'a', body: { name: 'X', bookingStatus: 'bogus' } }, resStub);
@@ -675,7 +804,7 @@ describe('Venue Controller', () => {
     });
 
     it('persists the vetting tags on create', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'v10' }));
       c.model.create = create;
       await c.createVenue({
@@ -831,7 +960,7 @@ describe('Venue Controller', () => {
 
   describe('outreachEligible tagging (#843)', () => {
     it('persists outreachEligible on create (passes through ...body)', async () => {
-      c.model.findOne = vi.fn(() => Promise.resolve(null));
+      c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'v9' }));
       c.model.create = create;
       await c.createVenue({ user: 'a', body: { name: 'The Spot', venueType: 'Originals', outreachEligible: true } }, resStub);


### PR DESCRIPTION
## Summary
- Add optional `address` field (String, trimmed) to the venue schema — the disambiguator for same-name/same-city locations (e.g. two Macado's in Roanoke).
- Rewrite `POST /venue`'s `findDuplicate` to match on name+city (case-insensitive, as before), refined by `address` ONLY when both the incoming body and a given candidate have a non-empty address; a candidate with a different non-empty address is no longer treated as the same venue, and a candidate with no address on file still falls back to name+city (filling the address in on that write).
- Remove email entirely from the dedup/match logic — the bug that let Starr Hill's shared `info@starrhill.com` inbox silently overwrite a different location's record. Email is now plain contact data: the same address may exist on multiple venues, `POST /venue` never overwrites a different venue on an email match.
- (#985) When `POST /venue` creates a brand-new venue whose email is already on another venue, append a dated line to the NEW venue's own `notes` (e.g. `[2026-07-19] Email info@starrhill.com also used by venue 'Starr Hill Pilot Brewery'.`) — append-only, never overwriting pre-existing notes, and only the newly-created record is touched (the matched other venue, and any upsert-onto-an-existing-match, are left alone). A matching `console.log` notice is kept as well. Multiple matches name the first one found (kept simple, per #985).
- Add unit tests for all three #983 acceptance scenarios (same name+city+different address gives two records; same name+city with no address dedupes as today; shared email across two differently-named venues gives two records with no overwrite) plus the #985 notes-append scenarios (dup-email appends note / preserves existing notes / unique email adds nothing / upsert path untouched).

Closes #983
Closes #985

## How to test locally
Run the full gate:
```sh
npm test
```
Expect: eslint clean, jscpd report only (no new duplication introduced), typecheck clean, 846/846 vitest tests green, coverage gate (90/90/80/80) passing.

Then exercise the change itself against a running instance (`npm start`), using a JaM-admin or agent bearer token:
```sh
# 1. Two Macado's in Roanoke, different addresses -> two records
curl -s -X POST http://localhost:3000/venue -H 'Authorization: Bearer TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"Macados","city":"Roanoke","address":"1 Electric Rd"}'
curl -s -X POST http://localhost:3000/venue -H 'Authorization: Bearer TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"Macados","city":"Roanoke","address":"2 Franklin Rd"}'
# Expect: two distinct 201s with two distinct _ids (GET /venue then shows 2 Roanoke Macados records).

# 2. Starr Hill's shared chain inbox no longer overwrites a different location, and the
#    notice is persisted to the NEW venue's own notes (#985)
curl -s -X POST http://localhost:3000/venue -H 'Authorization: Bearer TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"Starr Hill On Main","city":"Lynchburg","email":"info@starrhill.com"}'
curl -s -X POST http://localhost:3000/venue -H 'Authorization: Bearer TOKEN' -H 'Content-Type: application/json' \
  -d '{"name":"Starr Hill Pilot Brewery","city":"Roanoke","email":"info@starrhill.com"}'
# Expect: 201 both times (two records) -- the Roanoke record is NOT overwritten by the Lynchburg POST. The second
# venue's response body has notes: "[YYYY-MM-DD] Email info@starrhill.com also used by venue 'Starr Hill On Main'."
# and the server log prints a matching non-blocking notice.
```

## Test evidence
```
> web-jam-back@2.7.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

(eslint: no output, zero errors/warnings)
(jscpd: pre-existing clones only, unrelated to this change)

> web-jam-back@2.7.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit

(typecheck: no output, zero errors)

> web-jam-back@2.7.0 test:unit
> vitest run --coverage

 Test Files  52 passed (52)
      Tests  846 passed (846)

=============================== Coverage summary ===============================
Statements   : 93.21% ( 2390/2564 )
Branches     : 87.32% ( 1522/1743 )
Functions    : 88.78% ( 380/428 )
Lines        : 93.94% ( 1985/2113 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5
