### PR TITLE
Clean venue website values that are missing a URL scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",
@@ -29,6 +29,7 @@
     "migrate:drop-contact-verified": "node build/src/scripts/migrate-drop-contact-verified.js",
     "migrate:drop-do-not-contact": "node build/src/scripts/migrate-drop-do-not-contact.js",
     "migrate:clean-city": "node build/src/scripts/migrate-clean-city.js",
+    "migrate:clean-website": "node build/src/scripts/migrate-clean-website.js",
     "restore:backup": "node scripts/restore-backup.mjs",
     "ts-watch": "tsc -w",
     "ts-start": "DEBUG=web-jam-back:* node --watch --trace-deprecation build/src/index.js",

--- a/src/scripts/migrate-clean-website.ts
+++ b/src/scripts/migrate-clean-website.ts
@@ -70,13 +70,13 @@ export type WebsiteCategory =
 // "don't touch" is the safer, more general reading of that rule.
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
 
-// A confident bare-domain match: one or more dot-separated labels (so a
-// dot-less bare word like a venue name or "TBD" never matches), optional
-// port, optional path/query/fragment. No whitespace and no "@" anywhere —
-// which also excludes an email address ("booking@example.com") from ever
-// matching, since '@' isn't in the character class.
-// eslint-disable-next-line sonarjs/slow-regex
-const DOMAIN_LIKE_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+(:\d+)?([/?#].*)?$/i;
+// A confident bare-domain match: starts alphanumeric, requires at least one
+// "." followed by a final alnum/hyphen label (so a dot-less bare word like a
+// venue name or "TBD" never matches), optional port, optional
+// path/query/fragment. No whitespace and no "@" anywhere — which also
+// excludes an email address ("booking@example.com") from ever matching,
+// since '@' isn't in the character class.
+const DOMAIN_LIKE_RE = /^[a-z0-9][a-z0-9.-]*\.[a-z0-9-]+(:\d+)?([/?#].*)?$/i;
 
 export function classifyWebsite(raw: string | undefined): WebsiteCategory {
   const trimmed = (raw || '').trim();

--- a/src/scripts/migrate-clean-website.ts
+++ b/src/scripts/migrate-clean-website.ts
@@ -1,0 +1,189 @@
+// src/scripts/migrate-clean-website.ts — web-jam-back#1008
+//
+// Some venue records store `website` without a URL scheme — e.g.
+// "www.petedyerivercourse.com" instead of "https://www.petedyerivercourse.com".
+// Anything that renders the raw value as an href gets a RELATIVE URL (Josh
+// hit this in production on the public gigs table:
+// https://web-jam.com/www.petedyerivercourse.com). This migration finds
+// venue records whose `website` is non-empty and has no URL scheme, and
+// rewrites each to the same value prefixed with "https://".
+//
+// REPORT, DON'T GUESS (explicit in the issue): a `website` value is only
+// rewritten when it confidently looks like a bare domain/URL missing its
+// scheme. Everything else is either left untouched silently (already has a
+// scheme, or empty/absent — nothing to do) or surfaced in its own report
+// section so Josh can decide by hand:
+//   - protocol-relative values ("//example.com") — reported, never rewritten
+//     (upgrading these to "https://example.com" would be a guess about
+//     intent this issue doesn't authorize).
+//   - non-URL junk (a bare venue name, an email address, free text someone
+//     typed into the field) — reported as "skipped, needs a human".
+//
+// NON-GOALS (see the issue): does not touch gig records (JaMmusic#1268 owns
+// gig-side render-time normalization); does not upgrade an existing
+// "http://" value to "https://"; does not add validation to the venue write
+// path (POST/PATCH /venue) — this is a one-time data cleanup only.
+//
+// LESSON FROM #954 (see migrate-drop-contact-verified.ts's header for the
+// full story): writes go through the RAW MongoDB collection
+// (Model.collection.updateOne per venue), matching the sibling #980
+// migrations' convention.
+//
+// Idempotent: once a value has been rewritten to carry a scheme, it's
+// classified "already-schemed" on the next run and excluded — re-running
+// after a successful --apply reports zero changes.
+//
+// SAFETY GUARD (mirrors the sibling #980/#974/#954 migrations): refuses to
+// run at all against anything that doesn't look like local/DEV/TEST (db name
+// containing 'dev'/'test', or localhost/127.0.0.1) unless --force is passed.
+// Running it for real against prod is a deliberate act, run manually by Josh
+// after reviewing the dry-run output posted to #1008 (e.g. `heroku run "npm
+// run migrate:clean-website -- --force" -a webjamsalem` for the dry run,
+// then `--force --apply` to write) — never wired into
+// build/postinstall/Procfile/CI.
+//
+// Usage:
+//   npm run migrate:clean-website                    # dry run, DEV/local
+//   npm run migrate:clean-website -- --apply          # writes, DEV/local only
+//   npm run migrate:clean-website -- --force --apply  # writes for real (prod)
+
+import { config } from 'dotenv';
+import mongoose from 'mongoose';
+import venueModel from '#src/model/venue/venue-facade.js';
+import { guardOrExit, isMainModule } from '#src/lib/migration-cli.js';
+
+config(); // load .env if present
+
+interface VenueDoc { _id: unknown; name?: string; website?: string }
+
+// ── Classification ──────────────────────────────────────────────────────
+export type WebsiteCategory =
+  | { kind: 'empty' }
+  | { kind: 'already-schemed' }
+  | { kind: 'protocol-relative' }
+  | { kind: 'rewrite'; newValue: string }
+  | { kind: 'junk'; reason: string };
+
+// Any recognized "scheme://" prefix (http/https/ftp/etc.) — leave alone.
+// Deliberately generic rather than http(s)-only: the issue only calls out
+// NOT upgrading http->https, and treating any already-schemed value as
+// "don't touch" is the safer, more general reading of that rule.
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+// A confident bare-domain match: one or more dot-separated labels (so a
+// dot-less bare word like a venue name or "TBD" never matches), optional
+// port, optional path/query/fragment. No whitespace and no "@" anywhere —
+// which also excludes an email address ("booking@example.com") from ever
+// matching, since '@' isn't in the character class.
+// eslint-disable-next-line sonarjs/slow-regex
+const DOMAIN_LIKE_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+(:\d+)?([/?#].*)?$/i;
+
+export function classifyWebsite(raw: string | undefined): WebsiteCategory {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return { kind: 'empty' };
+  if (SCHEME_RE.test(trimmed)) return { kind: 'already-schemed' };
+  if (trimmed.startsWith('//')) return { kind: 'protocol-relative' };
+  if (DOMAIN_LIKE_RE.test(trimmed)) return { kind: 'rewrite', newValue: `https://${trimmed}` };
+  return { kind: 'junk', reason: `does not look like a URL: "${trimmed}"` };
+}
+
+export interface RewritePlan { venue: VenueDoc; newValue: string }
+export interface ReportedVenue { venue: VenueDoc; reason: string }
+export interface BuildPlansResult {
+  plans: RewritePlan[];
+  protocolRelative: ReportedVenue[];
+  junk: ReportedVenue[];
+}
+
+// Classify every candidate venue into a rewrite plan or one of the two
+// report-only buckets. 'empty' and 'already-schemed' venues are dropped
+// silently (nothing to do, nothing to report). Split out of run() to keep
+// its cognitive complexity down and to be independently unit-testable.
+export function buildPlans(venues: VenueDoc[]): BuildPlansResult {
+  const plans: RewritePlan[] = [];
+  const protocolRelative: ReportedVenue[] = [];
+  const junk: ReportedVenue[] = [];
+  for (const venue of venues) {
+    const category = classifyWebsite(venue.website);
+    if (category.kind === 'rewrite') {
+      plans.push({ venue, newValue: category.newValue });
+    } else if (category.kind === 'protocol-relative') {
+      protocolRelative.push({ venue, reason: `protocol-relative value, left as-is: "${(venue.website || '').trim()}"` });
+    } else if (category.kind === 'junk') {
+      junk.push({ venue, reason: category.reason });
+    }
+  }
+  return { plans, protocolRelative, junk };
+}
+
+// Print the plan/write line for every venue that would change, then the two
+// report-only sections (if non-empty). Split out of run() to keep its
+// cognitive complexity down.
+function logPlansAndReports(result: BuildPlansResult, apply: boolean): void {
+  const { plans, protocolRelative, junk } = result;
+  for (const { venue, newValue } of plans) {
+    const verb = apply ? 'WRITE' : 'PLAN';
+    console.log(`  ${verb}: venue ${String(venue._id)} "${venue.name}" website "${venue.website}" -> "${newValue}"`);
+  }
+  if (protocolRelative.length) {
+    console.log('\nPROTOCOL-RELATIVE — reported, not rewritten (needs a human decision):');
+    for (const { venue, reason } of protocolRelative) {
+      console.log(`  venue ${String(venue._id)} "${venue.name}": ${reason}`);
+    }
+  }
+  if (junk.length) {
+    console.log('\nSKIPPED, NEEDS A HUMAN — not a recognizable URL:');
+    for (const { venue, reason } of junk) {
+      console.log(`  venue ${String(venue._id)} "${venue.name}": ${reason}`);
+    }
+  }
+}
+
+// Write every rewrite plan via the raw collection. Split out of run() to
+// keep its cognitive complexity down.
+async function applyPlans(plans: RewritePlan[]): Promise<number> {
+  let modifiedCount = 0;
+  for (const { venue, newValue } of plans) {
+    const filter = { _id: new mongoose.Types.ObjectId(String(venue._id)) };
+    const update = { $set: { website: newValue } };
+    // eslint-disable-next-line no-await-in-loop
+    const res = await venueModel.Schema.collection.updateOne(filter, update);
+    modifiedCount += res.modifiedCount || 0;
+  }
+  return modifiedCount;
+}
+
+async function run(): Promise<void> {
+  const { apply, uri, maskedUri } = guardOrExit('migrate-clean-website', 'migrate:clean-website');
+
+  await mongoose.connect(uri);
+  console.log(`Connected to "${mongoose.connection.name}" (${maskedUri})`);
+  console.log(apply ? 'Mode: APPLY — writes will happen.' : 'Mode: DRY RUN — no writes (pass --apply to write).');
+
+  const venues = (await venueModel.find({ website: { $exists: true, $ne: '' } })) as unknown as VenueDoc[];
+  const result = buildPlans(venues);
+  const { plans, protocolRelative, junk } = result;
+
+  logPlansAndReports(result, apply);
+
+  const modifiedCount = apply ? await applyPlans(plans) : 0;
+
+  console.log(`\n${venues.length} venue(s) scanned; ${plans.length} would change; `
+    + `${protocolRelative.length} protocol-relative (reported); ${junk.length} junk (reported, needs Josh).`);
+  console.log(apply
+    ? `${modifiedCount} venue(s) updated.`
+    : `Dry run — ${plans.length} venue(s) WOULD be updated. Re-run with --apply to write for real.`);
+
+  await mongoose.connection.close();
+}
+
+// Only auto-execute when run directly — NOT when imported by a unit test.
+/* istanbul ignore if -- exercised only when the script is executed directly, never under vitest */
+if (isMainModule(import.meta.url)) {
+  run().catch((err) => {
+    console.error('Migration failed:', (err as Error).message);
+    process.exit(1);
+  });
+}
+
+export { run };

--- a/test/unit/scripts/migrate-clean-website.spec.ts
+++ b/test/unit/scripts/migrate-clean-website.spec.ts
@@ -1,0 +1,215 @@
+// Unit tests for the #1008 venue-website-scheme migration script's logic.
+// Importing the module must NOT touch Mongo or process.exit (no top-level
+// side effects beyond dotenv) — run()'s isMain guard is never true under
+// vitest.
+//
+// parseArgs/isSafeToRun/logSafetyBlock are shared (src/lib/migration-cli.ts,
+// #980) and covered by their own test/unit/lib/migration-cli.spec.ts — not
+// re-tested here to avoid duplicating that coverage.
+import mongoose from 'mongoose';
+import {
+  run, classifyWebsite, buildPlans,
+} from '#src/scripts/migrate-clean-website.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+
+describe('migrate-clean-website (#1008)', () => {
+  describe('classifyWebsite', () => {
+    it('empty/absent values are left alone', () => {
+      expect(classifyWebsite(undefined)).toEqual({ kind: 'empty' });
+      expect(classifyWebsite('')).toEqual({ kind: 'empty' });
+      expect(classifyWebsite('   ')).toEqual({ kind: 'empty' });
+    });
+
+    it('a schemeless value gets prefixed with https://', () => {
+      expect(classifyWebsite('www.petedyerivercourse.com')).toEqual({
+        kind: 'rewrite', newValue: 'https://www.petedyerivercourse.com',
+      });
+    });
+
+    it('a bare domain (no www) also gets prefixed', () => {
+      expect(classifyWebsite('example.com')).toEqual({ kind: 'rewrite', newValue: 'https://example.com' });
+    });
+
+    it('a schemeless value with a path/query still gets prefixed as-is', () => {
+      expect(classifyWebsite('example.com/menu?x=1')).toEqual({
+        kind: 'rewrite', newValue: 'https://example.com/menu?x=1',
+      });
+    });
+
+    it('trims surrounding whitespace before classifying/rewriting', () => {
+      expect(classifyWebsite('  www.example.com  ')).toEqual({ kind: 'rewrite', newValue: 'https://www.example.com' });
+    });
+
+    it('a value already starting http:// is left alone', () => {
+      expect(classifyWebsite('http://www.example.com')).toEqual({ kind: 'already-schemed' });
+    });
+
+    it('a value already starting https:// is left alone (never re-rewritten)', () => {
+      expect(classifyWebsite('https://www.example.com')).toEqual({ kind: 'already-schemed' });
+    });
+
+    it('a protocol-relative value is reported, not rewritten', () => {
+      expect(classifyWebsite('//example.com')).toEqual({ kind: 'protocol-relative' });
+    });
+
+    it('an email address is junk, not a URL rewrite', () => {
+      const result = classifyWebsite('booking@example.com');
+      expect(result.kind).toBe('junk');
+    });
+
+    it('a bare venue name (free text, no domain) is junk', () => {
+      const result = classifyWebsite("Pete Dyer's Rec Center");
+      expect(result.kind).toBe('junk');
+    });
+
+    it('a dot-less bare word is junk', () => {
+      expect(classifyWebsite('TBD').kind).toBe('junk');
+    });
+  });
+
+  describe('buildPlans', () => {
+    it('separates rewrite plans, protocol-relative, and junk; drops empty/already-schemed silently', () => {
+      const venues = [
+        { _id: 'a', name: 'A', website: 'www.example.com' }, // rewrite
+        { _id: 'b', name: 'B', website: 'https://already.com' }, // already-schemed, dropped
+        { _id: 'c', name: 'C', website: '//protocol-relative.com' }, // reported
+        { _id: 'd', name: 'D', website: 'booking@example.com' }, // junk
+        { _id: 'e', name: 'E', website: '' }, // empty, dropped
+      ];
+      const { plans, protocolRelative, junk } = buildPlans(venues);
+      expect(plans).toEqual([{ venue: venues[0], newValue: 'https://www.example.com' }]);
+      expect(protocolRelative.map((r) => r.venue._id)).toEqual(['c']);
+      expect(junk.map((r) => r.venue._id)).toEqual(['d']);
+    });
+  });
+
+  describe('run()', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      process.env.MONGO_DB_URI = 'mongodb://localhost:27017/web-jam-test';
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    function stubMongo(venues: { _id: string; name: string; website?: string }[]) {
+      vi.spyOn(mongoose, 'connect').mockResolvedValue(undefined as unknown as typeof mongoose);
+      vi.spyOn(mongoose.connection, 'close').mockResolvedValue(undefined);
+      const findSpy = vi.spyOn(venueModel, 'find').mockImplementation((filter: unknown) => {
+        const f = filter as { website?: { $exists?: boolean } } | undefined;
+        if (f?.website?.$exists === true) return Promise.resolve(venues);
+        return Promise.resolve([]);
+      });
+      const fakeResult = {
+        acknowledged: true, matchedCount: 1, modifiedCount: 1, upsertedCount: 0, upsertedId: null,
+      };
+      const updateOneSpy = vi.spyOn(venueModel.Schema.collection, 'updateOne')
+        .mockImplementation(() => Promise.resolve(fakeResult) as unknown as ReturnType<typeof venueModel.Schema.collection.updateOne>);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      return {
+        findSpy, updateOneSpy, logSpy,
+      };
+    }
+
+    it('dry run: plans confident rewrites, reports protocol-relative/junk separately, writes nothing', async () => {
+      process.argv = ['node', 'migrate-clean-website.js']; // no --apply
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const id2 = new mongoose.Types.ObjectId().toString();
+      const id3 = new mongoose.Types.ObjectId().toString();
+      const id4 = new mongoose.Types.ObjectId().toString();
+      const { findSpy, updateOneSpy, logSpy } = stubMongo([
+        { _id: id1, name: 'A', website: 'www.petedyerivercourse.com' },
+        { _id: id2, name: 'B', website: 'https://already-schemed.com' },
+        { _id: id3, name: 'C', website: '//protocol-relative.com' },
+        { _id: id4, name: 'D', website: 'booking@example.com' },
+      ]);
+
+      await run();
+
+      expect(findSpy).toHaveBeenCalledWith({ website: { $exists: true, $ne: '' } });
+      expect(updateOneSpy).not.toHaveBeenCalled();
+
+      const lines = logSpy.mock.calls.map((c) => c[0]).filter((l): l is string => typeof l === 'string');
+      const planLines = lines.filter((l) => l.includes('PLAN'));
+      expect(planLines).toHaveLength(1);
+      expect(planLines[0]).toContain('"www.petedyerivercourse.com" -> "https://www.petedyerivercourse.com"');
+
+      expect(lines.some((l) => l.includes('PROTOCOL-RELATIVE'))).toBe(true);
+      expect(lines.some((l) => l.includes('SKIPPED, NEEDS A HUMAN'))).toBe(true);
+      const summary = lines.find((l) => l.includes('venue(s) scanned'));
+      expect(summary).toContain('4 venue(s) scanned');
+      expect(summary).toContain('1 would change');
+      expect(summary).toContain('1 protocol-relative');
+      expect(summary).toContain('1 junk');
+    });
+
+    it('apply: writes rewrite plans via the raw collection updateOne, never for reported venues', async () => {
+      process.argv = ['node', 'migrate-clean-website.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const id2 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy } = stubMongo([
+        { _id: id1, name: 'A', website: 'www.example.com' },
+        { _id: id2, name: 'B', website: '//protocol-relative.com' },
+      ]);
+
+      await run();
+
+      expect(updateOneSpy).toHaveBeenCalledTimes(1);
+      expect(updateOneSpy).toHaveBeenCalledWith(
+        { _id: new mongoose.Types.ObjectId(id1) },
+        { $set: { website: 'https://www.example.com' } },
+      );
+    });
+
+    it('is a no-op on re-run once every website is already schemed (idempotent)', async () => {
+      process.argv = ['node', 'migrate-clean-website.js', '--apply'];
+      const id1 = new mongoose.Types.ObjectId().toString();
+      const { updateOneSpy, logSpy } = stubMongo([{ _id: id1, name: 'A', website: 'https://www.example.com' }]);
+
+      await run();
+
+      expect(updateOneSpy).not.toHaveBeenCalled();
+      const summary = logSpy.mock.calls.map((c) => c[0]).find(
+        (l): l is string => typeof l === 'string' && l.includes('venue(s) scanned'),
+      );
+      expect(summary).toContain('0 would change');
+    });
+  });
+
+  describe('SAFETY GUARD', () => {
+    let originalArgv: string[];
+    let originalUri: string | undefined;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      originalUri = process.env.MONGO_DB_URI;
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      if (originalUri === undefined) delete process.env.MONGO_DB_URI;
+      else process.env.MONGO_DB_URI = originalUri;
+      vi.restoreAllMocks();
+    });
+
+    it('refuses to run against a prod-looking db without --force', async () => {
+      process.argv = ['node', 'migrate-clean-website.js', '--apply'];
+      process.env.MONGO_DB_URI = 'mongodb+srv://user:pass@cluster.mongodb.net/release';
+      await expect(run()).rejects.toThrow('exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('only runs against a local, DEV, or TEST database'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- [ ] Branch off origin/dev, add the new script under src/scripts/ following the existing migration pattern
- [ ] Implement detection + normalization with the issue's edge cases (already-schemed, empty, non-URL junk, protocol-relative)
- [ ] Unit tests for every case, including "dry run writes nothing" and idempotency
- [ ] Run the dry run against the LOCAL/DEV database and capture its output
- [ ] Green lint + typecheck + tests, finalize the PR

Closes #1008

## How to test locally
- `npm run migrate:clean-website` (dry run, default) against whatever DB `.env`'s MONGO_DB_URI already points at (DEV Atlas on this laptop) — expect a per-venue PLAN line for each schemeless website, a PROTOCOL-RELATIVE section and a SKIPPED/junk section if any exist, and zero writes.
- `npm run test:unit -- migrate-clean-website` — unit coverage for classifyWebsite/buildPlans/run() dry-run/apply/idempotency.
- `npm test` (full lint + jscpd + typecheck + coverage) green.

## Test evidence
```
Tests: not yet run — initial checkpoint; real evidence lands at finalize.
```

🤖 Work by Claude Code — Sonnet 5