### PR TITLE
Venue bookedThrough date: 'calendar full through' vs 'don't contact until' are two different facts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -969,16 +969,18 @@ class OutreachController extends Controller {
     });
   }
 
-  // GET /outreach/candidates — propose the target list (#844/#980): a venue
-  // is a candidate for target window W iff `outreachEligible = GO` AND a
-  // valid primary email AND not archived AND no active `resumeBooking`
-  // cooldown (unset, or a date already in the past) AND — the
-  // excludeUpcomingGigVenues spacing check below — (`gigInterval = 0` OR
-  // every linked gig at that venue is ≥ `gigInterval` months from W), minus
-  // any venue that already has an active outreach with an OVERLAPPING
-  // targetWeekend. #898: the targetWeekend filter is date-range aware
-  // (matching the dedup guard's overlap semantics) rather than the old
-  // targetDates string filter. Read-only.
+  // GET /outreach/candidates — propose the target list (#844/#980/#995): a
+  // venue is a candidate for target window W iff `outreachEligible = GO` AND
+  // a valid primary email AND not archived AND no active `resumeBooking`
+  // cooldown (unset, or a date already in the past, relative to NOW) AND no
+  // active `bookedThrough` (unset, or already before W's START — #995: a
+  // "calendar full through" date is compared against the window being
+  // pitched, not today) AND — the excludeUpcomingGigVenues spacing check
+  // below — (`gigInterval = 0` OR every linked gig at that venue is ≥
+  // `gigInterval` months from W), minus any venue that already has an active
+  // outreach with an OVERLAPPING targetWeekend. #898: the targetWeekend
+  // filter is date-range aware (matching the dedup guard's overlap
+  // semantics) rather than the old targetDates string filter. Read-only.
   // Optional query:
   //   • targetWeekend {start, end} (bracket-notation query params, e.g.
   //     ?targetWeekend[start]=...&targetWeekend[end]=...) — W for both the
@@ -1017,7 +1019,8 @@ class OutreachController extends Controller {
       // ($regex EMAIL_RE), not just non-empty ($nin): a venue with no VALID
       // primary email is not sendable, so it must never be offered as a
       // candidate. #980 — resumeBooking is an active cooldown only when set
-      // to a date strictly in the future; unset or in the past never blocks.
+      // to a date strictly in the future; unset or in the past never blocks
+      // (compared against `now` — "don't contact until" is a today check).
       const filter: Record<string, unknown> = {
         outreachEligible: true,
         status: { $ne: 'archived' },
@@ -1026,6 +1029,27 @@ class OutreachController extends Controller {
           { resumeBooking: { $exists: false } },
           { resumeBooking: null },
           { resumeBooking: { $lte: now } },
+        ],
+        // #995 — bookedThrough is a SEPARATE fact from resumeBooking ("their
+        // calendar is full through this date", not "don't contact them"), so
+        // it blocks on its OWN condition rather than folding into the $or
+        // above, compared against `w` (the target window's START, not
+        // `now`) — a venue booked solid through 2026 is still a valid
+        // candidate for a Jan 2027 window pitched today. Kept as a separate
+        // top-level $and (rather than merging into the resumeBooking $or
+        // above) so this clause is independently testable/readable and
+        // resumeBooking's own query shape stays untouched (#980, non-goal:
+        // no change to resumeBooking semantics or comparisons). Unset or
+        // null never blocks; both fields unset/null reproduces today's
+        // exact behavior.
+        $and: [
+          {
+            $or: [
+              { bookedThrough: { $exists: false } },
+              { bookedThrough: null },
+              { bookedThrough: { $lt: w } },
+            ],
+          },
         ],
       };
       // #980 — optional city filter, AND'd with everything above.

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -89,6 +89,11 @@ interface VenueBody {
   // written (see createVenue/updateVenue).
   gigInterval?: number;
   resumeBooking?: string;
+  // #995 — "calendar full through" (compared against a target window's
+  // start, not today — see venue-schema.ts); a distinct fact from
+  // resumeBooking's "don't contact until" (compared against today).
+  // Same validation pattern as resumeBooking (validateBody below).
+  bookedThrough?: string;
   bookedDate?: string;
   actor?: string;
 }
@@ -233,15 +238,24 @@ function invalidGigInterval(gigInterval: number | undefined): boolean {
     && (typeof gigInterval !== 'number' || !Number.isInteger(gigInterval) || gigInterval < 0);
 }
 
+// Shared "optional, but if present must parse as a date" rule — used by both
+// resumeBooking and bookedThrough (#995: same validation pattern, deliberately
+// kept as one helper since the rule itself is identical, even though the two
+// fields mean different things and are compared against different anchors
+// elsewhere — see venue-schema.ts).
+function invalidOptionalDate(value: string | undefined): boolean {
+  return value !== undefined && value !== '' && Number.isNaN(new Date(value).getTime());
+}
+
 function validateBody(body: VenueBody, partial: boolean): string {
   if ((!partial || body.name !== undefined) && (!body.name || !body.name.trim())) return 'Name is required';
   const enumErr = invalidEnum(body);
   if (enumErr) return enumErr;
   if (invalidPriority(body.priority)) return 'priority must be a number 0-5';
   if (invalidGigInterval(body.gigInterval)) return 'gigInterval must be a non-negative whole number of months';
-  if (body.resumeBooking !== undefined && body.resumeBooking !== '' && Number.isNaN(new Date(body.resumeBooking).getTime())) {
-    return 'resumeBooking must be a valid date';
-  }
+  if (invalidOptionalDate(body.resumeBooking)) return 'resumeBooking must be a valid date';
+  // #995 — bookedThrough validated identically to resumeBooking above.
+  if (invalidOptionalDate(body.bookedThrough)) return 'bookedThrough must be a valid date';
   if (body.email !== undefined && body.email !== '' && !isValidEmail(body.email)) {
     return 'A valid email is required';
   }
@@ -363,10 +377,21 @@ class VenueController extends Controller {
   // "active" when set to a date strictly in the future, relative to `now` —
   // the same instant the caller resolves everything else against (mirrors
   // the exact wording of #980: "unset or in the past" = no active cooldown).
+  //
+  // #995 — `bookedThrough` (their calendar is full through this date, but
+  // contacting them is fine) ALSO drives `not-booking`, alongside the
+  // resumeBooking cooldown above: "active" here means bookedThrough is set to
+  // a date at-or-after `now` (this readout has no target-window context to
+  // compare against — see the getCandidates exclusion in
+  // outreach-controller.ts for the window-aware comparison), so the badge
+  // just tells Josh "still booked up as of right now." Precedence is
+  // otherwise unchanged: booked still beats not-booking either way.
   static computeBookingStatus(venue: Record<string, unknown>, hasUpcomingGig: boolean, now: number): DerivedBookingStatus {
     if (hasUpcomingGig) return 'booked';
     const resumeBooking = venue.resumeBooking ? new Date(venue.resumeBooking as string) : null;
     if (resumeBooking && !Number.isNaN(resumeBooking.getTime()) && resumeBooking.getTime() > now) return 'not-booking';
+    const bookedThrough = venue.bookedThrough ? new Date(venue.bookedThrough as string) : null;
+    if (bookedThrough && !Number.isNaN(bookedThrough.getTime()) && bookedThrough.getTime() >= now) return 'not-booking';
     return 'booking';
   }
 

--- a/src/model/venue/venue-schema.ts
+++ b/src/model/venue/venue-schema.ts
@@ -177,6 +177,18 @@ const venueSchema = new Schema({
   // cooldown. Drives both the getCandidates exclusion (outreach-
   // controller.ts) and the derived bookingStatus:'not-booking' readout above.
   resumeBooking: { type: Date, required: false },
+  // #995 — a SEPARATE "calendar full through" fact, split out from
+  // resumeBooking: `resumeBooking` means "don't contact until" (the venue
+  // asked for space, compared against TODAY — e.g. Mama Jean's "try again in
+  // 4 months"); `bookedThrough` means "their dates are gone, but contacting
+  // them now is fine" (compared against the TARGET WINDOW being pitched, not
+  // today — e.g. Olde Salem Brewing is booked solid through 2026 but still
+  // pitchable NOW for a January 2027 weekend). Conflating the two into one
+  // date lost information Josh can't reconstruct from memory later, hence the
+  // split. Optional; unset behaves identically to today on both the
+  // getCandidates exclusion (outreach-controller.ts) and the derived
+  // bookingStatus readout above.
+  bookedThrough: { type: Date, required: false },
   notes: { type: String, required: false },
   // Template-selection inputs (#848). `relationshipStage` overrides the
   // auto-derived cold/returning stage when set; left unset = auto-derive

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -611,6 +611,42 @@ describe('Outreach Controller (#844 batch model)', () => {
       ]));
     });
 
+    // #995 — bookedThrough is a SEPARATE fact from resumeBooking: "calendar
+    // full through" a date, compared against the target window's START (W),
+    // not `now`, and blocking is `bookedThrough >= W` (so the query only
+    // includes venues with `bookedThrough < W`, unset, or null). Enforced as
+    // its own $and clause so resumeBooking's own $or (asserted above) is
+    // never touched — mirrors the #980 non-goal that resumeBooking's
+    // semantics/comparisons must not change.
+    describe('bookedThrough (#995)', () => {
+      it('excludes an active bookedThrough via the query, compared against now when no targetWeekend is given', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: {} }, resStub);
+        expect(status).toBe(200);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg.$and).toEqual(expect.arrayContaining([
+          {
+            $or: [
+              { bookedThrough: { $exists: false } },
+              { bookedThrough: null },
+              { bookedThrough: { $lt: expect.any(Date) } },
+            ],
+          },
+        ]));
+        // resumeBooking's own $or is untouched by the addition — still
+        // exactly the three original clauses, never merged with bookedThrough.
+        expect(callArg.$or).toHaveLength(3);
+      });
+
+      it('compares bookedThrough against the targetWeekend START, not now, when a targetWeekend is given', async () => {
+        (venueModel as any).find = vi.fn(() => Promise.resolve([{ _id: 'a' }]));
+        await c.getCandidates({ user: 'a', query: { targetWeekend: VALID_WEEKEND } }, resStub);
+        expect(status).toBe(200);
+        const callArg = (venueModel as any).find.mock.calls[0][0];
+        expect(callArg.$and[0].$or).toContainEqual({ bookedThrough: { $lt: new Date(VALID_WEEKEND.start) } });
+      });
+    });
+
     // #980 — optional cities filter, AND'd with every other criterion;
     // omitted/empty = all cities (back-compat).
     describe('cities filter (#980)', () => {

--- a/test/unit/venue/venue-controller.spec.ts
+++ b/test/unit/venue/venue-controller.spec.ts
@@ -735,6 +735,39 @@ describe('Venue Controller', () => {
         expect(payload.message).toContain('resumeBooking');
       });
     });
+
+    // #995 — bookedThrough: a separate optional Date, validated identically
+    // to resumeBooking above.
+    describe('bookedThrough (#995)', () => {
+      it('accepts bookedThrough on update', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        const upd = vi.fn(() => Promise.resolve({ _id: id }));
+        c.model.findByIdAndUpdate = upd;
+        await c.updateVenue({
+          user: 'agent', params: { id }, body: { bookedThrough: '2026-12-31' },
+        }, resStub);
+        expect(status).toBe(200);
+        expect(upd).toHaveBeenCalledWith(id, expect.objectContaining({ bookedThrough: '2026-12-31' }));
+      });
+
+      it('rejects an invalid bookedThrough date', async () => {
+        const id = new mongoose.Types.ObjectId().toString();
+        await c.updateVenue({ user: 'agent', params: { id }, body: { bookedThrough: 'not-a-date' } }, resStub);
+        expect(status).toBe(400);
+        expect(payload.message).toContain('bookedThrough');
+      });
+
+      it('accepts bookedThrough on create alongside the required address', async () => {
+        c.model.find = vi.fn(() => Promise.resolve([]));
+        const created = vi.fn(() => Promise.resolve({ _id: 'x' }));
+        c.model.create = created;
+        await c.createVenue({
+          user: 'agent', body: { name: 'Olde Salem Brewing', address: '1 Main St', bookedThrough: '2026-12-31' },
+        }, resStub);
+        expect(status).toBe(201);
+        expect(created).toHaveBeenCalledWith(expect.objectContaining({ bookedThrough: '2026-12-31' }));
+      });
+    });
   });
 
   describe('deleteVenue (soft-delete)', () => {
@@ -949,6 +982,63 @@ describe('Venue Controller', () => {
       it('precedence: booked wins over an active resumeBooking cooldown', () => {
         const now = Date.now();
         expect(compute({ resumeBooking: new Date(now + 1e9) }, true, now)).toBe('booked');
+      });
+
+      // #995 — bookedThrough >= now ALSO drives not-booking, independent of
+      // resumeBooking. Tested both sides of the >= now boundary.
+      it('not-booking — bookedThrough exactly at now (boundary, inclusive)', () => {
+        const now = Date.now();
+        expect(compute({ bookedThrough: new Date(now) }, false, now)).toBe('not-booking');
+      });
+
+      it('not-booking — bookedThrough in the future, no upcoming gig', () => {
+        const now = Date.now();
+        expect(compute({ bookedThrough: new Date(now + 1e9).toISOString() }, false, now)).toBe('not-booking');
+      });
+
+      it('booking — bookedThrough just in the past (one ms before now) does not count as active', () => {
+        const now = Date.now();
+        expect(compute({ bookedThrough: new Date(now - 1).toISOString() }, false, now)).toBe('booking');
+      });
+
+      it('booking — an invalid bookedThrough value is ignored, not treated as active', () => {
+        const now = Date.now();
+        expect(compute({ bookedThrough: 'not-a-date' }, false, now)).toBe('booking');
+      });
+
+      it('precedence: booked wins over an active bookedThrough', () => {
+        const now = Date.now();
+        expect(compute({ bookedThrough: new Date(now + 1e9) }, true, now)).toBe('booked');
+      });
+
+      it('not-booking — both resumeBooking (future) and bookedThrough (future) set', () => {
+        const now = Date.now();
+        expect(compute({
+          resumeBooking: new Date(now + 1e9), bookedThrough: new Date(now + 2e9),
+        }, false, now)).toBe('not-booking');
+      });
+
+      it('booking — both resumeBooking and bookedThrough unset', () => {
+        const now = Date.now();
+        expect(compute({}, false, now)).toBe('booking');
+      });
+
+      it('is wired into listVenues: not-booking with an active bookedThrough, no upcoming gig, no resumeBooking', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: idA, name: 'Booked-Up Venue', bookedThrough: new Date(Date.now() + 1e10).toISOString() },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('not-booking');
+      });
+
+      it('is wired into listVenues: booking with a bookedThrough already in the past', async () => {
+        const idA = new mongoose.Types.ObjectId().toString();
+        c.model.find = vi.fn(() => Promise.resolve([
+          { _id: idA, name: 'Reopened Venue', bookedThrough: new Date(Date.now() - 1e10).toISOString() },
+        ]));
+        await c.listVenues({ user: 'a', query: {} }, resStub);
+        expect(payload[0].bookingStatus).toBe('booking');
       });
 
       it('is wired into listVenues: booked when there is an upcoming linked gig', async () => {


### PR DESCRIPTION
## Summary
- Add `bookedThrough: Date` (optional) to the venue schema — a fact separate from `resumeBooking`: "their calendar is full through this date" (compared against the **target window start**) vs. `resumeBooking`'s "don't contact until this date" (compared against **today**).
- Accept `bookedThrough` on `POST /venue` and `PUT /venue/:id` with the same "optional, but must parse as a date" validation `resumeBooking` already has (extracted the shared check into `invalidOptionalDate` to keep `validateBody`'s cognitive complexity under the lint threshold).
- `GET /outreach/candidates` now also excludes a venue when `bookedThrough >= targetWindowStart` — added as an independent `$and` clause so `resumeBooking`'s existing `$or` query shape is untouched (non-goal: no change to `resumeBooking` semantics/comparisons).
- Derived `bookingStatus` is now `not-booking` when either an active `resumeBooking` cooldown OR `bookedThrough >= now` applies; existing precedence (`booked` > `not-booking` > `booking`) is unchanged.
- Both fields unset reproduces today's exact behavior (no migration/backfill, per the issue's non-goals).
- Bumped `package.json` 2.8.0 → 2.9.0 (minor: new optional field/feature).

Closes #995

## How to test locally
Run the full gated suite:
```sh
npm test
```
Expect: eslint clean, jscpd clean, typecheck clean, 914/914 tests green, coverage ≥ 90/80/80/90 gate.

Then exercise the new rule directly against a running server (`npm run dev`, or against staging) with a real venue and admin Bearer token (replace `HOST`, `TOKEN`, `VENUE_ID` below):

1. Create/tag a venue as booked through end of 2026 but not resumeBooking-paused:
```sh
curl -X PUT https://HOST/venue/VENUE_ID \
  -H "Authorization: Bearer TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"outreachEligible": true, "bookedThrough": "2026-12-31", "actor": "test"}'
```
Expect: `200`, response body has `bookedThrough: "2026-12-31T00:00:00.000Z"`, `resumeBooking` absent/unchanged.

2. Query candidates for a window INSIDE the booked-through period (Oct 16-18, 2026) — the venue must be EXCLUDED:
```sh
curl "https://HOST/outreach/candidates?targetWeekend[start]=2026-10-16&targetWeekend[end]=2026-10-18" \
  -H "Authorization: Bearer TOKEN"
```
Expect: `200`; `VENUE_ID` is NOT present in `candidates` (or the plain array, if no other params).

3. Query candidates for a window AFTER the booked-through date (Jan 16-18, 2027), run today — the venue must be PRESENT:
```sh
curl "https://HOST/outreach/candidates?targetWeekend[start]=2027-01-16&targetWeekend[end]=2027-01-18" \
  -H "Authorization: Bearer TOKEN"
```
Expect: `200`; `VENUE_ID` IS present in `candidates` (assuming it also passes the other criteria — outreachEligible, valid email, not archived, gigInterval spacing).

4. Boundary check — a `resumeBooking` set in the future excludes the venue from EVERY window regardless of `bookedThrough`:
```sh
curl -X PUT https://HOST/venue/VENUE_ID \
  -H "Authorization: Bearer TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"resumeBooking": "2099-01-01", "actor": "test"}'
curl "https://HOST/outreach/candidates?targetWeekend[start]=2027-01-16&targetWeekend[end]=2027-01-18" \
  -H "Authorization: Bearer TOKEN"
```
Expect: `VENUE_ID` is NOT present, even for the Jan 2027 window that clears `bookedThrough`.

5. Invalid `bookedThrough` is rejected the same way `resumeBooking` is:
```sh
curl -X PUT https://HOST/venue/VENUE_ID \
  -H "Authorization: Bearer TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"bookedThrough": "not-a-date"}'
```
Expect: `400` with `{"message": "bookedThrough must be a valid date"}`.

## Test evidence
```
> web-jam-back@2.9.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

...
> web-jam-back@2.9.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit

> web-jam-back@2.9.0 test:unit
> vitest run --coverage

 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back
      Coverage enabled with v8

 Test Files  53 passed (53)
      Tests  914 passed (914)
   Start at  15:04:42
   Duration  49.50s (transform 770ms, setup 0ms, import 8.35s, tests 33.60s, environment 5ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |   93.36 |    87.56 |   88.99 |   94.02 |
 src/model/venue   |   91.71 |    92.13 |   88.13 |   92.25 |
  ...controller.ts |   94.83 |    91.86 |     100 |   96.48 | ...38,646,696,736
  venue-router.ts  |   26.31 |      100 |       0 |   26.31 | ...27,32-41,48-49
 ...model/outreach |   94.11 |    87.28 |   84.21 |   94.09 |
  ...controller.ts |   98.37 |    86.95 |     100 |   99.58 | 187,1484
  ...ach-router.ts |   30.23 |      100 |       0 |   30.23 | ...06-107,112-121
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 93.36% ( 2450/2624 )
Branches     : 87.56% ( 1563/1785 )
Functions    : 88.99% ( 388/436 )
Lines        : 94.02% ( 2030/2159 )
================================================================================
```

`eslint`, `jscpd` (duplication scan), and `tsc` typecheck all ran clean before the test run (no errors reported by any of them — the chain would have stopped short of `vitest` otherwise). Gate is 90/80/80/90; actuals 93.36/87.56/88.99/94.02 all clear it.

🤖 Work by Claude Code — Sonnet 5