### PR TITLE
Add PATCH /venue/:id (the honest verb for our partial-merge update)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,14 @@
 
 ## Tech Stack
 - **Runtime:** Node.js
-- **Framework:** Express (likely, based on structure)
-- **Testing:** Vitest (vitest.config.ts found)
-- **Linting:** ESLint (eslint.config.mjs found)
+- **Framework:** Express
+- **Testing:** Vitest (vitest.config.ts)
+- **Linting:** ESLint (eslint.config.mjs)
 
 ## Development Workflow
 - **Build:** Check package.json for build scripts.
 - **Standards:** Follow existing ESM patterns.
 - **Merging:** Gemini is **NOT** allowed to merge PR changes to the `dev` or `main` branches. The user is the reviewer.
+
+## Routes & Verbs
+- **Venue Updates (`/venue/:id`)**: `PATCH /venue/:id` is the standard partial-merge update verb. `PUT /venue/:id` is maintained alongside `PATCH` for backward compatibility, both routing to `controller.updateVenue`. Address updates enforce immutability once set (`400: address cannot be removed`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-jam-back",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "description": "web-jam.com",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/model/venue/venue-controller.ts
+++ b/src/model/venue/venue-controller.ts
@@ -677,7 +677,7 @@ class VenueController extends Controller {
     return null;
   }
 
-  // PUT /venue/:id — partial update. See applyAddressUpdate above for the
+  // PATCH /venue/:id (and legacy PUT /venue/:id) — partial update. See applyAddressUpdate above for the
   // #987 address-immutability rule this enforces.
   async updateVenue(req: AuthIdRequest, res: Response): Promise<unknown> {
     const guardErr = await this.authorize(req, ['venue:edit']);

--- a/src/model/venue/venue-router.ts
+++ b/src/model/venue/venue-router.ts
@@ -36,6 +36,10 @@ router.route('/:id')
     const action = routeUtils.makeAction(req, res, 'updateVenue', controller, authUtils);
     void action();
   })
+  .patch((req, res) => {
+    const action = routeUtils.makeAction(req, res, 'updateVenue', controller, authUtils);
+    void action();
+  })
   .delete((req, res) => {
     const action = routeUtils.makeAction(req, res, 'deleteVenue', controller, authUtils);
     void action();

--- a/test/unit/venue/venue-router.spec.ts
+++ b/test/unit/venue/venue-router.spec.ts
@@ -1,0 +1,96 @@
+import app from '#src/index.js';
+import venueModel from '#src/model/venue/venue-facade.js';
+import userModel from '#src/model/user/user-facade.js';
+import authUtils from '#src/auth/authUtils.js';
+import request, { type ApiResponse } from '../../helpers/api.js';
+
+describe('Venue Router (PATCH and PUT /venue/:id)', () => {
+  let r: ApiResponse, agentUser: { _id: string };
+  const allowedUrl = JSON.parse(process.env.AllowUrl || '{}').urls[0];
+
+  beforeAll(async () => {
+    await venueModel.deleteMany({});
+    await userModel.deleteMany({});
+    const createdUser = await userModel.create({
+      name: 'agent-test',
+      email: 'agent-venue-router@example.com',
+      privileges: ['venue:create', 'venue:edit', 'venue:delete'],
+    }) as unknown as { _id: { toString(): string } };
+    agentUser = { _id: createdUser._id.toString() };
+  });
+
+  beforeEach(async () => {
+    await venueModel.deleteMany({});
+  });
+
+  it('updates a venue using PATCH /venue/:id with partial-merge semantics (#990)', async () => {
+    const venue = await venueModel.create({
+      name: 'The Spot on Kirk',
+      address: '22 S Kirk St',
+      city: 'Roanoke',
+      usState: 'Virginia',
+      phone: '540-555-0100',
+    }) as unknown as { _id: { toString(): string }; name: string; city: string; phone: string };
+
+    r = await request(app)
+      .patch(`/venue/${venue._id.toString()}`)
+      .set({ origin: allowedUrl })
+      .set('Authorization', `Bearer ${authUtils.createJWT({ _id: agentUser._id })}`)
+      .send({ phone: '540-555-0199' });
+
+    expect(r.status).toBe(200);
+    expect(r.body.phone).toBe('540-555-0199');
+    expect(r.body.name).toBe('The Spot on Kirk');
+    expect(r.body.city).toBe('Roanoke');
+  });
+
+  it('updates a venue using PUT /venue/:id with identical partial-merge semantics (#990)', async () => {
+    const venue = await venueModel.create({
+      name: 'The Spot on Kirk',
+      address: '22 S Kirk St',
+      city: 'Roanoke',
+      usState: 'Virginia',
+      phone: '540-555-0100',
+    }) as unknown as { _id: { toString(): string }; name: string; city: string; phone: string };
+
+    r = await request(app)
+      .put(`/venue/${venue._id.toString()}`)
+      .set({ origin: allowedUrl })
+      .set('Authorization', `Bearer ${authUtils.createJWT({ _id: agentUser._id })}`)
+      .send({ phone: '540-555-0200' });
+
+    expect(r.status).toBe(200);
+    expect(r.body.phone).toBe('540-555-0200');
+    expect(r.body.name).toBe('The Spot on Kirk');
+    expect(r.body.city).toBe('Roanoke');
+  });
+
+  it('enforces address validation rules identically on both PATCH and PUT /venue/:id (#987/#990)', async () => {
+    const venue = await venueModel.create({
+      name: 'The Spot on Kirk',
+      address: '22 S Kirk St',
+      city: 'Roanoke',
+      usState: 'Virginia',
+    }) as unknown as { _id: { toString(): string } };
+
+    // Attempting to remove address when one is already set fails on PATCH
+    r = await request(app)
+      .patch(`/venue/${venue._id.toString()}`)
+      .set({ origin: allowedUrl })
+      .set('Authorization', `Bearer ${authUtils.createJWT({ _id: agentUser._id })}`)
+      .send({ address: '' });
+
+    expect(r.status).toBe(400);
+    expect(r.body.message).toContain('cannot be removed');
+
+    // Attempting to remove address when one is already set fails identically on PUT
+    r = await request(app)
+      .put(`/venue/${venue._id.toString()}`)
+      .set({ origin: allowedUrl })
+      .set('Authorization', `Bearer ${authUtils.createJWT({ _id: agentUser._id })}`)
+      .send({ address: '' });
+
+    expect(r.status).toBe(400);
+    expect(r.body.message).toContain('cannot be removed');
+  });
+});


### PR DESCRIPTION
## Summary
- Resolves web-jam-back#990: "Add PATCH /venue/:id (the honest verb for our partial-merge update)"
- Registered `PATCH /venue/:id` route in `src/model/venue/venue-router.ts` to direct to `controller.updateVenue`.
- Preserved `PUT /venue/:id` working with identical behavior and validation rules (#987 address rules, partial-merge semantics).
- Added `test/unit/venue/venue-router.spec.ts` unit test suite covering both `PATCH` and `PUT` HTTP methods hitting the same handler.
- Updated `AGENTS.md` context file.
- Version bumped `package.json` from `2.10.3` to `2.11.0` (first commit).

Closes #990

## How to test locally
1. Run `npx vitest run test/unit/venue/venue-router.spec.ts` to verify `PATCH /venue/:id` and `PUT /venue/:id` endpoints pass all partial update and address validation tests.
2. Run `npm test` to verify linting (`eslint ./src`), duplication checks (`jscpd`), typechecking (`tsc --noEmit`), unit tests (`vitest`), and coverage thresholds (90/90/80/80) pass cleanly.

## Test evidence
```
> web-jam-back@2.11.0 test
> eslint ./src && npm run jscpd && npm run typecheck && rimraf coverage && npm run test:unit

> web-jam-back@2.11.0 typecheck
> tsc --noEmit -p tsconfig.prod.json && tsc --noEmit

✓ test/unit/venue/venue-router.spec.ts (3 tests)
  ✓ updates a venue using PATCH /venue/:id with partial-merge semantics (#990)
  ✓ updates a venue using PUT /venue/:id with identical partial-merge semantics (#990)
  ✓ enforces address validation rules identically on both PATCH and PUT /venue/:id (#987/#990)

Test Files  56 passed (56)
     Tests  308 passed (308)
  Duration  45.74s
```

🤖 Work by agy — Gemini 3.6 Flash (High)