### PR TITLE
should not skip should use a default template and send, please fix !!!!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -25,6 +25,20 @@ import { MAX_STEP, nextTouchDueAfter, touchAt } from './cadence.js';
 // InquiryController CC precedent). Maria's address is the same one inquiries CC.
 const PITCH_CC = ['joshua.v.sherman@gmail.com', 'chemmariasherman@gmail.com'];
 
+// JaMmusic#1250 — a 29-venue batch silently skipped 6 venues with no
+// venueType/templateOverride/templateType because resolvePitch hard-400'd
+// instead of sending. Rather than drop a venue on the floor for a missing
+// tag (the real gap is web-jam-back#843's venueType backfill), fall back to
+// this safest-for-an-unknown-venue template type. Prod carries both a `cold`
+// and a `returning` stage for it, so findTemplate always resolves. Kept as
+// one exported constant so it's changeable in a single place.
+export const DEFAULT_TEMPLATE_TYPE = 'MidRangeCafeBar';
+
+// JaMmusic#1250 — placeholder venueName for a skipped-batch entry where no
+// venue doc could even be loaded (invalid id, or venue not found). The
+// frontend always renders venueName, so this field is never omitted.
+export const UNKNOWN_VENUE_NAME = '(unknown venue)';
+
 // An active campaign blocks a new pitch for the same venue + window (no
 // double-pitching). sent / replied are active; every outcome status
 // (no-response / interested / not-interested / booked / target-filled) is
@@ -42,7 +56,11 @@ const OUTREACH_SEND_CAPS = ['outreach:create', 'outreach:approve'];
 interface AuthedUser { userType?: string; privileges?: string[] }
 type AuthRequest = Request & { user?: string };
 type AuthIdRequest = Request<{ id: string }> & { user?: string };
-type AuthzError = { status: number; message: string; outreach?: unknown };
+// venueName (JaMmusic#1250) — carried alongside every resolvePitch error so
+// sendBatch's skipped report can name the venue instead of just its
+// ObjectId. Always set by resolvePitch (UNKNOWN_VENUE_NAME when no venue doc
+// could be loaded at all), never left undefined for a batch-originated error.
+type AuthzError = { status: number; message: string; outreach?: unknown; venueName?: string };
 type AuthzResult = AuthzError | null;
 interface PitchContext { error?: AuthzError; venue?: VenueDoc; template?: TemplateDoc; type?: string }
 interface ResolveOpts { skipDedup?: boolean; requireEligible?: boolean }
@@ -724,38 +742,43 @@ class OutreachController extends Controller {
     const { skipDedup = false, requireEligible = true } = opts;
     let venue: VenueDoc | null;
     try { venue = await venueModel.findById(body.venueId || '') as unknown as VenueDoc | null; } catch (e) {
-      return { error: { status: 500, message: (e as Error).message } };
+      return { error: { status: 500, message: (e as Error).message, venueName: UNKNOWN_VENUE_NAME } };
     }
-    if (!venue) return { error: { status: 400, message: 'venue not found' } };
-    if (venue.status === 'archived') return { error: { status: 400, message: 'venue is archived' } };
+    if (!venue) return { error: { status: 400, message: 'venue not found', venueName: UNKNOWN_VENUE_NAME } };
+    const venueName = venue.name || UNKNOWN_VENUE_NAME;
+    if (venue.status === 'archived') return { error: { status: 400, message: 'venue is archived', venueName } };
     if (requireEligible && !venue.outreachEligible) {
-      return { error: { status: 400, message: 'venue is not outreach-eligible (not vetted)' } };
+      return { error: { status: 400, message: 'venue is not outreach-eligible (not vetted)', venueName } };
     }
     // #974 — sendability precondition, ADDITIONAL to (never a replacement for)
     // the outreachEligible vetting gate just above: a venue with no VALID
     // primary email is never sendable. Format-checked, not just presence —
     // `contactVerified` is gone; a real, present primary email IS the
     // verification now.
-    if (!isValidEmail(venue.email)) return { error: { status: 400, message: 'venue has no valid primary email to pitch' } };
+    if (!isValidEmail(venue.email)) return { error: { status: 400, message: 'venue has no valid primary email to pitch', venueName } };
 
     // Dedup guard first — refuse a duplicate before doing template work.
     if (!skipDedup) {
       const dupeErr = await this.dedupGuard(body.venueId, parseTargetWeekend(body.targetWeekend));
-      if (dupeErr) return { error: dupeErr };
+      if (dupeErr) return { error: { ...dupeErr, venueName } };
     }
 
-    // Template type: explicit caller value > per-venue override > venue's type (#848).
-    const type = (body.templateType || venue.templateOverride || venue.venueType || '').trim();
-    if (!type) return { error: { status: 400, message: 'no templateType and venue has no venueType' } };
+    // Template type: explicit caller value > per-venue override > venue's type
+    // (#848). JaMmusic#1250 — when NONE of those resolve, fall back to
+    // DEFAULT_TEMPLATE_TYPE rather than hard-400ing and silently skipping the
+    // venue (the #843 venueType-backfill gap is real, but a missing tag must
+    // never cost a send). findTemplate below still fails hard if even the
+    // default template is missing/inactive.
+    const type = (body.templateType || venue.templateOverride || venue.venueType || '').trim() || DEFAULT_TEMPLATE_TYPE;
 
     let template: TemplateDoc | null;
     try {
       const stage = await this.resolveStage(venue);
       template = await this.findTemplate(type, stage);
     } catch (e) {
-      return { error: { status: 500, message: (e as Error).message } };
+      return { error: { status: 500, message: (e as Error).message, venueName } };
     }
-    if (!template) return { error: { status: 400, message: `no active template for type ${type}` } };
+    if (!template) return { error: { status: 400, message: `no active template for type ${type}`, venueName } };
 
     return { venue, template, type };
   }
@@ -848,22 +871,29 @@ class OutreachController extends Controller {
     if (sendErr) return res.status(sendErr.status).json({ message: sendErr.message });
 
     const actor = resolveActor(req, body);
-    const result: { requested: number; sent: number; skipped: { venueId: string; reason: string }[]; records: unknown[] } = {
+    // venueName (JaMmusic#1250) — carried on every skipped entry, never
+    // omitted, so the report is readable without cross-referencing Mongo
+    // ObjectIds by hand.
+    const result: { requested: number; sent: number; skipped: { venueId: string; venueName: string; reason: string }[]; records: unknown[] } = {
       requested: body.venueIds.length, sent: 0, skipped: [], records: [],
     };
     for (const venueId of body.venueIds) {
-      if (!mongoose.Types.ObjectId.isValid(venueId)) { result.skipped.push({ venueId, reason: 'invalid id' }); continue; }
+      if (!mongoose.Types.ObjectId.isValid(venueId)) {
+        result.skipped.push({ venueId, venueName: UNKNOWN_VENUE_NAME, reason: 'invalid id' }); continue;
+      }
       const sendBody = {
         targetDates: body.targetDates, targetWeekend: body.targetWeekend, bookingPeriod: body.bookingPeriod, cc: body.cc,
         customIntro: body.customIntro, customBody: body.customBody,
       };
       // eslint-disable-next-line no-await-in-loop
       const ctx = await this.resolvePitch({ venueId, templateType: body.templateType, ...sendBody });
-      if (ctx.error) { result.skipped.push({ venueId, reason: ctx.error.message }); continue; }
+      if (ctx.error) {
+        result.skipped.push({ venueId, venueName: ctx.error.venueName || UNKNOWN_VENUE_NAME, reason: ctx.error.message }); continue;
+      }
       const { venue, template, type } = ctx as Required<PitchContext>;
       // eslint-disable-next-line no-await-in-loop
       const r = await this.performSend(venue, template, type, sendBody, actor);
-      if (!r.ok) { result.skipped.push({ venueId, reason: r.message }); continue; }
+      if (!r.ok) { result.skipped.push({ venueId, venueName: venue.name || UNKNOWN_VENUE_NAME, reason: r.message }); continue; }
       result.sent += 1; result.records.push(r.record);
     }
     return res.status(200).json(result);

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -26,7 +26,9 @@ vi.mock('#src/lib/classify-reply.js', () => ({
   default: { classifyReply },
 }));
 
-const { default: controller } = await import('#src/model/outreach/outreach-controller.js');
+const {
+  default: controller, DEFAULT_TEMPLATE_TYPE, UNKNOWN_VENUE_NAME,
+} = await import('#src/model/outreach/outreach-controller.js');
 const { default: userModel } = await import('#src/model/user/user-facade.js');
 const { default: venueModel } = await import('#src/model/venue/venue-facade.js');
 const { default: templateModel } = await import('#src/model/template/template-facade.js');
@@ -195,12 +197,18 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(sendMail).not.toHaveBeenCalled();
     });
 
-    it('400s when no template type can be resolved', async () => {
+    // JaMmusic#1250 — a venue with no templateType/templateOverride/venueType
+    // no longer hard-400s and gets silently skipped; it falls back to
+    // DEFAULT_TEMPLATE_TYPE (MidRangeCafeBar) and the pitch still sends.
+    it('falls back to DEFAULT_TEMPLATE_TYPE and sends when no template type can be resolved (#1250)', async () => {
       asApprover();
       (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ venueType: '' })));
+      const findOne = vi.fn(() => Promise.resolve(validTemplate({ type: DEFAULT_TEMPLATE_TYPE })));
+      (templateModel as any).findOne = findOne;
       await c.sendPitch({ user: 'a', body: { venueId: oid(), targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
-      expect(status).toBe(400);
-      expect(payload.message).toContain('venueType');
+      expect(status).toBe(201);
+      expect(findOne).toHaveBeenCalledWith(expect.objectContaining({ type: DEFAULT_TEMPLATE_TYPE, active: true }));
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).toBe(DEFAULT_TEMPLATE_TYPE);
     });
 
     it('400s when no active template exists for the type', async () => {
@@ -486,6 +494,30 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(status).toBe(201);
       expect((c.model.create as any).mock.calls[0][0].templateUsed).toBe('MidRangeCafeBar');
     });
+
+    // JaMmusic#1250 — precedence guardrails around the new default fallback:
+    // an explicit templateType, or a bare venue.venueType, must still win
+    // over DEFAULT_TEMPLATE_TYPE; the fallback is the LAST resort only.
+    it('an explicit templateType still wins over the default (#1250)', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ venueType: '', templateOverride: '' })));
+      await c.sendPitch(
+        { user: 'josh', body: { venueId: oid(), targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND, templateType: 'PubFestivalBrewery' } },
+        resStub,
+      );
+      expect(status).toBe(201);
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).toBe('PubFestivalBrewery');
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).not.toBe(DEFAULT_TEMPLATE_TYPE);
+    });
+
+    it('venue.venueType still wins over the default (#1250)', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(validVenue({ venueType: 'PubFestivalBrewery', templateOverride: '' })));
+      await c.sendPitch({ user: 'josh', body: { venueId: oid(), targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
+      expect(status).toBe(201);
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).toBe('PubFestivalBrewery');
+      expect((c.model.create as any).mock.calls[0][0].templateUsed).not.toBe(DEFAULT_TEMPLATE_TYPE);
+    });
   });
 
   describe('sendBatch (#844)', () => {
@@ -539,18 +571,19 @@ describe('Outreach Controller (#844 batch model)', () => {
       asApprover();
       await c.sendBatch({ user: 'josh', body: { venueIds: ['bad', oid()], targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
       expect(payload.sent).toBe(1);
-      expect(payload.skipped).toEqual([{ venueId: 'bad', reason: 'invalid id' }]);
+      expect(payload.skipped).toEqual([{ venueId: 'bad', venueName: UNKNOWN_VENUE_NAME, reason: 'invalid id' }]);
     });
 
     it('skips an ineligible venue (collected, batch continues)', async () => {
       asApprover();
       (venueModel as any).findById = vi.fn()
         .mockResolvedValueOnce(validVenue())
-        .mockResolvedValueOnce(validVenue({ outreachEligible: false }));
+        .mockResolvedValueOnce(validVenue({ name: 'The Ineligible Room', outreachEligible: false }));
       await c.sendBatch({ user: 'josh', body: { venueIds: [oid(), oid()], targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
       expect(payload.sent).toBe(1);
       expect(payload.skipped).toHaveLength(1);
       expect(payload.skipped[0].reason).toContain('not outreach-eligible');
+      expect(payload.skipped[0].venueName).toBe('The Ineligible Room');
     });
 
     it('skips a venue whose send fails', async () => {
@@ -560,6 +593,19 @@ describe('Outreach Controller (#844 batch model)', () => {
       expect(payload.sent).toBe(0);
       expect(payload.skipped).toHaveLength(1);
       expect(payload.skipped[0].reason).toContain('email send failed');
+      expect(payload.skipped[0].venueName).toBe('The Spot on Kirk');
+    });
+
+    // JaMmusic#1250 — every skipped entry carries venueName; a venue that
+    // never even loaded (bad id, or not found) gets the UNKNOWN_VENUE_NAME
+    // placeholder instead of the field being omitted.
+    it('carries venueName on every skipped entry, including the unknown-venue placeholder (#1250)', async () => {
+      asApprover();
+      (venueModel as any).findById = vi.fn(() => Promise.resolve(null));
+      await c.sendBatch({ user: 'josh', body: { venueIds: ['bad', oid()], targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
+      expect(payload.skipped).toHaveLength(2);
+      expect(payload.skipped[0]).toEqual({ venueId: 'bad', venueName: UNKNOWN_VENUE_NAME, reason: 'invalid id' });
+      expect(payload.skipped[1]).toMatchObject({ venueName: UNKNOWN_VENUE_NAME, reason: 'venue not found' });
     });
 
     it('lets an agent batch-send when auto-approve is ON', async () => {


### PR DESCRIPTION
## Summary
- **Default template fallback (JaMmusic#1250 root cause):** `resolvePitch` in `src/model/outreach/outreach-controller.ts` built the template type as `body.templateType || venue.templateOverride || venue.venueType`, then hard-400'd when all three were empty — that's how 6 of 29 venues silently got skipped in a batch. It now falls back to `DEFAULT_TEMPLATE_TYPE` (`MidRangeCafeBar`, per Josh's decision on the issue — the safest pitch for a venue we know nothing about) instead of erroring. Existing precedence is unchanged; the `no active template for type ${type}` guard is left intact so a missing/inactive default template still fails hard rather than sending garbage.
- **Venue names in the skipped report:** `sendBatch`'s `skipped` entries only carried `{ venueId, reason }`, so the report was unreadable without cross-referencing Mongo ObjectIds by hand. Every skipped entry now also carries `venueName` — the actual venue name when a venue doc loaded, or the `UNKNOWN_VENUE_NAME` placeholder (`'(unknown venue)'`) when no venue could be loaded at all (invalid id, venue not found). The field is never omitted.
- `DEFAULT_TEMPLATE_TYPE` and `UNKNOWN_VENUE_NAME` are single exported module-scope constants (no scattered string literals).
- Out of scope, untouched: venueType tagging/backfill (web-jam-back#843), the dedup guard, the eligibility guard, the kill switch, the email-validity guard.
- Bumps patch version 2.10.1 -> 2.10.2.

Closes WebJamApps/JaMmusic#1250

## How to test locally
Run the full gate:
```sh
npm test
```
Expect: eslint clean, jscpd clean, typecheck clean, all vitest suites green, coverage at/above the 90/90/80/80 gate.

Then exercise the two changes directly against a running server (`npm run dev`), using curl against `POST /outreach/batch` (already covered by the unit-test mocks too — see evidence below):
```sh
# A venue with no templateType/templateOverride/venueType in the request/venue
# doc now sends instead of being skipped:
curl -i -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"venueIds":["VENUE_ID_NO_TYPE"],"targetDates":"Aug 14-16","targetWeekend":{"start":"2026-09-25","end":"2026-09-27"}}' \
  "$BASE_URL/outreach/batch"
# Expect: sent: 1, skipped: [] (previously this venue landed in skipped with
# "no templateType and venue has no venueType").

# A batch containing an invalid id and a real venue now shows readable names:
curl -i -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"venueIds":["not-an-id","REAL_VENUE_ID"],"targetDates":"Aug 14-16","targetWeekend":{"start":"2026-09-25","end":"2026-09-27"}}' \
  "$BASE_URL/outreach/batch"
# Expect: skipped: [{ venueId: "not-an-id", venueName: "(unknown venue)", reason: "invalid id" }]
```

## Test evidence
Targeted outreach-controller suite:
```
$ npx vitest run test/unit/outreach/outreach-controller.spec.ts
 RUN  v4.1.5 /home/joshua/WebJamApps/web-jam-back

 Test Files  1 passed (1)
      Tests  213 passed (213)
   Start at  03:01:47
   Duration  839ms (transform 289ms, setup 0ms, import 502ms, tests 208ms, environment 0ms)
```

Full gate (`npm test` = eslint + jscpd + typecheck + vitest --coverage), exit 0:
```
> web-jam-back@2.10.2 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

...(jscpd: pre-existing clones unrelated to this change, under threshold)...

> web-jam-back@2.10.2 test:unit
> vitest run --coverage

 Test Files  54 passed (54)
      Tests  933 passed (933)
   Start at  03:02:05
   Duration  58.21s (transform 975ms, setup 0ms, import 12.75s, tests 35.69s, environment 6ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |   93.37 |    87.43 |   88.99 |   94.03 |
 ...model/outreach |   94.12 |    86.82 |   84.21 |   94.13 |
  ...controller.ts |   98.38 |    86.48 |     100 |   99.58 | 205,1514
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 93.37% ( 2451/2625 )
Branches     : 87.43% ( 1566/1791 )
Functions    : 88.99% ( 388/436 )
Lines        : 94.03% ( 2034/2163 )
================================================================================
```

🤖 Work by Claude Code — Sonnet 5
