### PR TITLE
Merge-gate GitHub Action — enforce FE/BE coupling (enforcement half of wjt#240)

### DIFF
--- a/.github/scripts/coupling-gate.sh
+++ b/.github/scripts/coupling-gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# FE/BE coupling gate — see .github/workflows/fe-be-coupling-gate.yml and
+# web-jam-back#1002. Conventions (`FE-couples:` / `Coupling-override:`) are
+# canonical in web-jam-tools/docs/cross-ai-rules.md — don't redefine here.
+set -euo pipefail
+
+DEFAULT_OWNER="WebJamApps"
+
+# PR_BODY is passed via env (not interpolated into the script) to avoid
+# shell injection from PR body content.
+body="${PR_BODY:-}"
+
+fe_line="$(printf '%s\n' "$body" | grep -m1 -E '^FE-couples:[[:space:]]*\S+' || true)"
+
+if [ -z "$fe_line" ]; then
+  echo "no coupling declared — pass"
+  exit 0
+fi
+
+override_line="$(printf '%s\n' "$body" | grep -m1 -E '^Coupling-override:[[:space:]]*\S' || true)"
+
+if [ -n "$override_line" ]; then
+  reason="$(printf '%s\n' "$override_line" | sed -E 's/^Coupling-override:[[:space:]]*//')"
+  echo "Coupling-override given: ${reason}"
+  echo "override accepted — pass"
+  exit 0
+fi
+
+fe_ref="$(printf '%s\n' "$fe_line" | sed -E 's/^FE-couples:[[:space:]]*//' | awk '{print $1}')"
+
+# fe_ref is one of: Repo#NNN | owner/repo#NNN
+if [[ "$fe_ref" =~ ^([^/#[:space:]]+)/([^/#[:space:]]+)#([0-9]+)$ ]]; then
+  owner="${BASH_REMATCH[1]}"
+  repo="${BASH_REMATCH[2]}"
+  number="${BASH_REMATCH[3]}"
+elif [[ "$fe_ref" =~ ^([^/#[:space:]]+)#([0-9]+)$ ]]; then
+  owner="$DEFAULT_OWNER"
+  repo="${BASH_REMATCH[1]}"
+  number="${BASH_REMATCH[2]}"
+else
+  echo "FE-couples line found but could not parse a <repo>#NNN reference: ${fe_line}" >&2
+  echo "add a valid FE-couples: <repo>#NNN line, or a Coupling-override: <reason> line" >&2
+  exit 1
+fi
+
+echo "coupled FE reference: ${owner}/${repo}#${number}"
+
+pr_url="$(gh api "repos/${owner}/${repo}/issues/${number}" --jq '.pull_request.url // empty' 2>/dev/null || true)"
+
+pass=0
+
+if [ -n "$pr_url" ]; then
+  # It's a PR — pass iff merged to that repo's main.
+  pr_info="$(gh api "repos/${owner}/${repo}/pulls/${number}" --jq '[.merged, .base.ref] | @tsv' 2>/dev/null || true)"
+  merged="$(printf '%s' "$pr_info" | cut -f1)"
+  base_ref="$(printf '%s' "$pr_info" | cut -f2)"
+  if [ "$merged" = "true" ] && [ "$base_ref" = "main" ]; then
+    pass=1
+  fi
+else
+  # It's an issue — check its closing PRs via GraphQL.
+  result="$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){closedByPullRequestsReferences(first:20,includeClosedPrs:true){nodes{merged baseRefName}}}}}' -F o="$owner" -F r="$repo" -F n="$number" --jq '[.data.repository.issue.closedByPullRequestsReferences.nodes[] | select(.merged==true and .baseRefName=="main")] | length' 2>/dev/null || true)"
+  if [ -n "$result" ] && [ "$result" -gt 0 ]; then
+    pass=1
+  fi
+fi
+
+if [ "$pass" -eq 1 ]; then
+  echo "coupled FE change (${owner}/${repo}#${number}) is merged to ${repo}'s main — pass"
+  exit 0
+fi
+
+echo "FE-couples reference ${owner}/${repo}#${number} is not yet merged to ${repo}'s main." >&2
+echo "This BE change is coupled to a front-end change that hasn't shipped." >&2
+echo "Either wait for ${owner}/${repo}#${number} to merge to main, or add a" >&2
+echo "Coupling-override: <reason> line if this is backward-compatible / behind a flag." >&2
+exit 1

--- a/.github/workflows/fe-be-coupling-gate.yml
+++ b/.github/workflows/fe-be-coupling-gate.yml
@@ -1,0 +1,22 @@
+name: FE/BE coupling gate
+
+# Required status check on dev->main PRs. Parses the PR body for a
+# `FE-couples: <repo>#NNN` line and blocks the PR unless that front-end
+# change has merged to its own repo's main, or a `Coupling-override:`
+# line is present. Conventions are canonical in
+# web-jam-tools/docs/cross-ai-rules.md.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  coupling-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check FE/BE coupling
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/coupling-gate.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/fe-be-coupling-gate.yml`: required status check on `dev->main` PRs (triggers on opened/edited/reopened/synchronize)
- Adds `.github/scripts/coupling-gate.sh`: parses `FE-couples: <repo>#NNN` and `Coupling-override: <reason>` from the PR body
- No `FE-couples:` line -> pass (uncoupled). `Coupling-override:` present -> pass. Otherwise resolves the FE issue/PR via `gh api`/GraphQL and requires it merged to the FE repo's `main`
- Uses the default workflow token (`github.token`) since all FE repos (JaMmusic, CollegeLutheran, AppersonAuto, web-jam-tools) are public — no PAT secret needed
- Bumps `package.json` 2.9.0 -> 2.10.0 (new capability)
- **Manual step for Josh required for enforcement:** web-jam-back -> Settings -> Branches -> `main` -> add `coupling-gate` as a required status check. Until then the check runs but is advisory only.

**Part of #1002 — do NOT auto-close on merge.** The workflow ships here, but #1002 stays OPEN until part two (require `coupling-gate` in `main` branch protection) is done manually.

## How to test locally
Local smoke test of the parser against sample PR bodies, run from the repo root:
```sh
bash -n .github/scripts/coupling-gate.sh
PR_BODY=$'no coupling here' bash .github/scripts/coupling-gate.sh; echo "exit=$?"
PR_BODY=$'FE-couples: JaMmusic#1\nCoupling-override: backward compatible, behind flag' bash .github/scripts/coupling-gate.sh; echo "exit=$?"
PR_BODY=$'FE-couples: JaMmusic#999999' bash .github/scripts/coupling-gate.sh; echo "exit=$?"
```
Expect: syntax check silent/OK, first two print pass and exit=0, third prints a clear fail message and exit=1 (real gh API 404 on a nonexistent issue). Also exercised a real merged-but-not-to-main FE PR (JaMmusic#1247, known merged to `dev`) to confirm the gate correctly distinguishes merged-to-dev from merged-to-main. Also ran the full backend unit suite (`npx vitest run`) to confirm the new CI files don't break anything (no `src/` code was touched).

## Test evidence
Shell smoke test:
```
$ bash -n .github/scripts/coupling-gate.sh && echo SYNTAX OK
SYNTAX OK

--- test 1: no coupling ---
no coupling declared — pass
exit=0 (expect 0)

--- test 2: override ---
Coupling-override given: backward compatible, behind flag
override accepted — pass
exit=0 (expect 0)

--- test 3: unresolvable/fake ref (no override) ---
coupled FE reference: WebJamApps/JaMmusic#999999
FE-couples reference WebJamApps/JaMmusic#999999 is not yet merged to JaMmusic's main.
exit=1 (expect 1)

--- real-ref check: JaMmusic#1247 (merged to dev, not main) ---
coupled FE reference: WebJamApps/JaMmusic#1247
FE-couples reference WebJamApps/JaMmusic#1247 is not yet merged to JaMmusic's main.
exit=1 (correctly fails — confirms dev-vs-main distinction works against live API)
```

Backend unit suite (unaffected by this CI-only change):
```
 Test Files  53 passed (53)
      Tests  914 passed (914)
   Start at  20:42:27
   Duration  52.61s
```

🤖 Work by Claude Sonnet 5