### PR TITLE
Venue addresses: normalize on write (USPS Pub 28) and require one on creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/normalize-address.ts
+++ b/src/model/venue/normalize-address.ts
@@ -1,0 +1,103 @@
+// src/model/venue/normalize-address.ts — web-jam-back#987
+//
+// Pure, table-driven address normalizer. Abbreviates USPS Publication 28
+// street-suffix / directional / unit-designator words to their standard
+// short form and Title-Cases the result, so the STORED `address` is always
+// the same compact, Google-Maps-friendly form regardless of how it was
+// typed (e.g. "1 Electric Road" and "1 Electric Rd" both normalize to the
+// same string, which is what makes the venue-controller dedup in #987 work).
+//
+// No external API — this is a local, offline lookup table, deliberately
+// (see #987's non-goals: no USPS/geocoding call on the create path).
+
+// USPS Pub 28 street-suffix abbreviations. Table-driven so extending the list
+// (more suffixes) is a one-line addition, never a code change.
+export const STREET_SUFFIXES: Record<string, string> = {
+  street: 'St',
+  road: 'Rd',
+  avenue: 'Ave',
+  boulevard: 'Blvd',
+  drive: 'Dr',
+  lane: 'Ln',
+  court: 'Ct',
+  circle: 'Cir',
+  highway: 'Hwy',
+  place: 'Pl',
+  parkway: 'Pkwy',
+  terrace: 'Ter',
+  trail: 'Trl',
+  square: 'Sq',
+  plaza: 'Plz',
+  turnpike: 'Tpke',
+};
+
+// Directional prefixes/suffixes, plus the four compass compounds.
+export const DIRECTIONALS: Record<string, string> = {
+  north: 'N',
+  south: 'S',
+  east: 'E',
+  west: 'W',
+  northeast: 'NE',
+  northwest: 'NW',
+  southeast: 'SE',
+  southwest: 'SW',
+};
+
+// Unit designators.
+export const UNIT_DESIGNATORS: Record<string, string> = {
+  suite: 'Ste',
+  apartment: 'Apt',
+  building: 'Bldg',
+  floor: 'Fl',
+};
+
+// Full-word (lowercase key) -> canonical abbreviation, merged from the three
+// tables above. One combined lookup, used uniformly per token below.
+const ABBREVIATIONS: Record<string, string> = {
+  ...STREET_SUFFIXES,
+  ...DIRECTIONALS,
+  ...UNIT_DESIGNATORS,
+};
+
+// Reverse map: lowercased abbreviation -> its canonically-cased form (e.g.
+// 'st' -> 'St', 'ne' -> 'NE'). This is what makes normalization idempotent —
+// an address that's already abbreviated (e.g. "100 N Main St") normalizes to
+// itself, rather than the naive per-word Title-Case mis-casing an already
+// all-caps compass compound like "NE" down to "Ne" on a second pass.
+const CANONICAL_ABBREVIATIONS: Record<string, string> = {};
+Object.values(ABBREVIATIONS).forEach((abbr) => {
+  CANONICAL_ABBREVIATIONS[abbr.toLowerCase()] = abbr;
+});
+
+// Title-case a plain alphabetic word (first letter up, rest down). Tokens
+// containing digits/punctuation (house numbers, unit numbers, a bare '#',
+// "I-81", etc.) are left untouched — there is no "case" to correct there.
+function titleCaseWord(token: string): string {
+  if (!/^[A-Za-z]+$/.test(token)) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+}
+
+// Map one whitespace-delimited token through the abbreviation tables, falling
+// back to Title Case for an ordinary word and to a no-op for anything else
+// (numbers, a bare '#', a '#'-prefixed unit number like "#2" — the bare '#'
+// is deliberately left exactly as typed; it's already the compact USPS form,
+// so there is nothing to abbreviate or strip).
+function normalizeToken(token: string): string {
+  const key = token.toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(ABBREVIATIONS, key)) return ABBREVIATIONS[key];
+  if (Object.prototype.hasOwnProperty.call(CANONICAL_ABBREVIATIONS, key)) return CANONICAL_ABBREVIATIONS[key];
+  return titleCaseWord(token);
+}
+
+// Normalize a raw address string to the canonical stored form:
+// collapse whitespace, trim, strip ',' and '.', abbreviate suffixes/
+// directionals/unit designators (table-driven, see above), Title-Case
+// everything else. Non-string / empty input normalizes to ''.
+export function normalizeAddress(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  const withoutPunctuation = raw.replace(/[,.]/g, ' ');
+  const tokens = withoutPunctuation.split(/\s+/).filter(Boolean);
+  return tokens.map(normalizeToken).join(' ');
+}
+
+export default normalizeAddress;

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -4,6 +4,7 @@ import Controller from '#src/lib/controller.js';
 import { Icontroller } from '#src/lib/routeUtils.js';
 import { isValidEmail } from '#src/lib/email.js';
 import venueModel from './venue-facade.js';
+import { normalizeAddress } from './normalize-address.js';
 import userModel from '../user/user-facade.js';
 import gigModel from '../gig/gig-facade.js';
 import {
@@ -47,9 +48,12 @@ interface VenueBody {
   _id?: string;
   name?: string;
   city?: string;
-  // #983 — street address, the disambiguator for same-name/same-city
-  // locations. Optional; refines POST /venue dedup (see findDuplicate below)
-  // but is never required.
+  // #983/#987 — street address, the disambiguator for same-name/same-city
+  // locations. REQUIRED on every POST /venue (#987 Part B — validated in
+  // validateBody below, before any DB write) and normalized on write (#987
+  // Part A — see normalize-address.ts), on both POST and PUT. PUT keeps it
+  // optional (schema stays required:false — see venue-schema.ts) but an
+  // address, once set, cannot be removed; see updateVenue below.
   address?: string;
   usState?: string;
   // #972 — country (2-letter code, default 'US' at the schema level) + region
@@ -90,6 +94,14 @@ interface VenueBody {
 }
 
 interface GigDoc { venue?: string; datetime?: string | Date }
+
+// #987 — findDuplicate's result: a definite match to upsert onto, no match
+// (create fresh), or an ambiguous set of address-less legacy candidates that
+// createVenue must 400 on rather than guess between.
+type DuplicateResolution =
+  | { kind: 'match'; venue: Record<string, unknown> }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; ids: string[] };
 
 // #898 — wire shape for POST /venue/:id/touch. `targetWeekend` mirrors the
 // outreach schema's shape (strings over the wire; parsed to Dates below).
@@ -240,6 +252,15 @@ function validateBody(body: VenueBody, partial: boolean): string {
   }
   if (body.country !== undefined && body.country !== '' && !COUNTRY_RE.test(String(body.country).trim())) {
     return 'country must be a 2-letter code';
+  }
+  // #987 Part B — address is required on every POST /venue (partial=false),
+  // validated here before any DB write. Checked last so any other body error
+  // (a bad enum, an invalid email, etc.) still reports its own specific
+  // message first — this only fires when nothing else is already wrong.
+  // PUT (partial=true) stays optional; see updateVenue for its own
+  // immutable-once-set address rule.
+  if (!partial && (!body.address || !String(body.address).trim())) {
+    return 'address is required to create a venue';
   }
   return '';
 }
@@ -449,37 +470,44 @@ class VenueController extends Controller {
     return res.status(200).json(withLinks[0]);
   }
 
-  // Find an existing venue for dedupe (#983). Email is NOT part of this
-  // match anymore — a shared chain inbox (e.g. Starr Hill's info@starrhill
-  // .com) is not unique per location, and matching on it silently overwrote
-  // a different venue's record (the Starr Hill incident this issue fixes).
+  // Find an existing venue for dedupe (#983, refined by #987). Email is NOT
+  // part of this match — a shared chain inbox (e.g. Starr Hill's
+  // info@starrhill.com) is not unique per location, and matching on it
+  // silently overwrote a different venue's record (the Starr Hill incident
+  // #983 fixed).
   //
-  // Match key is name + city (case-insensitive, as before #983), refined by
-  // `address` ONLY when BOTH the incoming body and a given candidate have a
-  // non-empty address — records without one keep falling back to name+city,
-  // same as before #983 (no back-migration; address fills in on next edit).
-  // When address IS supplied and matches a candidate's address exactly,
-  // that candidate wins outright (two Macado's in Roanoke, disambiguated).
-  // When address is supplied but matches no candidate, only fall back to
-  // name+city when there is exactly one address-less candidate to fall back
-  // to — never guess between two already address-differentiated locations.
-  async findDuplicate(body: VenueBody): Promise<Record<string, unknown> | null> {
+  // Match key is name + city (case-insensitive), refined by `address`
+  // compared NORMALIZED-to-normalized (#987 Part A's normalizeAddress) so an
+  // incoming un-normalized address still matches an already-stored
+  // (normalized, or pre-#987 legacy raw) one:
+  //   - a candidate with the SAME normalized address wins outright — that's
+  //     the venue, upsert onto it (two Macado's in Roanoke, disambiguated).
+  //   - a candidate with a DIFFERENT non-empty address is not a match.
+  //   - a legacy candidate with NO address on file (everything predating
+  //     #983) is a fallback match ONLY when there is exactly one such
+  //     candidate; two or more is reported back as 'ambiguous' so the caller
+  //     (createVenue) can 400 rather than guess.
+  async findDuplicate(body: VenueBody): Promise<DuplicateResolution> {
     const name = (body.name || '').trim();
-    if (!name) return null;
+    if (!name) return { kind: 'none' };
     const query: Record<string, unknown> = { name: new RegExp(`^${escapeRegExp(name)}$`, 'i') };
     const city = (body.city || '').trim();
     if (city) query.city = new RegExp(`^${escapeRegExp(city)}$`, 'i');
     const candidates = await this.model.find(query) as unknown as Record<string, unknown>[];
-    if (!candidates.length) return null;
-    const incomingAddress = (body.address || '').trim().toLowerCase();
-    if (incomingAddress) {
+    if (!candidates.length) return { kind: 'none' };
+    const incomingNormalized = normalizeAddress(body.address).toLowerCase();
+    if (incomingNormalized) {
       const addressMatch = candidates.find(
-        (c) => String(c.address || '').trim().toLowerCase() === incomingAddress,
+        (c) => normalizeAddress(String(c.address || '')).toLowerCase() === incomingNormalized,
       );
-      if (addressMatch) return addressMatch;
+      if (addressMatch) return { kind: 'match', venue: addressMatch };
     }
-    const noAddressCandidates = candidates.filter((c) => !String(c.address || '').trim());
-    return noAddressCandidates.length === 1 ? noAddressCandidates[0] : null;
+    const legacyCandidates = candidates.filter((c) => !String(c.address || '').trim());
+    if (legacyCandidates.length === 1) return { kind: 'match', venue: legacyCandidates[0] };
+    if (legacyCandidates.length > 1) {
+      return { kind: 'ambiguous', ids: legacyCandidates.map((c) => String(c._id)) };
+    }
+    return { kind: 'none' };
   }
 
   // #983 — email is plain contact data now: the same address (a shared chain
@@ -514,6 +542,29 @@ class VenueController extends Controller {
     return trimmed ? `${trimmed}\n${line}` : line;
   }
 
+  // #987 — resolve findDuplicate's result for createVenue: an error tuple
+  // when a 500 (the lookup itself threw) or a 400 (ambiguous legacy
+  // candidates, Part B) should short-circuit the create, or the existing doc
+  // to upsert onto (null = create fresh). Split out of createVenue to keep
+  // its cognitive complexity down.
+  async resolveExistingForCreate(
+    body: VenueBody,
+  ): Promise<{ error: { status: number; message: string } } | { existing: Record<string, unknown> | null }> {
+    let resolution: DuplicateResolution;
+    try { resolution = await this.findDuplicate(body); } catch (e) {
+      return { error: { status: 500, message: (e as Error).message } };
+    }
+    if (resolution.kind === 'ambiguous') {
+      return {
+        error: {
+          status: 400,
+          message: `multiple existing venues without an address match this name/city; specify which to update: ${resolution.ids.join(', ')}`,
+        },
+      };
+    }
+    return { existing: resolution.kind === 'match' ? resolution.venue : null };
+  }
+
   // POST /venue — create a venue, or upsert onto an existing match (dedupe), so
   // an agent that re-adds a known venue updates it instead of duplicating. A
   // matched venue is also un-archived.
@@ -525,10 +576,14 @@ class VenueController extends Controller {
     stripReadOnlyFields(body as unknown as Record<string, unknown>);
     const invalid = validateBody(body, false);
     if (invalid) return res.status(400).json({ message: invalid });
+    // #987 Part A — normalize the (now-guaranteed-present, per validateBody
+    // above) address on write, identically to the PUT path (updateVenue).
+    body.address = normalizeAddress(body.address);
 
     const actor = resolveActor(req, body);
-    let existing: Record<string, unknown> | null;
-    try { existing = await this.findDuplicate(body); } catch (e) { return res.status(500).json({ message: (e as Error).message }); }
+    const resolved = await this.resolveExistingForCreate(body);
+    if ('error' in resolved) return res.status(resolved.error.status).json({ message: resolved.error.message });
+    const { existing } = resolved;
 
     // #983/#985 — non-blocking "email also on '<venueName>'" notice: never
     // awaited in a way that could fail the create, and never used to
@@ -567,7 +622,38 @@ class VenueController extends Controller {
     return res.status(201).json(doc);
   }
 
-  // PUT /venue/:id — partial update.
+  // #987 — validates/normalizes a PUT body's `address` in place (mutates
+  // `body.address`) per the once-set-cannot-be-removed rule, returning an
+  // error tuple to short-circuit on, or null when fine to proceed:
+  //   - `address` key absent from the body entirely -> null immediately
+  //     (normal partial-merge behavior; nothing below runs, body untouched).
+  //   - present and non-empty -> normalized identically to POST (Part A) —
+  //     this is how you correct a wrong address.
+  //   - present but empty/whitespace/null -> allowed ONLY as a no-op when the
+  //     venue currently has no address on file (legacy records must stay
+  //     editable); an error tuple (400, nothing written) when it does have
+  //     one. Split out of updateVenue to keep its cognitive complexity down.
+  async applyAddressUpdate(id: string, body: VenueBody): Promise<{ status: number; message: string } | null> {
+    if (!Object.prototype.hasOwnProperty.call(body, 'address')) return null;
+    const trimmedAddress = typeof body.address === 'string' ? body.address.trim() : '';
+    if (trimmedAddress) {
+      body.address = normalizeAddress(trimmedAddress);
+      return null;
+    }
+    let currentDoc: Record<string, unknown> | null;
+    try { currentDoc = await this.model.findById(id); } catch (e) { return { status: 500, message: (e as Error).message }; }
+    if (!currentDoc) return { status: 400, message: 'Id Not Found' };
+    if (String(currentDoc.address || '').trim()) {
+      return { status: 400, message: 'address cannot be removed; supply a corrected address instead' };
+    }
+    // No address on file — allowed no-op; write a definite '' rather than
+    // whatever falsy shape (e.g. null) the caller sent.
+    body.address = '';
+    return null;
+  }
+
+  // PUT /venue/:id — partial update. See applyAddressUpdate above for the
+  // #987 address-immutability rule this enforces.
   async updateVenue(req: AuthIdRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, ['venue:edit']);
     if (guardErr) return res.status(guardErr.status).json({ message: guardErr.message });
@@ -577,6 +663,8 @@ class VenueController extends Controller {
     stripReadOnlyFields(body as unknown as Record<string, unknown>);
     const invalid = validateBody(body, true);
     if (invalid) return res.status(400).json({ message: invalid });
+    const addressErr = await this.applyAddressUpdate(req.params.id, body);
+    if (addressErr) return res.status(addressErr.status).json({ message: addressErr.message });
     let doc;
     try {
       doc = await this.model.findByIdAndUpdate(req.params.id, { ...body, lastModifiedBy: resolveActor(req, body) });

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -73,10 +73,15 @@ const venueSchema = new Schema({
   name: { type: String, required: true, trim: true },
   city: { type: String, required: false, trim: true },
   // #983 — street address, the disambiguator for same-name/same-city
-  // locations (e.g. two Macado's in Roanoke). Optional: not back-migrated
-  // onto existing records (see #983 non-goals) — it's filled in the next
-  // time a venue is created/edited. See venue-controller.ts's findDuplicate
-  // for how this refines the POST /venue dedup match.
+  // locations (e.g. two Macado's in Roanoke). Schema stays required:false ON
+  // PURPOSE (#987): a schema-level `required` would break every write to
+  // every existing address-less record. `address` IS required on create,
+  // and normalized on every write (USPS Pub 28 abbreviations) — both
+  // enforced in the controller, not here. Never back-migrated onto existing
+  // records (see #983/#987 non-goals) — it's filled/normalized the next time
+  // a venue is created/edited. See venue-controller.ts's findDuplicate for
+  // how this refines the POST /venue dedup match, and updateVenue for why a
+  // once-set address can't be cleared via PUT.
   address: { type: String, required: false, trim: true },
   usState: { type: String, required: false, trim: true },
   // #972 — 2-letter country code (validated in venue-controller.ts), defaulting

--- a/test/unit/venue/normalize-address.spec.ts
+++ b/test/unit/venue/normalize-address.spec.ts
@@ -1,0 +1,89 @@
+import {
+  normalizeAddress, STREET_SUFFIXES, DIRECTIONALS, UNIT_DESIGNATORS,
+} from '#src/model/venue/normalize-address.js';
+
+// web-jam-back#987 — the normalizer table drives POST/PUT /venue's on-write
+// normalization and the dedup comparison in findDuplicate. Tested directly,
+// independent of the controller.
+describe('normalizeAddress (#987)', () => {
+  it('non-string / empty input normalizes to an empty string', () => {
+    expect(normalizeAddress(undefined)).toBe('');
+    expect(normalizeAddress(null)).toBe('');
+    expect(normalizeAddress(123 as unknown as string)).toBe('');
+    expect(normalizeAddress('')).toBe('');
+    expect(normalizeAddress('   ')).toBe('');
+  });
+
+  it('collapses whitespace runs and trims', () => {
+    expect(normalizeAddress('  100   Main   Street  ')).toBe('100 Main St');
+  });
+
+  it('strips commas and periods', () => {
+    expect(normalizeAddress('221 Church St.,')).toBe('221 Church St');
+    expect(normalizeAddress('100 N. Main St., Suite 2')).toBe('100 N Main St Ste 2');
+  });
+
+  // Every USPS Pub 28 street suffix in the table, individually.
+  describe('street suffixes (table-driven)', () => {
+    Object.entries(STREET_SUFFIXES).forEach(([word, abbr]) => {
+      it(`abbreviates "${word}" -> "${abbr}"`, () => {
+        expect(normalizeAddress(`1 Main ${word}`)).toBe(`1 Main ${abbr}`);
+        // Case-insensitive on input.
+        expect(normalizeAddress(`1 Main ${word.toUpperCase()}`)).toBe(`1 Main ${abbr}`);
+      });
+    });
+  });
+
+  describe('directionals (table-driven)', () => {
+    Object.entries(DIRECTIONALS).forEach(([word, abbr]) => {
+      it(`abbreviates "${word}" -> "${abbr}"`, () => {
+        expect(normalizeAddress(`100 ${word} Main St`)).toBe(`100 ${abbr} Main St`);
+      });
+    });
+  });
+
+  describe('unit designators (table-driven)', () => {
+    Object.entries(UNIT_DESIGNATORS).forEach(([word, abbr]) => {
+      it(`abbreviates "${word}" -> "${abbr}"`, () => {
+        expect(normalizeAddress(`1 Main St ${word} 2`)).toBe(`1 Main St ${abbr} 2`);
+      });
+    });
+  });
+
+  it('applies Title Case to ordinary words', () => {
+    expect(normalizeAddress('100 north main street')).toBe('100 N Main St');
+    expect(normalizeAddress('100 NORTH MAIN STREET')).toBe('100 N Main St');
+  });
+
+  it('leaves a bare "#" (and a "#"-prefixed unit number) untouched — documented choice', () => {
+    expect(normalizeAddress('100 Main St # 2')).toBe('100 Main St # 2');
+    expect(normalizeAddress('100 Main St #2')).toBe('100 Main St #2');
+  });
+
+  it('acceptance example: "100 North Main Street, Suite 2" -> "100 N Main St Ste 2"', () => {
+    expect(normalizeAddress('100 North Main Street, Suite 2')).toBe('100 N Main St Ste 2');
+  });
+
+  it('acceptance example: "221 Church Street" -> "221 Church St"', () => {
+    expect(normalizeAddress('221 Church Street')).toBe('221 Church St');
+  });
+
+  it('"1 Electric Road" and "1 Electric Rd" normalize to the same string', () => {
+    expect(normalizeAddress('1 Electric Road')).toBe(normalizeAddress('1 Electric Rd'));
+    expect(normalizeAddress('1 Electric Road')).toBe('1 Electric Rd');
+  });
+
+  it('already-normalized input is a no-op (idempotent)', () => {
+    const already = '100 N Main St Ste 2';
+    expect(normalizeAddress(already)).toBe(already);
+  });
+
+  it('an already-abbreviated compass compound stays correctly cased (idempotent, not "Ne")', () => {
+    expect(normalizeAddress('1 NE Main St')).toBe('1 NE Main St');
+    expect(normalizeAddress('1 Northeast Main St')).toBe('1 NE Main St');
+  });
+
+  it('numbers and non-alphabetic tokens pass through unchanged', () => {
+    expect(normalizeAddress('123 Main St')).toBe('123 Main St');
+  });
+});

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -114,7 +114,7 @@ describe('Venue Controller', () => {
       await c.createVenue({
         user: 'a',
         body: {
-          name: 'The Spot', originalsFit: 'loves', travelBand: 'local', priority: 4,
+          name: 'The Spot', address: '1 Main St', originalsFit: 'loves', travelBand: 'local', priority: 4,
         },
       }, resStub);
       expect(status).toBe(201);
@@ -144,7 +144,10 @@ describe('Venue Controller', () => {
       const create = vi.fn(() => Promise.resolve({ _id: 'n3' }));
       c.model.create = create;
       await c.createVenue({
-        user: 'a', body: { name: 'Slow Play Brewing', email: 'info@slowplaybrewing.com', secondaryEmail: 'chelsea@slowplaybrewing.com' },
+        user: 'a',
+        body: {
+          name: 'Slow Play Brewing', address: '1 Main St', email: 'info@slowplaybrewing.com', secondaryEmail: 'chelsea@slowplaybrewing.com',
+        },
       }, resStub);
       expect(status).toBe(201);
       const arg = (create.mock.calls[0] as unknown[])[0] as any;
@@ -156,7 +159,7 @@ describe('Venue Controller', () => {
       c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'n4' }));
       c.model.create = create;
-      await c.createVenue({ user: 'a', body: { name: 'X', secondaryEmail: '' } }, resStub);
+      await c.createVenue({ user: 'a', body: { name: 'X', address: '1 Main St', secondaryEmail: '' } }, resStub);
       expect(status).toBe(201);
     });
 
@@ -176,7 +179,7 @@ describe('Venue Controller', () => {
       const create = vi.fn(() => Promise.resolve({ _id: 'n2' }));
       c.model.create = create;
       await c.createVenue({
-        user: 'a', body: { name: 'The North Spot', country: 'ca', region: 'Ontario' },
+        user: 'a', body: { name: 'The North Spot', address: '1 Main St', country: 'ca', region: 'Ontario' },
       }, resStub);
       expect(status).toBe(201);
       const arg = (create.mock.calls[0] as unknown[])[0] as any;
@@ -188,7 +191,11 @@ describe('Venue Controller', () => {
       c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'new' }));
       c.model.create = create;
-      await c.createVenue({ user: 'agent', body: { name: 'The Spot', city: 'Salem', actor: 'sonnet' } }, resStub);
+      await c.createVenue({
+        user: 'agent', body: {
+          name: 'The Spot', city: 'Salem', address: '1 Main St', actor: 'sonnet',
+        },
+      }, resStub);
       expect(status).toBe(201);
       const arg = (create.mock.calls[0] as unknown[])[0] as any;
       expect(arg.status).toBe('active');
@@ -201,7 +208,7 @@ describe('Venue Controller', () => {
       c.model.findByIdAndUpdate = upd;
       const create = vi.fn();
       c.model.create = create;
-      await c.createVenue({ user: 'agent', body: { name: 'The Spot', email: 'b@k.com' } }, resStub);
+      await c.createVenue({ user: 'agent', body: { name: 'The Spot', address: '1 Main St', email: 'b@k.com' } }, resStub);
       expect(status).toBe(200);
       expect(create).not.toHaveBeenCalled();
       expect(upd).toHaveBeenCalledWith('dup1', expect.objectContaining({ status: 'active' }));
@@ -210,23 +217,30 @@ describe('Venue Controller', () => {
     // #983 — dedup logic. Email is entirely out of the match key now; only
     // name+city (refined by address when both sides have one) is used.
     describe('dedup (#983)', () => {
-      it('matches by name+city (case-insensitive), no address involved', async () => {
+      it('matches by name+city (case-insensitive); the one legacy address-less candidate is upserted onto (#987)', async () => {
         const find = vi.fn(() => Promise.resolve([{ _id: 'dup2', name: 'The Spot', city: 'Salem' }]));
         c.model.find = find;
         const upd = vi.fn(() => Promise.resolve({ _id: 'dup2' }));
         c.model.findByIdAndUpdate = upd;
-        await c.createVenue({ user: 'a', body: { name: 'the spot', city: 'SALEM' } }, resStub);
+        await c.createVenue({
+          user: 'a', body: { name: 'the spot', city: 'SALEM', address: '1 Main St' },
+        }, resStub);
         expect(status).toBe(200);
         expect(upd).toHaveBeenCalledWith('dup2', expect.objectContaining({ status: 'active' }));
       });
 
-      it('same name+city, no address on either side, dedupes as today', async () => {
+      // #987 — address is required on every POST now, so "no address on
+      // either side" is no longer a create scenario; the incoming address
+      // fills in on the one legacy address-less candidate instead.
+      it('same name+city, exactly one legacy address-less candidate ⇒ upserts onto it, filling the address in', async () => {
         c.model.find = vi.fn(() => Promise.resolve([{ _id: 'dup3', name: "Macado's", city: 'Roanoke' }]));
         const upd = vi.fn(() => Promise.resolve({ _id: 'dup3' }));
         c.model.findByIdAndUpdate = upd;
-        await c.createVenue({ user: 'a', body: { name: "Macado's", city: 'Roanoke' } }, resStub);
+        await c.createVenue({
+          user: 'a', body: { name: "Macado's", city: 'Roanoke', address: '1 Electric Road' },
+        }, resStub);
         expect(status).toBe(200);
-        expect(upd).toHaveBeenCalledWith('dup3', expect.objectContaining({ status: 'active' }));
+        expect(upd).toHaveBeenCalledWith('dup3', expect.objectContaining({ status: 'active', address: '1 Electric Rd' }));
       });
 
       it('same name+city, different (both non-empty) address ⇒ creates a new record, not an overwrite', async () => {
@@ -287,7 +301,7 @@ describe('Venue Controller', () => {
         const upd = vi.fn();
         c.model.findByIdAndUpdate = upd;
         await c.createVenue({
-          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', email: 'info@starrhill.com' },
+          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', address: '5 Points', email: 'info@starrhill.com' },
         }, resStub);
         expect(status).toBe(201);
         expect(upd).not.toHaveBeenCalled();
@@ -301,7 +315,7 @@ describe('Venue Controller', () => {
         c.model.create = create;
         const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
         await c.createVenue({
-          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', email: 'info@starrhill.com' },
+          user: 'a', body: { name: 'Starr Hill Pilot Brewery', city: 'Roanoke', address: '5 Points', email: 'info@starrhill.com' },
         }, resStub);
         expect(status).toBe(201);
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("also used by venue 'Starr Hill On Main'"));
@@ -314,7 +328,7 @@ describe('Venue Controller', () => {
         const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
         c.model.create = create;
         await c.createVenue({
-          user: 'a', body: { name: 'Some Venue', email: 'info@starrhill.com' },
+          user: 'a', body: { name: 'Some Venue', address: '1 Main St', email: 'info@starrhill.com' },
         }, resStub);
         expect(status).toBe(201);
       });
@@ -329,7 +343,7 @@ describe('Venue Controller', () => {
           const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
           c.model.create = create;
           await c.createVenue({
-            user: 'a', body: { name: 'Starr Hill On Main', city: 'Lynchburg', email: 'info@starrhill.com' },
+            user: 'a', body: { name: 'Starr Hill On Main', city: 'Lynchburg', address: '5 Points', email: 'info@starrhill.com' },
           }, resStub);
           expect(status).toBe(201);
           const arg = (create.mock.calls[0] as unknown[])[0] as any;
@@ -345,7 +359,7 @@ describe('Venue Controller', () => {
           await c.createVenue({
             user: 'a',
             body: {
-              name: 'Starr Hill On Main', city: 'Lynchburg', email: 'info@starrhill.com', notes: 'Great patio.',
+              name: 'Starr Hill On Main', city: 'Lynchburg', address: '5 Points', email: 'info@starrhill.com', notes: 'Great patio.',
             },
           }, resStub);
           expect(status).toBe(201);
@@ -359,7 +373,7 @@ describe('Venue Controller', () => {
           const create = vi.fn(() => Promise.resolve({ _id: 'new-venue' }));
           c.model.create = create;
           await c.createVenue({
-            user: 'a', body: { name: 'Unique Venue', email: 'nobody-else@x.com' },
+            user: 'a', body: { name: 'Unique Venue', address: '1 Main St', email: 'nobody-else@x.com' },
           }, resStub);
           expect(status).toBe(201);
           const arg = (create.mock.calls[0] as unknown[])[0] as any;
@@ -374,7 +388,7 @@ describe('Venue Controller', () => {
           const create = vi.fn();
           c.model.create = create;
           await c.createVenue({
-            user: 'a', body: { name: 'The Spot', city: 'Salem', email: 'shared@x.com' },
+            user: 'a', body: { name: 'The Spot', city: 'Salem', address: '1 Main St', email: 'shared@x.com' },
           }, resStub);
           expect(status).toBe(200);
           expect(create).not.toHaveBeenCalled();
@@ -383,13 +397,13 @@ describe('Venue Controller', () => {
         });
       });
 
-      it('findDuplicate: no candidates at all resolves null', async () => {
+      it('findDuplicate: no candidates at all resolves { kind: "none" }', async () => {
         c.model.find = vi.fn(() => Promise.resolve([]));
         const result = await c.findDuplicate({ name: 'Nobody Here' });
-        expect(result).toBeNull();
+        expect(result).toEqual({ kind: 'none' });
       });
 
-      it('findDuplicate: an address supplied with no matching candidate and no unambiguous address-less fallback resolves null', async () => {
+      it('findDuplicate: an address supplied with no matching candidate and no unambiguous address-less fallback resolves { kind: "none" }', async () => {
         c.model.find = vi.fn(() => Promise.resolve([
           {
             _id: 'a1', name: "Macado's", city: 'Roanoke', address: '1 Electric Rd',
@@ -399,7 +413,105 @@ describe('Venue Controller', () => {
           },
         ]));
         const result = await c.findDuplicate({ name: "Macado's", city: 'Roanoke', address: '3 Brand New Rd' });
-        expect(result).toBeNull();
+        expect(result).toEqual({ kind: 'none' });
+      });
+
+      // #987 Part B — two or more legacy (address-less) candidates for the
+      // same name+city: do not guess, do not silently duplicate.
+      it('findDuplicate: two+ legacy address-less candidates resolves { kind: "ambiguous" } naming their ids', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: 'legacy-1', name: 'Old Venue', city: 'Salem' },
+          { _id: 'legacy-2', name: 'Old Venue', city: 'Salem' },
+        ]));
+        const result = await c.findDuplicate({ name: 'Old Venue', city: 'Salem', address: '1 Main St' });
+        expect(result).toEqual({ kind: 'ambiguous', ids: ['legacy-1', 'legacy-2'] });
+      });
+
+      it('POST /venue 400s naming the ids when two+ legacy address-less candidates match name+city', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: 'legacy-1', name: 'Old Venue', city: 'Salem' },
+          { _id: 'legacy-2', name: 'Old Venue', city: 'Salem' },
+        ]));
+        const create = vi.fn();
+        c.model.create = create;
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.createVenue({
+          user: 'a', body: { name: 'Old Venue', city: 'Salem', address: '1 Main St' },
+        }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('legacy-1');
+        expect(payload.message).toContain('legacy-2');
+        expect(create).not.toHaveBeenCalled();
+        expect(upd).not.toHaveBeenCalled();
+      });
+    });
+
+    // #987 Part A — normalization on write (POST).
+    describe('address normalization on create (#987)', () => {
+      it('normalizes the stored address per the USPS Pub 28 table', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        const create = vi.fn(() => Promise.resolve({ _id: 'norm-1' }));
+        c.model.create = create;
+        await c.createVenue({
+          user: 'a', body: { name: 'Norm Venue', address: '100 North Main Street, Suite 2' },
+        }, resStub);
+        expect(status).toBe(201);
+        const arg = (create.mock.calls[0] as unknown[])[0] as any;
+        expect(arg.address).toBe('100 N Main St Ste 2');
+      });
+
+      it('"1 Electric Road" and "1 Electric Rd" resolve to the same venue (one record, normalized form stored)', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        const create = vi.fn(() => Promise.resolve({ _id: 'macados-1', address: '1 Electric Rd' }));
+        c.model.create = create;
+        await c.createVenue({
+          user: 'a', body: { name: 'Macados', city: 'Roanoke', address: '1 Electric Road' },
+        }, resStub);
+        expect(status).toBe(201);
+        const created = (create.mock.calls[0] as unknown[])[0] as any;
+        expect(created.address).toBe('1 Electric Rd');
+
+        // Re-post with the already-abbreviated form: matches the same venue
+        // by normalized address, upserts rather than creating a second record.
+        c.model.find = vi.fn(() => Promise.resolve([{ _id: 'macados-1', name: 'Macados', city: 'Roanoke', address: '1 Electric Rd' }]));
+        const upd = vi.fn(() => Promise.resolve({ _id: 'macados-1' }));
+        c.model.findByIdAndUpdate = upd;
+        const create2 = vi.fn();
+        c.model.create = create2;
+        await c.createVenue({
+          user: 'a', body: { name: 'Macados', city: 'Roanoke', address: '1 Electric Rd' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(create2).not.toHaveBeenCalled();
+        expect(upd).toHaveBeenCalledWith('macados-1', expect.objectContaining({ address: '1 Electric Rd' }));
+      });
+    });
+
+    // #987 Part B — address required on every POST /venue.
+    describe('address required on create (#987)', () => {
+      it('rejects a missing address, before any DB write', async () => {
+        const find = vi.fn();
+        c.model.find = find;
+        const create = vi.fn();
+        c.model.create = create;
+        await c.createVenue({ user: 'a', body: { name: 'X' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('address is required');
+        expect(find).not.toHaveBeenCalled();
+        expect(create).not.toHaveBeenCalled();
+      });
+
+      it('rejects an empty-string address', async () => {
+        await c.createVenue({ user: 'a', body: { name: 'X', address: '' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('address is required');
+      });
+
+      it('rejects a whitespace-only address', async () => {
+        await c.createVenue({ user: 'a', body: { name: 'X', address: '   ' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('address is required');
       });
     });
   });
@@ -488,6 +600,97 @@ describe('Venue Controller', () => {
       const written = (upd.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
       expect(written).not.toHaveProperty('bookingStatus');
       expect(written).toMatchObject({ notes: 'x' });
+    });
+
+    // #987 — address normalization on PUT (Part A) + the once-set-cannot-be-
+    // removed rule (Part B).
+    describe('address handling on update (#987)', () => {
+      it('omitting address entirely leaves it unchanged (no lookup, no address in the write)', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        const findById = vi.fn();
+        c.model.findById = findById;
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { notes: 'x' } }, resStub);
+        expect(status).toBe(200);
+        expect(findById).not.toHaveBeenCalled();
+        const written = (upd.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+        expect(written).not.toHaveProperty('address');
+      });
+
+      it('a non-empty address is normalized identically to POST (Part A)', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({
+          user: 'agent', params: { id }, body: { address: '221 Church Street' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ address: '221 Church St' }));
+      });
+
+      it('explicit "" on a venue that HAS an address ⇒ 400, nothing written', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.resolve({ _id: id, address: '1 Electric Rd' }));
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { address: '' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('cannot be removed');
+        expect(upd).not.toHaveBeenCalled();
+      });
+
+      it('explicit null on a venue that HAS an address ⇒ 400, nothing written', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.resolve({ _id: id, address: '1 Electric Rd' }));
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({
+          user: 'agent', params: { id }, body: { address: null as unknown as string },
+        }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('cannot be removed');
+        expect(upd).not.toHaveBeenCalled();
+      });
+
+      it('whitespace-only address on a venue that HAS an address ⇒ 400, nothing written', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.resolve({ _id: id, address: '1 Electric Rd' }));
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { address: '   ' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('cannot be removed');
+        expect(upd).not.toHaveBeenCalled();
+      });
+
+      it('the same "" call on an address-less venue ⇒ allowed no-op', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.resolve({ _id: id }));
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { address: '' } }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ address: '' }));
+      });
+
+      it('400s "Id Not Found" when clearing address on a venue that does not exist', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.resolve(null));
+        const upd = vi.fn();
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({ user: 'agent', params: { id }, body: { address: '' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('Id Not Found');
+        expect(upd).not.toHaveBeenCalled();
+      });
+
+      it('500s when the pre-check lookup throws', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        c.model.findById = vi.fn(() => Promise.reject(new Error('db down')));
+        await c.updateVenue({ user: 'agent', params: { id }, body: { address: '' } }, resStub);
+        expect(status).toBe(500);
+      });
     });
 
     // #980 — gigInterval (spacing, months) + resumeBooking (cooldown date).
@@ -862,7 +1065,7 @@ describe('Venue Controller', () => {
       c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'v11' }));
       c.model.create = create;
-      await c.createVenue({ user: 'a', body: { name: 'X', bookingStatus: 'bogus' } }, resStub);
+      await c.createVenue({ user: 'a', body: { name: 'X', address: '1 Main St', bookingStatus: 'bogus' } }, resStub);
       expect(status).toBe(201);
       expect((create.mock.calls[0] as unknown[])[0]).not.toHaveProperty('bookingStatus');
     });
@@ -874,7 +1077,7 @@ describe('Venue Controller', () => {
       await c.createVenue({
         user: 'a',
         body: {
-          name: 'Olde Salem', interested: false, payTier: 'low',
+          name: 'Olde Salem', address: '1 Main St', interested: false, payTier: 'low',
         },
       }, resStub);
       expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({
@@ -1027,7 +1230,11 @@ describe('Venue Controller', () => {
       c.model.find = vi.fn(() => Promise.resolve([]));
       const create = vi.fn(() => Promise.resolve({ _id: 'v9' }));
       c.model.create = create;
-      await c.createVenue({ user: 'a', body: { name: 'The Spot', venueType: 'Originals', outreachEligible: true } }, resStub);
+      await c.createVenue({
+        user: 'a', body: {
+          name: 'The Spot', address: '1 Main St', venueType: 'Originals', outreachEligible: true,
+        },
+      }, resStub);
       expect((create.mock.calls[0] as unknown[])[0]).toMatchObject({ outreachEligible: true, venueType: 'Originals' });
     });
 


### PR DESCRIPTION
## Summary
- Add a table-driven `normalizeAddress` helper (`src/model/venue/normalize-address.ts`) implementing USPS Pub 28 abbreviations for street suffixes, directionals, and unit designators, plus punctuation/whitespace cleanup and Title Case — pure, no external API.
- Apply normalization identically on both `POST /venue` and `PUT /venue/:id` so the stored `address` is always the same compact form regardless of how it was typed (e.g. "1 Electric Road" and "1 Electric Rd" both normalize to "1 Electric Rd").
- `findDuplicate` now compares normalized-to-normalized addresses; a legacy address-less candidate is upserted onto when there is exactly one, and returns an `ambiguous` result (400 naming the ids) when there are two or more.
- `address` is now REQUIRED on every `POST /venue`, validated in `validateBody` before any DB write. `PUT /venue/:id` keeps address optional (schema stays `required: false`, unchanged), but an address once set cannot be cleared — omitted is unchanged, non-empty corrects it, explicit `""`/`null` on a venue that already has one is a 400.
- No back-migration of existing venues (explicit non-goal).

Closes #987

## How to test locally
Run the full suite:
```sh
npm test
```
Expect: lint clean, jscpd clean, typecheck clean, all unit tests green, coverage gate (90/90/80/80) holds.

Exercise the change itself against a running server (`npm run dev`, then a valid
JaM-admin/agent bearer token):

Create a venue without an address (should 400, nothing written):
```sh
curl -s -X POST http://localhost:PORT/venue \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"name":"No Address Venue"}'
```
Expect: `400 {"message":"address is required to create a venue"}`.

Create a venue with an unabbreviated address (normalizes on write):
```sh
curl -s -X POST http://localhost:PORT/venue \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"name":"Macados","city":"Roanoke","address":"100 North Main Street, Suite 2"}'
```
Expect: `201`, response `address` is `"100 N Main St Ste 2"`.

Re-POST the same name/city with the already-abbreviated address (dedupes onto the
same record instead of creating a second one):
```sh
curl -s -X POST http://localhost:PORT/venue \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"name":"Macados","city":"Roanoke","address":"100 N Main St Ste 2"}'
```
Expect: `200` (upsert onto the existing `_id`, not a new one).

Try to clear the address on that same venue via PUT (should 400):
```sh
curl -s -X PUT "http://localhost:PORT/venue/$VENUE_ID" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"address":""}'
```
Expect: `400 {"message":"address cannot be removed; supply a corrected address instead"}`.

## Test evidence
```
$ npm test

> web-jam-back@2.8.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

(eslint: clean, 0 problems)

> web-jam-back@2.8.0 jscpd
> jscpd src

Found 35 clones. (pre-existing, unrelated to this change; jscpd is informational, not a gate)

> web-jam-back@2.8.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit

(typecheck: clean, no errors)

> web-jam-back@2.8.0 test:unit
> vitest run --coverage

 Test Files  53 passed (53)
      Tests  900 passed (900)
   Start at  13:25:01
   Duration  49.22s

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
All files          |   93.35 |     87.5 |   88.96 |   94.01 |
 src/model/venue   |   91.57 |    91.89 |   87.93 |   92.17 |
  ...controller.ts |   94.73 |     91.6 |     100 |   96.44 |
-------------------|---------|----------|---------|---------|

=============================== Coverage summary ===============================
Statements   : 93.35% ( 2444/2618 )
Branches     : 87.5% ( 1554/1776 )
Functions    : 88.96% ( 387/435 )
Lines        : 94.01% ( 2027/2156 )
================================================================================
```

Venue suite alone, 155 tests (existing #983/#980 tests updated for the new
address-required-on-create behavior + new #987 tests: normalization table,
required-on-create, ambiguous-legacy-candidates 400, and address-immutability
on PUT):

```
$ npx vitest run test/unit/venue/

 Test Files  2 passed (2)
      Tests  155 passed (155)
   Start at  13:28:40
   Duration  661ms
```

🤖 Work by Claude Code — Claude Sonnet 5