### PR TITLE
email subject or title still not easy for  me to see its target venue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-jam-back",
-  "version": "2.10.0",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-jam-back",
-      "version": "2.10.0",
+      "version": "2.10.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/outreach/outreach-controller.ts
+++ b/src/model/outreach/outreach-controller.ts
@@ -292,12 +292,13 @@ function fillCustomBodyMarker(bodyHtml: string, customBody?: string): string {
 // template author may already wire the [Venue Name] token into their subject
 // (personalize() fills it same as it does in the body) — in that case the
 // name is already present and nothing further is needed. When it isn't
-// (an un-tokenized subject, or the hardcoded fallback below), append it. This
-// is the single choke point every send path's subject passes through so the
-// guarantee holds everywhere without string-concatenating in each caller.
+// (an un-tokenized subject, or the hardcoded fallback below), prepend it at
+// the front so Gmail's inbox view doesn't truncate it. This is the single
+// choke point every send path's subject passes through so the guarantee holds
+// everywhere without string-concatenating in each caller.
 function ensureVenueInSubject(subject: string, venueName: string): string {
   if (!venueName || subject.indexOf(venueName) !== -1) return subject;
-  return `${subject} — ${venueName}`;
+  return `${venueName} — ${subject}`;
 }
 
 // Render a template into a ready-to-send email: token-filled subject + intro +

--- a/test/unit/outreach/outreach-controller.spec.ts
+++ b/test/unit/outreach/outreach-controller.spec.ts
@@ -1069,7 +1069,7 @@ describe('Outreach Controller (#844 batch model)', () => {
   // from every other one; the subject must always name the target venue,
   // whether or not the template author wired the [Venue Name] token into it.
   describe('subject includes the target venue (#917)', () => {
-    it('sendPitch: appends " — <Venue Name>" when the template subject carries no token', async () => {
+    it('sendPitch: prepends "<Venue Name> — " when the template subject carries no token', async () => {
       asApprover();
       (templateModel as any).findOne = vi.fn(() => Promise.resolve(validTemplate({ subject: 'Performance Inquiry: Josh and Maria' })));
       await c.sendPitch(
@@ -1078,7 +1078,7 @@ describe('Outreach Controller (#844 batch model)', () => {
       );
       expect(status).toBe(201);
       const sentSubject = (sendMail as any).mock.calls[0][0].subject;
-      expect(sentSubject).toBe('Performance Inquiry: Josh and Maria — The Spot on Kirk');
+      expect(sentSubject).toBe('The Spot on Kirk — Performance Inquiry: Josh and Maria');
     });
 
     it('sendPitch: does not duplicate the venue name when the template subject already tokenizes it', async () => {
@@ -1106,15 +1106,15 @@ describe('Outreach Controller (#844 batch model)', () => {
       );
       expect(status).toBe(200);
       expect(sendMail).toHaveBeenCalledTimes(2);
-      expect((sendMail as any).mock.calls[0][0].subject).toBe('Performance Inquiry: Josh and Maria — Venue One');
-      expect((sendMail as any).mock.calls[1][0].subject).toBe('Performance Inquiry: Josh and Maria — Venue Two');
+      expect((sendMail as any).mock.calls[0][0].subject).toBe('Venue One — Performance Inquiry: Josh and Maria');
+      expect((sendMail as any).mock.calls[1][0].subject).toBe('Venue Two — Performance Inquiry: Josh and Maria');
     });
 
-    it('previewByVenue (single form): appends the venue name when the template subject has no token', async () => {
+    it('previewByVenue (single form): prepends the venue name when the template subject has no token', async () => {
       (templateModel as any).findOne = vi.fn(() => Promise.resolve(validTemplate({ subject: 'Performance Inquiry: Josh and Maria' })));
       await c.previewByVenue({ user: 'a', query: { venueId: oid(), targetDates: 'Aug 14-16', targetWeekend: VALID_WEEKEND } }, resStub);
       expect(status).toBe(200);
-      expect(payload.subject).toBe('Performance Inquiry: Josh and Maria — The Spot on Kirk');
+      expect(payload.subject).toBe('The Spot on Kirk — Performance Inquiry: Josh and Maria');
     });
 
     it('previewByVenue (batch form): each preview names its own venue in the subject', async () => {
@@ -1126,8 +1126,8 @@ describe('Outreach Controller (#844 batch model)', () => {
       (templateModel as any).findOne = vi.fn(() => Promise.resolve(validTemplate({ subject: 'Performance Inquiry: Josh and Maria' })));
       await c.previewByVenue({ user: 'a', query: { venueIds: `${id1},${id2}`, targetDates: 'Sept 25-27' } }, resStub);
       expect(status).toBe(200);
-      expect(payload[0].subject).toBe('Performance Inquiry: Josh and Maria — Venue One');
-      expect(payload[1].subject).toBe('Performance Inquiry: Josh and Maria — Venue Two');
+      expect(payload[0].subject).toBe('Venue One — Performance Inquiry: Josh and Maria');
+      expect(payload[1].subject).toBe('Venue Two — Performance Inquiry: Josh and Maria');
     });
 
     it('advanceCadence: a due EMAIL follow-up names the venue in the subject', async () => {


### PR DESCRIPTION
## Summary
- Move venue name from end to beginning of outreach email subject for visibility in Gmail inbox
- Subject now shows venue first to prevent Gmail truncation

Closes #998

## How to test locally
Run all outreach controller tests and verify subject formatting:
```sh
npm run test:unit -- test/unit/outreach/outreach-controller.spec.ts
```
Verify 6 subject-related tests pass:
- sendPitch prepends venue name when template has no token
- sendPitch does not duplicate venue name when already tokenized
- sendBatch names each venue in subject
- previewByVenue single form prepends venue name
- previewByVenue batch form prepends venue name for each
- advanceCadence follow-up email names the venue

## Test evidence
```
Test Files  1 passed (1)
     Tests  213 passed (213)
  Start at  20:14:29
  Duration  1.22s

✓ sendPitch: prepends "`<Venue Name>`" — " when the template subject carries no token 1ms
✓ sendPitch: does not duplicate the venue name when the template subject already tokenizes it 1ms
✓ sendBatch: every sent email's subject names its own venue 1ms
✓ previewByVenue (single form): prepends the venue name when the template subject has no token 1ms
✓ previewByVenue (batch form): each preview names its own venue in the subject 1ms
✓ advanceCadence: a due EMAIL follow-up names the venue in the subject 1ms

Typecheck: tsc --noEmit (passed with no errors)
Linting: eslint ./src --fix (passed with no errors)
```

🤖 Work by Claude Code — Haiku 4.5